### PR TITLE
Ensure ConfigEntryNotReady is used like upstream

### DIFF
--- a/custom_components/plugwise-beta/__init__.py
+++ b/custom_components/plugwise-beta/__init__.py
@@ -44,15 +44,15 @@ async def async_setup_entry(hass, entry):
 
         if not connected:
             _LOGGER.error("Unable to connect to Smile: %s",api.smile_status)
-            raise PlatformNotReady
+            raise ConfigEntryNotReady
 
     except Smile.PlugwiseError:
         _LOGGER.error("Error while communicating to device")
-        raise PlatformNotReady
+        raise ConfigEntryNotReady
 
     except asyncio.TimeoutError:
         _LOGGER.error("Timeout while connecting to Smile")
-        raise PlatformNotReady
+        raise ConfigEntryNotReady
 
     if api.smile_type == "power":
         update_interval = timedelta(seconds=10)

--- a/custom_components/plugwise-beta/manifest.json
+++ b/custom_components/plugwise-beta/manifest.json
@@ -2,7 +2,7 @@
   "domain": "plugwise-beta",
   "name": "Plugwise Beta for Home Assistant",
   "documentation": "https://github.com/plugwise/plugwise-beta",
-  "requirements": ["Plugwise_Smile==0.2.9"],
+  "requirements": ["Plugwise_Smile==0.2.10"],
   "dependencies": [],
   "codeowners": ["@CoMPaTech","@bouwew"],
   "config_flow": true


### PR DESCRIPTION
and PNR isn't imported anyway, so should have failed?

See comments in #11 