### PR TITLE
P1 interval

### DIFF
--- a/custom_components/plugwise-beta/sensor.py
+++ b/custom_components/plugwise-beta/sensor.py
@@ -69,12 +69,12 @@ ENERGY_SENSOR_MAP = {
         ENERGY_WATT_HOUR,
         DEVICE_CLASS_POWER,
     ],
-    "electricity_consumed_interval_peak": [
+    "electricity_consumed_peak_interval": [
         "Consumed Power Interval",
         ENERGY_WATT_HOUR,
         DEVICE_CLASS_POWER,
     ],
-    "electricity_consumed_interval_off_peak": [
+    "electricity_consumed_off_peak_interval": [
         "Consumed Power Interval (off peak)",
         ENERGY_WATT_HOUR,
         DEVICE_CLASS_POWER,
@@ -84,12 +84,12 @@ ENERGY_SENSOR_MAP = {
         ENERGY_WATT_HOUR,
         DEVICE_CLASS_POWER,
     ],
-    "electricity_produced_interval_peak": [
+    "electricity_produced_peak_interval": [
         "Produced Power Interval",
         ENERGY_WATT_HOUR,
         DEVICE_CLASS_POWER,
     ],
-    "electricity_produced_interval_off_peak": [
+    "electricity_produced_off_peak_interval": [
         "Produced Power Interval (off peak)",
         ENERGY_WATT_HOUR,
         DEVICE_CLASS_POWER,

--- a/custom_components/plugwise-beta/sensor.py
+++ b/custom_components/plugwise-beta/sensor.py
@@ -69,8 +69,28 @@ ENERGY_SENSOR_MAP = {
         ENERGY_WATT_HOUR,
         DEVICE_CLASS_POWER,
     ],
+    "electricity_consumed_interval_peak": [
+        "Consumed Power Interval",
+        ENERGY_WATT_HOUR,
+        DEVICE_CLASS_POWER,
+    ],
+    "electricity_consumed_interval_off_peak": [
+        "Consumed Power Interval (off peak)",
+        ENERGY_WATT_HOUR,
+        DEVICE_CLASS_POWER,
+    ],
     "electricity_produced_interval": [
         "Produced Power Interval",
+        ENERGY_WATT_HOUR,
+        DEVICE_CLASS_POWER,
+    ],
+    "electricity_produced_interval_peak": [
+        "Produced Power Interval",
+        ENERGY_WATT_HOUR,
+        DEVICE_CLASS_POWER,
+    ],
+    "electricity_produced_interval_off_peak": [
+        "Produced Power Interval (off peak)",
         ENERGY_WATT_HOUR,
         DEVICE_CLASS_POWER,
     ],


### PR DESCRIPTION
Either by misjudgement or change in naming we only included non-peak interval measurements. As pointed out by @willsmarthome in #78 this should also be disclosed by our sensors platform.

Leaving the non peak indicated in (for now).

Closing #78