### PR TITLE
One unique_id and improved binary_sensor

### DIFF
--- a/custom_components/plugwise-beta/binary_sensor.py
+++ b/custom_components/plugwise-beta/binary_sensor.py
@@ -52,8 +52,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                         api,
                         coordinator,
                         device_properties["name"],
-                        binary_sensor,
                         dev_id,
+                        binary_sensor,
                         device_properties["class"],
                     )
                 )
@@ -67,8 +67,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                     api,
                     coordinator,
                     device_properties["name"],
-                    "plugwise_notification",
                     dev_id,
+                    "plugwise_notification",
                     device_properties["class"],
                 )
             )
@@ -80,7 +80,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 class PwBinarySensor(SmileSensor, BinarySensorEntity):
     """Representation of a Plugwise binary_sensor."""
 
-    def __init__(self, api, coordinator, name, binary_sensor, dev_id, model):
+    def __init__(self, api, coordinator, name, dev_id, binary_sensor, model):
         """Set up the Plugwise API."""
         super().__init__(api, coordinator, name, dev_id, binary_sensor)
 
@@ -125,9 +125,9 @@ class PwBinarySensor(SmileSensor, BinarySensorEntity):
 class PwNotifySensor(PwBinarySensor, BinarySensorEntity):
     """Representation of a Plugwise Notification binary_sensor."""
 
-    def __init__(self, hass, api, coordinator, name, binary_sensor, dev_id, model):
+    def __init__(self, hass, api, coordinator, name, dev_id, binary_sensor, model):
         """Set up the Plugwise API."""
-        super().__init__(api, coordinator, name, binary_sensor, dev_id, model)
+        super().__init__(api, coordinator, name, dev_id, binary_sensor, model)
         
         self._binary_sensor = binary_sensor
         self._hass = hass

--- a/custom_components/plugwise-beta/config_flow.py
+++ b/custom_components/plugwise-beta/config_flow.py
@@ -125,10 +125,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 errors[CONF_BASE] = "unknown"
 
             if not errors:
+                unique_id = api.gateway_id
                 if api.hostname is not None:
-                    await self.async_set_unique_id(api.hostname)
-                else:
-                    await self.async_set_unique_id(api.gateway_id)
+                    unique_id =  api.hostname
+                await self.async_set_unique_id(unique_id)
                 self._abort_if_unique_id_configured()
 
                 return self.async_create_entry(title=api.smile_name, data=user_input)

--- a/custom_components/plugwise-beta/config_flow.py
+++ b/custom_components/plugwise-beta/config_flow.py
@@ -87,8 +87,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         _LOGGER.debug("Discovery info: %s", self.discovery_info)
         _properties = self.discovery_info.get("properties")
 
-        unique_id = self.discovery_info.get("hostname").split(".")[0]
-        await self.async_set_unique_id(unique_id)
+        await self.async_set_unique_id(api.hostname)
         self._abort_if_unique_id_configured()
 
         _product = _properties.get("product", None)
@@ -126,7 +125,11 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 errors[CONF_BASE] = "unknown"
 
             if not errors:
-                await self.async_set_unique_id(api.gateway_id)
+                if api.hostname is not None:
+                    await self.async_set_unique_id(api.hostname)
+                else:
+                    await self.async_set_unique_id(api.gateway_id)
+                self._abort_if_unique_id_configured()
 
                 return self.async_create_entry(title=api.smile_name, data=user_input)
 

--- a/custom_components/plugwise-beta/manifest.json
+++ b/custom_components/plugwise-beta/manifest.json
@@ -2,7 +2,7 @@
   "domain": "plugwise-beta",
   "name": "Plugwise Beta for Home Assistant",
   "documentation": "https://github.com/plugwise/plugwise-beta",
-  "requirements": ["Plugwise_Smile==1.1.2"],
+  "requirements": ["Plugwise_Smile==1.2.0"],
   "codeowners": ["@CoMPaTech","@bouwew"],
   "config_flow": true,
   "zeroconf": ["_plugwise._tcp.local."]


### PR DESCRIPTION
This PR requires Smile v1.2.0!

Changes:
- Same config_flow unique_id when configuring via zeroconf discovery or via manual entry (BREAKING CHANGE)
- Fix config_flow "unique_id = None" for Smile P1 v2 (BREAKING CHANGE)
- Binary_sensor code improvements
- Fix notifications not automatically clearing (introduced in HA Core 0.113?)