### PR TITLE
Fix wrongly labeled meters for gas

### DIFF
--- a/custom_components/plugwise-beta/manifest.json
+++ b/custom_components/plugwise-beta/manifest.json
@@ -2,7 +2,7 @@
   "domain": "plugwise-beta",
   "name": "Plugwise Beta for Home Assistant",
   "documentation": "",
-  "requirements": ["Plugwise_Smile==0.0.40"],
+  "requirements": ["Plugwise_Smile==0.0.43"],
   "dependencies": [],
   "codeowners": ["@CoMPaTech","@bouwew"],
   "config_flow": true

--- a/custom_components/plugwise-beta/manifest.json.ha-core
+++ b/custom_components/plugwise-beta/manifest.json.ha-core
@@ -2,7 +2,7 @@
   "domain": "plugwise",
   "name": "Plugwise",
   "documentation": "https://www.home-assistant.io/integrations/plugwise",
-  "requirements": ["Plugwise_Smile==0.0.40"],
+  "requirements": ["Plugwise_Smile==0.0.43"],
   "dependencies": [],
   "codeowners": ["@CoMPaTech","@bouwew"],
   "config_flow": true

--- a/custom_components/plugwise-beta/sensor.py
+++ b/custom_components/plugwise-beta/sensor.py
@@ -119,13 +119,13 @@ SENSOR_MAP = {
         DEVICE_CLASS_POWER,
         "mdi:gauge",
     ],
-    "gas_consumed_point_peak_point": [
+    "gas_consumed_peak_interval": [
         "Current Consumed Gas",
         "m3",
         DEVICE_CLASS_GAS,
         "mdi:gas-cylinder",
     ],
-    "gas_consumed_point_peak_cumulative": [
+    "gas_consumed_peak_cumulative": [
         "Cumulative Consumed Gas",
         "m3",
         DEVICE_CLASS_GAS,


### PR DESCRIPTION
Diff says it all, using wrong labels meant no gas visibility

Issue https://github.com/plugwise/plugwise-beta/issues/2

Might be merged together with https://github.com/plugwise/Plugwise-Smile/pull/4 - note that both PRs **lack** `setup.py`/`manifest.json` updates.