### PR TITLE
Commits as per PR + first draft of dataupdatecoordinator

### DIFF
--- a/custom_components/plugwise-beta/__init__.py
+++ b/custom_components/plugwise-beta/__init__.py
@@ -116,7 +116,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     return unload_ok
 
 
-class SmileUpdater(DataUpdateCoordinator:
+class SmileUpdater(DataUpdateCoordinator):
     """Data storage for single Smile API endpoint."""
 
     def __init__(

--- a/custom_components/plugwise-beta/binary_sensor.py
+++ b/custom_components/plugwise-beta/binary_sensor.py
@@ -31,7 +31,6 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the Smile binary_sensors from a config entry."""
     api = hass.data[DOMAIN][config_entry.entry_id]["api"]
-    updater = hass.data[DOMAIN][config_entry.entry_id]["updater"]
 
     devices = []
     binary_sensor_classes = [
@@ -51,7 +50,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                     devices.append(
                         PwBinarySensor(
                             api,
-                            updater,
                             device["name"],
                             binary_sensor,
                             dev_id,
@@ -66,10 +64,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 class PwBinarySensor(BinarySensorDevice):
     """Representation of a Plugwise binary_sensor."""
 
-    def __init__(self, api, updater, name, binary_sensor, dev_id, model):
+    def __init__(self, api, name, binary_sensor, dev_id, model):
         """Set up the Plugwise API."""
         self._api = api
-        self._updater = updater
         self._dev_id = dev_id
         self._model = model
         self._name = name
@@ -93,14 +90,6 @@ class PwBinarySensor(BinarySensorDevice):
     def unique_id(self):
         """Return a unique ID."""
         return self._unique_id
-
-    async def async_added_to_hass(self):
-        """Register callbacks."""
-        self._updater.async_add_listener(self._update_callback)
-
-    async def async_will_remove_from_hass(self):
-        """Disconnect callbacks."""
-        self._updater.async_remove_listener(self._update_callback)
 
     @callback
     def _update_callback(self):

--- a/custom_components/plugwise-beta/climate.py
+++ b/custom_components/plugwise-beta/climate.py
@@ -36,7 +36,6 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the Smile Thermostats from a config entry."""
     api = hass.data[DOMAIN][config_entry.entry_id]["api"]
-    updater = hass.data[DOMAIN][config_entry.entry_id]["updater"]
 
     devices = []
     thermostat_classes = [
@@ -54,7 +53,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         _LOGGER.debug("Plugwise climate Dev %s", device["name"])
         thermostat = PwThermostat(
             api,
-            updater,
             device["name"],
             dev_id,
             device["location"],
@@ -75,10 +73,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 class PwThermostat(ClimateDevice):
     """Representation of an Plugwise thermostat."""
 
-    def __init__(self, api, updater, name, dev_id, loc_id, model, min_temp, max_temp):
+    def __init__(self, api, name, dev_id, loc_id, model, min_temp, max_temp):
         """Set up the Plugwise API."""
         self._api = api
-        self._updater = updater
         self._name = name
         self._dev_id = dev_id
         self._loc_id = loc_id
@@ -110,14 +107,6 @@ class PwThermostat(ClimateDevice):
     def unique_id(self):
         """Return a unique ID."""
         return self._unique_id
-
-    async def async_added_to_hass(self):
-        """Register callbacks."""
-        self._updater.async_add_listener(self._update_callback)
-
-    async def async_will_remove_from_hass(self):
-        """Disconnect callbacks."""
-        self._updater.async_remove_listener(self._update_callback)
 
     @callback
     def _update_callback(self):

--- a/custom_components/plugwise-beta/sensor.py
+++ b/custom_components/plugwise-beta/sensor.py
@@ -165,7 +165,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the Smile sensors from a config entry."""
     _LOGGER.debug("Plugwise hass data %s", hass.data[DOMAIN])
     api = hass.data[DOMAIN][config_entry.entry_id]["api"]
-    updater = hass.data[DOMAIN][config_entry.entry_id]["updater"]
 
     _LOGGER.debug("Plugwise sensor type %s", api.smile_type)
 
@@ -189,7 +188,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                         devices.append(
                             PwPowerSensor(
                                 api,
-                                updater,
                                 device["name"],
                                 dev_id,
                                 sensor,
@@ -201,7 +199,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                         devices.append(
                             PwThermostatSensor(
                                 api,
-                                updater,
                                 device["name"],
                                 dev_id,
                                 sensor,
@@ -218,7 +215,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                         _LOGGER.debug("Plugwise aux sensor Dev %s", device["name"])
                         devices.append(
                             PwThermostatSensor(
-                                api, updater, device["name"], dev_id, DEVICE_STATE, None,
+                                api, device["name"], dev_id, DEVICE_STATE, None,
                             )
                         )
                         _LOGGER.info(
@@ -232,10 +229,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 class PwThermostatSensor(Entity):
     """Thermostat (or generic) sensor devices."""
 
-    def __init__(self, api, updater, name, dev_id, sensor, sensor_type):
+    def __init__(self, api, name, dev_id, sensor, sensor_type):
         """Set up the Plugwise API."""
         self._api = api
-        self._updater = updater
         self._dev_id = dev_id
         if sensor_type is not None:
             self._unit_of_measurement = sensor_type[1]
@@ -269,14 +265,6 @@ class PwThermostatSensor(Entity):
     def unique_id(self):
         """Return a unique ID."""
         return self._unique_id
-
-    async def async_added_to_hass(self):
-        """Register callbacks."""
-        self._updater.async_add_listener(self._update_callback)
-
-    async def async_will_remove_from_hass(self):
-        """Disconnect callbacks."""
-        self._updater.async_remove_listener(self._update_callback)
 
     @callback
     def _update_callback(self):
@@ -368,10 +356,9 @@ class PwThermostatSensor(Entity):
 class PwPowerSensor(Entity):
     """Power sensor devices."""
 
-    def __init__(self, api, updater, name, dev_id, sensor, sensor_type, model):
+    def __init__(self, api, name, dev_id, sensor, sensor_type, model):
         """Set up the Plugwise API."""
         self._api = api
-        self._updater = updater
         self._model = model
         self._name = name
         self._dev_id = dev_id
@@ -395,14 +382,6 @@ class PwPowerSensor(Entity):
     def unique_id(self):
         """Return a unique ID."""
         return self._unique_id
-
-    async def async_added_to_hass(self):
-        """Register callbacks."""
-        self._updater.async_add_listener(self._update_callback)
-
-    async def async_will_remove_from_hass(self):
-        """Disconnect callbacks."""
-        self._updater.async_remove_listener(self._update_callback)
 
     @callback
     def _update_callback(self):

--- a/custom_components/plugwise-beta/switch.py
+++ b/custom_components/plugwise-beta/switch.py
@@ -15,7 +15,6 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the Smile switches from a config entry."""
     api = hass.data[DOMAIN][config_entry.entry_id]["api"]
-    updater = hass.data[DOMAIN][config_entry.entry_id]["updater"]
 
     devices = []
     all_devices = api.get_all_devices()
@@ -23,7 +22,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         if "plug" in device["types"]:
             model = "Metered Switch"
             _LOGGER.debug("Plugwise switch Dev %s", device["name"])
-            devices.append(PwSwitch(api, updater, device["name"], dev_id, model,))
+            devices.append(PwSwitch(api, device["name"], dev_id, model,))
             _LOGGER.info("Added switch.%s", "{}".format(device["name"]))
 
     async_add_entities(devices, True)
@@ -32,10 +31,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 class PwSwitch(SwitchDevice):
     """Representation of a Plugwise plug."""
 
-    def __init__(self, api, updater, name, dev_id, model):
+    def __init__(self, api, name, dev_id, model):
         """Set up the Plugwise API."""
         self._api = api
-        self._updater = updater
         self._model = model
         self._name = name
         self._dev_id = dev_id
@@ -46,14 +44,6 @@ class PwSwitch(SwitchDevice):
     def unique_id(self):
         """Return a unique ID."""
         return self._unique_id
-
-    async def async_added_to_hass(self):
-        """Register callbacks."""
-        self._updater.async_add_listener(self._update_callback)
-
-    async def async_will_remove_from_hass(self):
-        """Disconnect callbacks."""
-        self._updater.async_remove_listener(self._update_callback)
 
     @callback
     def _update_callback(self):


### PR DESCRIPTION
I think the dataupdater can be modeled against how `components/brother/__init__.py` does it in the quickest way. It works on my VSC dev-container for upstream, I have to work out how to get it in my test-instances now that's hassOS and running plugwise-beta:)