### PR TITLE
Code quality push (for platinum upstream)

### DIFF
--- a/custom_components/plugwise/.vscode/settings.json
+++ b/custom_components/plugwise/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "python.linting.enabled": true,
+    "python.linting.mypyEnabled": false,
+    "python.linting.flake8Enabled": false,
+    "python.linting.pycodestyleEnabled": false,
+    "python.linting.pydocstyleEnabled": true
+}

--- a/custom_components/plugwise/binary_sensor.py
+++ b/custom_components/plugwise/binary_sensor.py
@@ -221,7 +221,7 @@ class GwNotifySensor(GwBinarySensor, BinarySensorEntity):
         """Set up the Plugwise API."""
         self._enabled_default = True
 
-        super().__init__(api, coordinator, name, dev_id, self._enabled_default, binary_sensor, model)
+        super().__init__(api, coordinator, name, dev_id, binary_sensor, model)
 
         self._binary_sensor = binary_sensor
         self._hass = hass

--- a/custom_components/plugwise/binary_sensor.py
+++ b/custom_components/plugwise/binary_sensor.py
@@ -44,6 +44,8 @@ from .const import (
 from .sensor import SmileSensor
 from .usb import NodeEntity
 
+PARALLEL_UPDATES = 0
+
 _LOGGER = logging.getLogger(__name__)
 
 

--- a/custom_components/plugwise/binary_sensor.py
+++ b/custom_components/plugwise/binary_sensor.py
@@ -178,11 +178,15 @@ async def async_setup_entry_gateway(hass, config_entry, async_add_entities):
 class GwBinarySensor(SmileSensor, BinarySensorEntity):
     """Representation of a Plugwise binary_sensor."""
 
-    def __init__(self, api, coordinator, name, dev_id, enabled_default, binary_sensor, model):
+    def __init__(
+        self, api, coordinator, name, dev_id, enabled_default, binary_sensor, model
+    ):
         """Set up the Plugwise API."""
         self._enabled_default = enabled_default, True
 
-        super().__init__(api, coordinator, name, dev_id, self._enabled_default, binary_sensor)
+        super().__init__(
+            api, coordinator, name, dev_id, self._enabled_default, binary_sensor
+        )
 
         self._binary_sensor = binary_sensor
 
@@ -221,11 +225,23 @@ class GwBinarySensor(SmileSensor, BinarySensorEntity):
 class GwNotifySensor(GwBinarySensor, BinarySensorEntity):
     """Representation of a Plugwise Notification binary_sensor."""
 
-    def __init__(self, hass, api, coordinator, name, dev_id, enabled_default, binary_sensor, model):
+    def __init__(
+        self,
+        hass,
+        api,
+        coordinator,
+        name,
+        dev_id,
+        enabled_default,
+        binary_sensor,
+        model,
+    ):
         """Set up the Plugwise API."""
         self._enabled_default = enabled_default, True
 
-        super().__init__(api, coordinator, name, dev_id, self._enabled_default, binary_sensor, model)
+        super().__init__(
+            api, coordinator, name, dev_id, self._enabled_default, binary_sensor, model
+        )
 
         self._binary_sensor = binary_sensor
         self._hass = hass

--- a/custom_components/plugwise/binary_sensor.py
+++ b/custom_components/plugwise/binary_sensor.py
@@ -182,7 +182,7 @@ class GwBinarySensor(SmileSensor, BinarySensorEntity):
         self, api, coordinator, name, dev_id, enabled_default, binary_sensor, model
     ):
         """Set up the Plugwise API."""
-        self._enabled_default = enabled_default, True
+        self._enabled_default = enabled_default
 
         super().__init__(
             api, coordinator, name, dev_id, self._enabled_default, binary_sensor

--- a/custom_components/plugwise/binary_sensor.py
+++ b/custom_components/plugwise/binary_sensor.py
@@ -356,9 +356,5 @@ class USBBinarySensor(NodeEntity, BinarySensorEntity):
             str(clock_interval),
         )
         self._node.Configure_SED(
-            stay_active,
-            maintenance_interval,
-            sleep_for,
-            clock_sync,
-            clock_interval,
+            stay_active, maintenance_interval, sleep_for, clock_sync, clock_interval,
         )

--- a/custom_components/plugwise/binary_sensor.py
+++ b/custom_components/plugwise/binary_sensor.py
@@ -11,6 +11,7 @@ from homeassistant.helpers import config_validation as cv, entity_platform
 
 from .const import (
     API,
+    ATTR_ENABLED_DEFAULT,
     ATTR_SCAN_DAYLIGHT_MODE,
     ATTR_SCAN_SENSITIVITY_MODE,
     ATTR_SCAN_RESET_TIMER,
@@ -284,7 +285,7 @@ class USBBinarySensor(NodeEntity, BinarySensorEntity):
     @property
     def entity_registry_enabled_default(self):
         """Return the sensor registration state."""
-        return self.sensor_type["enabled_default"]
+        return self.sensor_type[ATTR_ENABLED_DEFAULT]
 
     @property
     def icon(self):

--- a/custom_components/plugwise/binary_sensor.py
+++ b/custom_components/plugwise/binary_sensor.py
@@ -159,6 +159,7 @@ async def async_setup_entry_gateway(hass, config_entry, async_add_entities):
                     coordinator,
                     device_properties["name"],
                     dev_id,
+                    True,
                     "plugwise_notification",
                     device_properties["class"],
                 )
@@ -174,9 +175,9 @@ async def async_setup_entry_gateway(hass, config_entry, async_add_entities):
 class GwBinarySensor(SmileSensor, BinarySensorEntity):
     """Representation of a Plugwise binary_sensor."""
 
-    def __init__(self, api, coordinator, name, dev_id, binary_sensor, model):
+    def __init__(self, api, coordinator, name, dev_id, enabled_default, binary_sensor, model):
         """Set up the Plugwise API."""
-        self._enabled_default = True
+        self._enabled_default = enabled_default, True
 
         super().__init__(api, coordinator, name, dev_id, self._enabled_default, binary_sensor)
 
@@ -217,11 +218,11 @@ class GwBinarySensor(SmileSensor, BinarySensorEntity):
 class GwNotifySensor(GwBinarySensor, BinarySensorEntity):
     """Representation of a Plugwise Notification binary_sensor."""
 
-    def __init__(self, hass, api, coordinator, name, dev_id, binary_sensor, model):
+    def __init__(self, hass, api, coordinator, name, dev_id, enabled_default, binary_sensor, model):
         """Set up the Plugwise API."""
-        self._enabled_default = True
+        self._enabled_default = enabled_default, True
 
-        super().__init__(api, coordinator, name, dev_id, binary_sensor, model)
+        super().__init__(api, coordinator, name, dev_id, self._enabled_default, binary_sensor, model)
 
         self._binary_sensor = binary_sensor
         self._hass = hass

--- a/custom_components/plugwise/binary_sensor.py
+++ b/custom_components/plugwise/binary_sensor.py
@@ -176,7 +176,9 @@ class GwBinarySensor(SmileSensor, BinarySensorEntity):
 
     def __init__(self, api, coordinator, name, dev_id, binary_sensor, model):
         """Set up the Plugwise API."""
-        super().__init__(api, coordinator, name, dev_id, binary_sensor)
+        self._enabled_default = True
+
+        super().__init__(api, coordinator, name, dev_id, self._enabled_default, binary_sensor)
 
         self._binary_sensor = binary_sensor
 
@@ -217,7 +219,9 @@ class GwNotifySensor(GwBinarySensor, BinarySensorEntity):
 
     def __init__(self, hass, api, coordinator, name, dev_id, binary_sensor, model):
         """Set up the Plugwise API."""
-        super().__init__(api, coordinator, name, dev_id, binary_sensor, model)
+        self._enabled_default = True
+
+        super().__init__(api, coordinator, name, dev_id, self._enabled_default, binary_sensor, model)
 
         self._binary_sensor = binary_sensor
         self._hass = hass

--- a/custom_components/plugwise/climate.py
+++ b/custom_components/plugwise/climate.py
@@ -77,8 +77,6 @@ class PwThermostat(SmileGateway, ClimateEntity):
         self, api, coordinator, name, dev_id, loc_id, model, min_temp, max_temp
     ):
         """Set up the Plugwise API."""
-        self._enabled_default = True
-
         super().__init__(api, coordinator, name, dev_id)
 
         self._api = api
@@ -292,4 +290,3 @@ class PwThermostat(SmileGateway, ClimateEntity):
             self._hvac_mode = HVAC_MODE_OFF
 
         self.async_write_ha_state()
-        

--- a/custom_components/plugwise/climate.py
+++ b/custom_components/plugwise/climate.py
@@ -79,7 +79,7 @@ class PwThermostat(SmileGateway, ClimateEntity):
         """Set up the Plugwise API."""
         self._enabled_default = True
 
-        super().__init__(api, coordinator, name, dev_id, self._enabled_default)
+        super().__init__(api, coordinator, name, dev_id)
 
         self._api = api
         self._loc_id = loc_id

--- a/custom_components/plugwise/climate.py
+++ b/custom_components/plugwise/climate.py
@@ -77,7 +77,9 @@ class PwThermostat(SmileGateway, ClimateEntity):
         self, api, coordinator, name, dev_id, loc_id, model, min_temp, max_temp
     ):
         """Set up the Plugwise API."""
-        super().__init__(api, coordinator, name, dev_id)
+        self._enabled_default = True
+
+        super().__init__(api, coordinator, name, dev_id, self._enabled_default)
 
         self._api = api
         self._loc_id = loc_id

--- a/custom_components/plugwise/config_flow.py
+++ b/custom_components/plugwise/config_flow.py
@@ -52,10 +52,7 @@ CONF_MANUAL_PATH = "Enter Manually"
 CONNECTION_SCHEMA = vol.Schema(
     {
         vol.Required(FLOW_TYPE, default=FLOW_NET): vol.In(
-            {
-                FLOW_NET: f"Network: {SMILE} / {STRETCH}",
-                FLOW_USB: "USB: Stick",
-            }
+            {FLOW_NET: f"Network: {SMILE} / {STRETCH}", FLOW_USB: "USB: Stick",}
         ),
     },
 )
@@ -118,10 +115,7 @@ def _base_gw_schema(discovery_info):
         base_gw_schema[vol.Required(CONF_HOST)] = str
         base_gw_schema[vol.Optional(CONF_PORT, default=DEFAULT_PORT)] = int
         base_gw_schema[vol.Required(CONF_USERNAME, default=SMILE)] = vol.In(
-            {
-                SMILE: FLOW_SMILE,
-                STRETCH: FLOW_STRETCH,
-            }
+            {SMILE: FLOW_SMILE, STRETCH: FLOW_STRETCH,}
         )
 
     base_gw_schema.update({vol.Required(CONF_PASSWORD): str})
@@ -308,9 +302,7 @@ class PlugwiseConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 return await self.async_step_user_usb()
 
         return self.async_show_form(
-            step_id="user",
-            data_schema=CONNECTION_SCHEMA,
-            errors=errors,
+            step_id="user", data_schema=CONNECTION_SCHEMA, errors=errors,
         )
 
     @staticmethod

--- a/custom_components/plugwise/const.py
+++ b/custom_components/plugwise/const.py
@@ -109,7 +109,7 @@ def temperature_sensor(name_default = "Temperature", enabled_default = True):
     """Return standardized dict with temperature description."""
     return {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_TEMPERATURE,
-        ATTR_ENABELD_DEFAULT: enabled_default,
+        ATTR_ENABLED_DEFAULT: enabled_default,
         ATTR_ICON: None,
         "name": name_default,
         ATTR_UNIT_OF_MEASUREMENT: TEMP_CELSIUS,
@@ -119,7 +119,7 @@ def energy_sensor(name_default = "Power usage", unit_default = POWER_WATT, enabl
     """Return standardized dict with energy description."""
     return {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_POWER,
-        ATTR_ENABELD_DEFAULT: enabled_default,
+        ATTR_ENABLED_DEFAULT: enabled_default,
         ATTR_ICON: None,
         "name": name_default,
         ATTR_UNIT_OF_MEASUREMENT: unit_default,
@@ -128,14 +128,14 @@ def energy_sensor(name_default = "Power usage", unit_default = POWER_WATT, enabl
 THERMOSTAT_SENSORS = {
     "battery": {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_BATTERY,
-        ATTR_ENABELD_DEFAULT: True,
+        ATTR_ENABLED_DEFAULT: True,
         ATTR_ICON: None,
         "name": "Charge",
         ATTR_UNIT_OF_MEASUREMENT: PERCENTAGE,
     },
     "illuminance": {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_ILLUMINANCE,
-        ATTR_ENABELD_DEFAULT: False,
+        ATTR_ENABLED_DEFAULT: False,
         ATTR_ICON: None,
         "name": "Illuminance",
         ATTR_UNIT_OF_MEASUREMENT: UNIT_LUMEN,
@@ -146,7 +146,7 @@ THERMOSTAT_SENSORS = {
     "temperature_difference": temperature_sensor(),
     "valve_position": {
         ATTR_DEVICE_CLASS: None,
-        ATTR_ENABELD_DEFAULT: True,
+        ATTR_ENABLED_DEFAULT: True,
         ATTR_ICON: "mdi:valve",
         "name": "Valve position",
         ATTR_UNIT_OF_MEASUREMENT: PERCENTAGE,
@@ -157,7 +157,7 @@ AUX_DEV_SENSORS = {
     "intended_boiler_temperature": temperature_sensor(),
     "modulation_level": {
         ATTR_DEVICE_CLASS: None,
-        ATTR_ENABELD_DEFAULT: False,
+        ATTR_ENABLED_DEFAULT: False,
         ATTR_ICON: "mdi:percent",
         "name": "Heater Modulation Level",
         ATTR_UNIT_OF_MEASUREMENT: PERCENTAGE,
@@ -165,7 +165,7 @@ AUX_DEV_SENSORS = {
     "return_temperature": temperature_sensor(False),
     "water_pressure": {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_PRESSURE,
-        ATTR_ENABELD_DEFAULT: True,
+        ATTR_ENABLED_DEFAULT: True,
         ATTR_ICON: None,
         "name": "Pressure",
         ATTR_UNIT_OF_MEASUREMENT: PRESSURE_BAR,
@@ -192,14 +192,14 @@ ENERGY_SENSORS = {
     "electricity_produced_peak_cumulative": energy_sensor("Cumulative Consumed Power", ENERGY_KILO_WATT_HOUR),
     "gas_consumed_interval": {
         ATTR_DEVICE_CLASS: None,
-        ATTR_ENABELD_DEFAULT: True,
+        ATTR_ENABLED_DEFAULT: True,
         ATTR_ICON: "mdi:fire",
         "name": "Current Consumed Gas",
         ATTR_UNIT_OF_MEASUREMENT: VOLUME_CUBIC_METERS,
     },
     "gas_consumed_cumulative": {
         ATTR_DEVICE_CLASS: None,
-        ATTR_ENABELD_DEFAULT: True,
+        ATTR_ENABLED_DEFAULT: True,
         ATTR_ICON: "mdi:fire",
         "name": "CUmulative Consumed Gas",
         ATTR_UNIT_OF_MEASUREMENT: VOLUME_CUBIC_METERS,
@@ -228,7 +228,7 @@ MOTION_SENSOR_ID = "motion"
 SENSORS = {
     AVAILABLE_SENSOR_ID: {
         ATTR_DEVICE_CLASS: None,
-        ATTR_ENABELD_DEFAULT: False,
+        ATTR_ENABLED_DEFAULT: False,
         ATTR_ICON: "mdi:signal-off",
         "name": "Available",
         "state": "get_available",
@@ -236,7 +236,7 @@ SENSORS = {
     },
     "ping": {
         ATTR_DEVICE_CLASS: None,
-        ATTR_ENABELD_DEFAULT: False,
+        ATTR_ENABLED_DEFAULT: False,
         ATTR_ICON: "mdi:speedometer",
         "name": "Ping roundtrip",
         "state": "get_ping",
@@ -244,7 +244,7 @@ SENSORS = {
     },
     CURRENT_POWER_SENSOR_ID: {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_POWER,
-        ATTR_ENABELD_DEFAULT: True,
+        ATTR_ENABLED_DEFAULT: True,
         ATTR_ICON: None,
         "name": "Power usage",
         "state": "get_power_usage",
@@ -252,7 +252,7 @@ SENSORS = {
     },
     "power_8s": {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_POWER,
-        ATTR_ENABELD_DEFAULT: False,
+        ATTR_ENABLED_DEFAULT: False,
         ATTR_ICON: None,
         "name": "Power usage 8 seconds",
         "state": "get_power_usage_8_sec",
@@ -260,7 +260,7 @@ SENSORS = {
     },
     "power_con_cur_hour": {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_POWER,
-        ATTR_ENABELD_DEFAULT: True,
+        ATTR_ENABLED_DEFAULT: True,
         ATTR_ICON: None,
         "name": "Power consumption current hour",
         "state": "get_power_consumption_current_hour",
@@ -268,7 +268,7 @@ SENSORS = {
     },
     "power_con_prev_hour": {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_POWER,
-        ATTR_ENABELD_DEFAULT: True,
+        ATTR_ENABLED_DEFAULT: True,
         ATTR_ICON: None,
         "name": "Power consumption previous hour",
         "state": "get_power_consumption_prev_hour",
@@ -276,7 +276,7 @@ SENSORS = {
     },
     TODAY_ENERGY_SENSOR_ID: {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_POWER,
-        ATTR_ENABELD_DEFAULT: True,
+        ATTR_ENABLED_DEFAULT: True,
         ATTR_ICON: None,
         "name": "Power consumption today",
         "state": "get_power_consumption_today",
@@ -284,7 +284,7 @@ SENSORS = {
     },
     "power_con_yesterday": {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_POWER,
-        ATTR_ENABELD_DEFAULT: True,
+        ATTR_ENABLED_DEFAULT: True,
         ATTR_ICON: None,
         "name": "Power consumption yesterday",
         "state": "get_power_consumption_yesterday",
@@ -292,7 +292,7 @@ SENSORS = {
     },
     "power_prod_cur_hour": {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_POWER,
-        ATTR_ENABELD_DEFAULT: False,
+        ATTR_ENABLED_DEFAULT: False,
         ATTR_ICON: None,
         "name": "Power production current hour",
         "state": "get_power_production_current_hour",
@@ -300,7 +300,7 @@ SENSORS = {
     },
     "power_prod_prev_hour": {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_POWER,
-        ATTR_ENABELD_DEFAULT: False,
+        ATTR_ENABLED_DEFAULT: False,
         ATTR_ICON: None,
         "name": "Power production previous hour",
         "state": "get_power_production_previous_hour",
@@ -308,7 +308,7 @@ SENSORS = {
     },
     "RSSI_in": {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_SIGNAL_STRENGTH,
-        ATTR_ENABELD_DEFAULT: False,
+        ATTR_ENABLED_DEFAULT: False,
         ATTR_ICON: None,
         "name": "Inbound RSSI",
         "state": "get_in_RSSI",
@@ -316,7 +316,7 @@ SENSORS = {
     },
     "RSSI_out": {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_SIGNAL_STRENGTH,
-        ATTR_ENABELD_DEFAULT: False,
+        ATTR_ENABLED_DEFAULT: False,
         ATTR_ICON: None,
         "name": "Outbound RSSI",
         "state": "get_out_RSSI",
@@ -326,7 +326,7 @@ SENSORS = {
 BINARY_SENSORS = {
     MOTION_SENSOR_ID: {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_MOTION,
-        ATTR_ENABELD_DEFAULT: True,
+        ATTR_ENABLED_DEFAULT: True,
         ATTR_ICON: None,
         "name": "Motion",
         "state": "get_motion",
@@ -338,7 +338,7 @@ BINARY_SENSORS = {
 SWITCHES = {
     "relay": {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_OUTLET,
-        ATTR_ENABELD_DEFAULT: True,
+        ATTR_ENABLED_DEFAULT: True,
         ATTR_ICON: None,
         "name": "Relay state",
         "state": "get_relay_state",

--- a/custom_components/plugwise/const.py
+++ b/custom_components/plugwise/const.py
@@ -80,10 +80,10 @@ NOTIFICATION_ICON = "mdi:mailbox-up-outline"
 NO_NOTIFICATION_ICON = "mdi:mailbox-outline"
 SWITCH_ICON = "mdi:electric-switch"
 
-# __init__ consts:
+# gatewau consts:
 ALL_PLATFORMS = ["binary_sensor", "climate", "sensor", "switch"]
-SERVICE_DELETE = "delete_notification"
 SENSOR_PLATFORMS = ["sensor", "switch"]
+SERVICE_DELETE = "delete_notification"
 
 BINARY_SENSOR_MAP = {
     "dhw_state": ["Domestic Hot Water State", None],

--- a/custom_components/plugwise/const.py
+++ b/custom_components/plugwise/const.py
@@ -142,7 +142,7 @@ THERMOSTAT_SENSORS = {
     },
     "illuminance": {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_ILLUMINANCE,
-        ATTR_ENABLED_DEFAULT: False,
+        ATTR_ENABLED_DEFAULT: True,
         ATTR_ICON: None,
         ATTR_NAME: "Illuminance",
         ATTR_UNIT_OF_MEASUREMENT: UNIT_LUMEN,

--- a/custom_components/plugwise/const.py
+++ b/custom_components/plugwise/const.py
@@ -5,6 +5,8 @@ from homeassistant.components.switch import DEVICE_CLASS_OUTLET
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
     ATTR_ICON,
+    ATTR_NAME,
+    ATTR_STATE,
     ATTR_UNIT_OF_MEASUREMENT,
     DEVICE_CLASS_BATTERY,
     DEVICE_CLASS_ILLUMINANCE,
@@ -80,7 +82,7 @@ NOTIFICATION_ICON = "mdi:mailbox-up-outline"
 NO_NOTIFICATION_ICON = "mdi:mailbox-outline"
 SWITCH_ICON = "mdi:electric-switch"
 
-# gatewau consts:
+# gateway consts:
 ALL_PLATFORMS = ["binary_sensor", "climate", "sensor", "switch"]
 SENSOR_PLATFORMS = ["sensor", "switch"]
 SERVICE_DELETE = "delete_notification"
@@ -105,39 +107,44 @@ ZEROCONF_MAP = {
     "stretch": "Stretch",
 }
 
-def temperature_sensor(name_default = "Temperature", enabled_default = True): 
+
+def temperature_sensor(name_default="Temperature", enabled_default=True):
     """Return standardized dict with temperature description."""
     return {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_TEMPERATURE,
         ATTR_ENABLED_DEFAULT: enabled_default,
         ATTR_ICON: None,
-        "name": name_default,
+        ATTR_NAME: name_default,
         ATTR_UNIT_OF_MEASUREMENT: TEMP_CELSIUS,
     }
 
-def energy_sensor(name_default = "Power usage", unit_default = POWER_WATT, enabled_default = True): 
+
+def energy_sensor(
+    name_default="Power usage", unit_default=POWER_WATT, enabled_default=True
+):
     """Return standardized dict with energy description."""
     return {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_POWER,
         ATTR_ENABLED_DEFAULT: enabled_default,
         ATTR_ICON: None,
-        "name": name_default,
+        ATTR_NAME: name_default,
         ATTR_UNIT_OF_MEASUREMENT: unit_default,
     }
+
 
 THERMOSTAT_SENSORS = {
     "battery": {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_BATTERY,
         ATTR_ENABLED_DEFAULT: True,
         ATTR_ICON: None,
-        "name": "Charge",
+        ATTR_NAME: "Charge",
         ATTR_UNIT_OF_MEASUREMENT: PERCENTAGE,
     },
     "illuminance": {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_ILLUMINANCE,
         ATTR_ENABLED_DEFAULT: False,
         ATTR_ICON: None,
-        "name": "Illuminance",
+        ATTR_NAME: "Illuminance",
         ATTR_UNIT_OF_MEASUREMENT: UNIT_LUMEN,
     },
     "outdoor_temperature": temperature_sensor(),
@@ -148,7 +155,7 @@ THERMOSTAT_SENSORS = {
         ATTR_DEVICE_CLASS: None,
         ATTR_ENABLED_DEFAULT: True,
         ATTR_ICON: "mdi:valve",
-        "name": "Valve position",
+        ATTR_NAME: "Valve position",
         ATTR_UNIT_OF_MEASUREMENT: PERCENTAGE,
     },
 }
@@ -159,7 +166,7 @@ AUX_DEV_SENSORS = {
         ATTR_DEVICE_CLASS: None,
         ATTR_ENABLED_DEFAULT: False,
         ATTR_ICON: "mdi:percent",
-        "name": "Heater Modulation Level",
+        ATTR_NAME: "Heater Modulation Level",
         ATTR_UNIT_OF_MEASUREMENT: PERCENTAGE,
     },
     "return_temperature": temperature_sensor(False),
@@ -167,45 +174,71 @@ AUX_DEV_SENSORS = {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_PRESSURE,
         ATTR_ENABLED_DEFAULT: True,
         ATTR_ICON: None,
-        "name": "Pressure",
+        ATTR_NAME: "Pressure",
         ATTR_UNIT_OF_MEASUREMENT: PRESSURE_BAR,
     },
     "water_temperature": temperature_sensor(),
 }
 
 ENERGY_SENSORS = {
-    "electricity_consumed": energy_sensor("Current Consumed Power"), 
+    "electricity_consumed": energy_sensor("Current Consumed Power"),
     "electricity_produced": energy_sensor("Current Produced Power"),
-    "electricity_consumed_interval": energy_sensor("Consumed Power Interval", ENERGY_WATT_HOUR),
-    "electricity_consumed_peak_interval": energy_sensor("Consumed Power Interval", ENERGY_WATT_HOUR),
-    "electricity_consumed_off_peak_interval": energy_sensor("Consumed Power Interval (off peak)", ENERGY_WATT_HOUR),
-    "electricity_produced_interval": energy_sensor("Produced Power Interval", ENERGY_WATT_HOUR),
-    "electricity_produced_peak_interval": energy_sensor("Produced Power Interval", ENERGY_WATT_HOUR),
-    "electricity_produced_off_peak_interval": energy_sensor("Produced Power Interval (off peak)", ENERGY_WATT_HOUR),
-    "electricity_consumed_off_peak_point": energy_sensor("Current Consumed Power (off peak)"),
+    "electricity_consumed_interval": energy_sensor(
+        "Consumed Power Interval", ENERGY_WATT_HOUR
+    ),
+    "electricity_consumed_peak_interval": energy_sensor(
+        "Consumed Power Interval", ENERGY_WATT_HOUR
+    ),
+    "electricity_consumed_off_peak_interval": energy_sensor(
+        "Consumed Power Interval (off peak)", ENERGY_WATT_HOUR
+    ),
+    "electricity_produced_interval": energy_sensor(
+        "Produced Power Interval", ENERGY_WATT_HOUR
+    ),
+    "electricity_produced_peak_interval": energy_sensor(
+        "Produced Power Interval", ENERGY_WATT_HOUR
+    ),
+    "electricity_produced_off_peak_interval": energy_sensor(
+        "Produced Power Interval (off peak)", ENERGY_WATT_HOUR
+    ),
+    "electricity_consumed_off_peak_point": energy_sensor(
+        "Current Consumed Power (off peak)"
+    ),
     "electricity_consumed_peak_point": energy_sensor("Current Consumed Power"),
-    "electricity_consumed_off_peak_cumulative": energy_sensor("Cumulative Consumed Power (off peak)", ENERGY_KILO_WATT_HOUR),
-    "electricity_consumed_peak_cumulative": energy_sensor("Cumulative Consumed Power", ENERGY_KILO_WATT_HOUR),
-    "electricity_produced_off_peak_point": energy_sensor("Current Consumed Power (off peak)"),
+    "electricity_consumed_off_peak_cumulative": energy_sensor(
+        "Cumulative Consumed Power (off peak)", ENERGY_KILO_WATT_HOUR
+    ),
+    "electricity_consumed_peak_cumulative": energy_sensor(
+        "Cumulative Consumed Power", ENERGY_KILO_WATT_HOUR
+    ),
+    "electricity_produced_off_peak_point": energy_sensor(
+        "Current Consumed Power (off peak)"
+    ),
     "electricity_produced_peak_point": energy_sensor("Current Consumed Power"),
-    "electricity_produced_off_peak_cumulative": energy_sensor("Cumulative Consumed Power (off peak)", ENERGY_KILO_WATT_HOUR),
-    "electricity_produced_peak_cumulative": energy_sensor("Cumulative Consumed Power", ENERGY_KILO_WATT_HOUR),
+    "electricity_produced_off_peak_cumulative": energy_sensor(
+        "Cumulative Consumed Power (off peak)", ENERGY_KILO_WATT_HOUR
+    ),
+    "electricity_produced_peak_cumulative": energy_sensor(
+        "Cumulative Consumed Power", ENERGY_KILO_WATT_HOUR
+    ),
     "gas_consumed_interval": {
         ATTR_DEVICE_CLASS: None,
         ATTR_ENABLED_DEFAULT: True,
         ATTR_ICON: "mdi:fire",
-        "name": "Current Consumed Gas",
+        ATTR_NAME: "Current Consumed Gas",
         ATTR_UNIT_OF_MEASUREMENT: VOLUME_CUBIC_METERS,
     },
     "gas_consumed_cumulative": {
         ATTR_DEVICE_CLASS: None,
         ATTR_ENABLED_DEFAULT: True,
         ATTR_ICON: "mdi:fire",
-        "name": "CUmulative Consumed Gas",
+        ATTR_NAME: "CUmulative Consumed Gas",
         ATTR_UNIT_OF_MEASUREMENT: VOLUME_CUBIC_METERS,
     },
     "net_electricity_point": energy_sensor("Current net Power"),
-    "net_electricity_cumulative": energy_sensor("Current net Power", ENERGY_KILO_WATT_HOUR),
+    "net_electricity_cumulative": energy_sensor(
+        "Current net Power", ENERGY_KILO_WATT_HOUR
+    ),
 }
 
 # switch const:
@@ -230,96 +263,96 @@ SENSORS = {
         ATTR_DEVICE_CLASS: None,
         ATTR_ENABLED_DEFAULT: False,
         ATTR_ICON: "mdi:signal-off",
-        "name": "Available",
-        "state": "get_available",
+        ATTR_NAME: "Available",
+        ATTR_STATE: "get_available",
         ATTR_UNIT_OF_MEASUREMENT: None,
     },
     "ping": {
         ATTR_DEVICE_CLASS: None,
         ATTR_ENABLED_DEFAULT: False,
         ATTR_ICON: "mdi:speedometer",
-        "name": "Ping roundtrip",
-        "state": "get_ping",
+        ATTR_NAME: "Ping roundtrip",
+        ATTR_STATE: "get_ping",
         ATTR_UNIT_OF_MEASUREMENT: TIME_MILLISECONDS,
     },
     CURRENT_POWER_SENSOR_ID: {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_POWER,
         ATTR_ENABLED_DEFAULT: True,
         ATTR_ICON: None,
-        "name": "Power usage",
-        "state": "get_power_usage",
+        ATTR_NAME: "Power usage",
+        ATTR_STATE: "get_power_usage",
         ATTR_UNIT_OF_MEASUREMENT: POWER_WATT,
     },
     "power_8s": {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_POWER,
         ATTR_ENABLED_DEFAULT: False,
         ATTR_ICON: None,
-        "name": "Power usage 8 seconds",
-        "state": "get_power_usage_8_sec",
+        ATTR_NAME: "Power usage 8 seconds",
+        ATTR_STATE: "get_power_usage_8_sec",
         ATTR_UNIT_OF_MEASUREMENT: POWER_WATT,
     },
     "power_con_cur_hour": {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_POWER,
         ATTR_ENABLED_DEFAULT: True,
         ATTR_ICON: None,
-        "name": "Power consumption current hour",
-        "state": "get_power_consumption_current_hour",
+        ATTR_NAME: "Power consumption current hour",
+        ATTR_STATE: "get_power_consumption_current_hour",
         ATTR_UNIT_OF_MEASUREMENT: ENERGY_KILO_WATT_HOUR,
     },
     "power_con_prev_hour": {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_POWER,
         ATTR_ENABLED_DEFAULT: True,
         ATTR_ICON: None,
-        "name": "Power consumption previous hour",
-        "state": "get_power_consumption_prev_hour",
+        ATTR_NAME: "Power consumption previous hour",
+        ATTR_STATE: "get_power_consumption_prev_hour",
         ATTR_UNIT_OF_MEASUREMENT: ENERGY_KILO_WATT_HOUR,
     },
     TODAY_ENERGY_SENSOR_ID: {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_POWER,
         ATTR_ENABLED_DEFAULT: True,
         ATTR_ICON: None,
-        "name": "Power consumption today",
-        "state": "get_power_consumption_today",
+        ATTR_NAME: "Power consumption today",
+        ATTR_STATE: "get_power_consumption_today",
         ATTR_UNIT_OF_MEASUREMENT: ENERGY_KILO_WATT_HOUR,
     },
     "power_con_yesterday": {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_POWER,
         ATTR_ENABLED_DEFAULT: True,
         ATTR_ICON: None,
-        "name": "Power consumption yesterday",
-        "state": "get_power_consumption_yesterday",
+        ATTR_NAME: "Power consumption yesterday",
+        ATTR_STATE: "get_power_consumption_yesterday",
         ATTR_UNIT_OF_MEASUREMENT: ENERGY_KILO_WATT_HOUR,
     },
     "power_prod_cur_hour": {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_POWER,
         ATTR_ENABLED_DEFAULT: False,
         ATTR_ICON: None,
-        "name": "Power production current hour",
-        "state": "get_power_production_current_hour",
+        ATTR_NAME: "Power production current hour",
+        ATTR_STATE: "get_power_production_current_hour",
         ATTR_UNIT_OF_MEASUREMENT: ENERGY_KILO_WATT_HOUR,
     },
     "power_prod_prev_hour": {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_POWER,
         ATTR_ENABLED_DEFAULT: False,
         ATTR_ICON: None,
-        "name": "Power production previous hour",
-        "state": "get_power_production_previous_hour",
+        ATTR_NAME: "Power production previous hour",
+        ATTR_STATE: "get_power_production_previous_hour",
         ATTR_UNIT_OF_MEASUREMENT: ENERGY_KILO_WATT_HOUR,
     },
     "RSSI_in": {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_SIGNAL_STRENGTH,
         ATTR_ENABLED_DEFAULT: False,
         ATTR_ICON: None,
-        "name": "Inbound RSSI",
-        "state": "get_in_RSSI",
+        ATTR_NAME: "Inbound RSSI",
+        ATTR_STATE: "get_in_RSSI",
         ATTR_UNIT_OF_MEASUREMENT: "dBm",
     },
     "RSSI_out": {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_SIGNAL_STRENGTH,
         ATTR_ENABLED_DEFAULT: False,
         ATTR_ICON: None,
-        "name": "Outbound RSSI",
-        "state": "get_out_RSSI",
+        ATTR_NAME: "Outbound RSSI",
+        ATTR_STATE: "get_out_RSSI",
         ATTR_UNIT_OF_MEASUREMENT: "dBm",
     },
 }
@@ -328,8 +361,8 @@ BINARY_SENSORS = {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_MOTION,
         ATTR_ENABLED_DEFAULT: True,
         ATTR_ICON: None,
-        "name": "Motion",
-        "state": "get_motion",
+        ATTR_NAME: "Motion",
+        ATTR_STATE: "get_motion",
         ATTR_UNIT_OF_MEASUREMENT: None,
     }
 }
@@ -340,8 +373,8 @@ SWITCHES = {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_OUTLET,
         ATTR_ENABLED_DEFAULT: True,
         ATTR_ICON: None,
-        "name": "Relay state",
-        "state": "get_relay_state",
+        ATTR_NAME: "Relay state",
+        ATTR_STATE: "get_relay_state",
         "switch": "set_relay_state",
         ATTR_UNIT_OF_MEASUREMENT: "state",
     }

--- a/custom_components/plugwise/const.py
+++ b/custom_components/plugwise/const.py
@@ -23,7 +23,7 @@ from homeassistant.const import (
 )
 
 API = "api"
-ATTR_DEFAULT_ENABLED = "default_enabled"
+ATTR_ENABLED_DEFAULT = "enabled_default"
 DOMAIN = "plugwise"
 COORDINATOR = "coordinator"
 GATEWAY = "gateway"
@@ -109,7 +109,7 @@ def temperature_sensor(name_default = "Temperature", enabled_default = True):
     """Return standardized dict with temperature description."""
     return {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_TEMPERATURE,
-        "enabled_default": enabled_default,
+        ATTR_ENABELD_DEFAULT: enabled_default,
         ATTR_ICON: None,
         "name": name_default,
         ATTR_UNIT_OF_MEASUREMENT: TEMP_CELSIUS,
@@ -119,7 +119,7 @@ def energy_sensor(name_default = "Power usage", unit_default = POWER_WATT, enabl
     """Return standardized dict with energy description."""
     return {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_POWER,
-        "enabled_default": enabled_default,
+        ATTR_ENABELD_DEFAULT: enabled_default,
         ATTR_ICON: None,
         "name": name_default,
         ATTR_UNIT_OF_MEASUREMENT: unit_default,
@@ -128,14 +128,14 @@ def energy_sensor(name_default = "Power usage", unit_default = POWER_WATT, enabl
 THERMOSTAT_SENSORS = {
     "battery": {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_BATTERY,
-        "enabled_default": True,
+        ATTR_ENABELD_DEFAULT: True,
         ATTR_ICON: None,
         "name": "Charge",
         ATTR_UNIT_OF_MEASUREMENT: PERCENTAGE,
     },
     "illuminance": {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_ILLUMINANCE,
-        "enabled_default": True,
+        ATTR_ENABELD_DEFAULT: False,
         ATTR_ICON: None,
         "name": "Illuminance",
         ATTR_UNIT_OF_MEASUREMENT: UNIT_LUMEN,
@@ -146,7 +146,7 @@ THERMOSTAT_SENSORS = {
     "temperature_difference": temperature_sensor(),
     "valve_position": {
         ATTR_DEVICE_CLASS: None,
-        "enabled_default": True,
+        ATTR_ENABELD_DEFAULT: True,
         ATTR_ICON: "mdi:valve",
         "name": "Valve position",
         ATTR_UNIT_OF_MEASUREMENT: PERCENTAGE,
@@ -157,7 +157,7 @@ AUX_DEV_SENSORS = {
     "intended_boiler_temperature": temperature_sensor(),
     "modulation_level": {
         ATTR_DEVICE_CLASS: None,
-        "enabled_default": False,
+        ATTR_ENABELD_DEFAULT: False,
         ATTR_ICON: "mdi:percent",
         "name": "Heater Modulation Level",
         ATTR_UNIT_OF_MEASUREMENT: PERCENTAGE,
@@ -165,7 +165,7 @@ AUX_DEV_SENSORS = {
     "return_temperature": temperature_sensor(False),
     "water_pressure": {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_PRESSURE,
-        "enabled_default": True,
+        ATTR_ENABELD_DEFAULT: True,
         ATTR_ICON: None,
         "name": "Pressure",
         ATTR_UNIT_OF_MEASUREMENT: PRESSURE_BAR,
@@ -192,14 +192,14 @@ ENERGY_SENSORS = {
     "electricity_produced_peak_cumulative": energy_sensor("Cumulative Consumed Power", ENERGY_KILO_WATT_HOUR),
     "gas_consumed_interval": {
         ATTR_DEVICE_CLASS: None,
-        "enabled_default": True,
+        ATTR_ENABELD_DEFAULT: True,
         ATTR_ICON: "mdi:fire",
         "name": "Current Consumed Gas",
         ATTR_UNIT_OF_MEASUREMENT: VOLUME_CUBIC_METERS,
     },
     "gas_consumed_cumulative": {
         ATTR_DEVICE_CLASS: None,
-        "enabled_default": True,
+        ATTR_ENABELD_DEFAULT: True,
         ATTR_ICON: "mdi:fire",
         "name": "CUmulative Consumed Gas",
         ATTR_UNIT_OF_MEASUREMENT: VOLUME_CUBIC_METERS,
@@ -228,7 +228,7 @@ MOTION_SENSOR_ID = "motion"
 SENSORS = {
     AVAILABLE_SENSOR_ID: {
         ATTR_DEVICE_CLASS: None,
-        "enabled_default": False,
+        ATTR_ENABELD_DEFAULT: False,
         ATTR_ICON: "mdi:signal-off",
         "name": "Available",
         "state": "get_available",
@@ -236,7 +236,7 @@ SENSORS = {
     },
     "ping": {
         ATTR_DEVICE_CLASS: None,
-        "enabled_default": False,
+        ATTR_ENABELD_DEFAULT: False,
         ATTR_ICON: "mdi:speedometer",
         "name": "Ping roundtrip",
         "state": "get_ping",
@@ -244,7 +244,7 @@ SENSORS = {
     },
     CURRENT_POWER_SENSOR_ID: {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_POWER,
-        "enabled_default": True,
+        ATTR_ENABELD_DEFAULT: True,
         ATTR_ICON: None,
         "name": "Power usage",
         "state": "get_power_usage",
@@ -252,7 +252,7 @@ SENSORS = {
     },
     "power_8s": {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_POWER,
-        "enabled_default": False,
+        ATTR_ENABELD_DEFAULT: False,
         ATTR_ICON: None,
         "name": "Power usage 8 seconds",
         "state": "get_power_usage_8_sec",
@@ -260,7 +260,7 @@ SENSORS = {
     },
     "power_con_cur_hour": {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_POWER,
-        "enabled_default": True,
+        ATTR_ENABELD_DEFAULT: True,
         ATTR_ICON: None,
         "name": "Power consumption current hour",
         "state": "get_power_consumption_current_hour",
@@ -268,7 +268,7 @@ SENSORS = {
     },
     "power_con_prev_hour": {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_POWER,
-        "enabled_default": True,
+        ATTR_ENABELD_DEFAULT: True,
         ATTR_ICON: None,
         "name": "Power consumption previous hour",
         "state": "get_power_consumption_prev_hour",
@@ -276,7 +276,7 @@ SENSORS = {
     },
     TODAY_ENERGY_SENSOR_ID: {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_POWER,
-        "enabled_default": True,
+        ATTR_ENABELD_DEFAULT: True,
         ATTR_ICON: None,
         "name": "Power consumption today",
         "state": "get_power_consumption_today",
@@ -284,7 +284,7 @@ SENSORS = {
     },
     "power_con_yesterday": {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_POWER,
-        "enabled_default": True,
+        ATTR_ENABELD_DEFAULT: True,
         ATTR_ICON: None,
         "name": "Power consumption yesterday",
         "state": "get_power_consumption_yesterday",
@@ -292,7 +292,7 @@ SENSORS = {
     },
     "power_prod_cur_hour": {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_POWER,
-        "enabled_default": False,
+        ATTR_ENABELD_DEFAULT: False,
         ATTR_ICON: None,
         "name": "Power production current hour",
         "state": "get_power_production_current_hour",
@@ -300,7 +300,7 @@ SENSORS = {
     },
     "power_prod_prev_hour": {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_POWER,
-        "enabled_default": False,
+        ATTR_ENABELD_DEFAULT: False,
         ATTR_ICON: None,
         "name": "Power production previous hour",
         "state": "get_power_production_previous_hour",
@@ -308,7 +308,7 @@ SENSORS = {
     },
     "RSSI_in": {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_SIGNAL_STRENGTH,
-        "enabled_default": False,
+        ATTR_ENABELD_DEFAULT: False,
         ATTR_ICON: None,
         "name": "Inbound RSSI",
         "state": "get_in_RSSI",
@@ -316,7 +316,7 @@ SENSORS = {
     },
     "RSSI_out": {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_SIGNAL_STRENGTH,
-        "enabled_default": False,
+        ATTR_ENABELD_DEFAULT: False,
         ATTR_ICON: None,
         "name": "Outbound RSSI",
         "state": "get_out_RSSI",
@@ -326,7 +326,7 @@ SENSORS = {
 BINARY_SENSORS = {
     MOTION_SENSOR_ID: {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_MOTION,
-        "enabled_default": True,
+        ATTR_ENABELD_DEFAULT: True,
         ATTR_ICON: None,
         "name": "Motion",
         "state": "get_motion",
@@ -338,7 +338,7 @@ BINARY_SENSORS = {
 SWITCHES = {
     "relay": {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_OUTLET,
-        "enabled_default": True,
+        ATTR_ENABELD_DEFAULT: True,
         ATTR_ICON: None,
         "name": "Relay state",
         "state": "get_relay_state",

--- a/custom_components/plugwise/const.py
+++ b/custom_components/plugwise/const.py
@@ -114,7 +114,7 @@ def temperature_sensor(name_default = "Temperature", enabled_default = True):
         "enabled_default": enabled_default,
         "icon": None,
         "name": name_default,
-        "unit": TEMP_CELCIUS,
+        "unit": TEMP_CELSIUS,
     }
 
 def energy_sensor(name_default = "Power usage", unit_default = POWER_WATT, enabled_default = True): 

--- a/custom_components/plugwise/const.py
+++ b/custom_components/plugwise/const.py
@@ -20,6 +20,7 @@ from homeassistant.const import (
 )
 
 API = "api"
+ATTR_DEFAULT_ENABLED = "default_enabled"
 DOMAIN = "plugwise"
 COORDINATOR = "coordinator"
 GATEWAY = "gateway"
@@ -38,10 +39,9 @@ FLOW_STRETCH = "stretch (Stretch)"
 UNDO_UPDATE_LISTENER = "undo_update_listener"
 
 # Sensor mapping
-SENSOR_MAP_DEVICE_CLASS = 2
-SENSOR_MAP_ICON = 3
-SENSOR_MAP_MODEL = 0
-SENSOR_MAP_UOM = 1
+SENSORS_DEVICE_CLASS = "class"
+SENSORS_ICON = "icon"
+SENSORS_UOM = "unit"
 
 # Default directives
 DEFAULT_MAX_TEMP = 30
@@ -87,7 +87,6 @@ ALL_PLATFORMS = ["binary_sensor", "climate", "sensor", "switch"]
 SERVICE_DELETE = "delete_notification"
 SENSOR_PLATFORMS = ["sensor", "switch"]
 
-# binary_sensor const:
 BINARY_SENSOR_MAP = {
     "dhw_state": ["Domestic Hot Water State", None],
     "slave_boiler_state": ["Secondary Heater Device State", None],
@@ -108,138 +107,107 @@ ZEROCONF_MAP = {
     "stretch": "Stretch",
 }
 
-# sensor consts:
-ATTR_TEMPERATURE = ["Temperature", TEMP_CELSIUS, DEVICE_CLASS_TEMPERATURE]
-ATTR_BATTERY_LEVEL = ["Charge", PERCENTAGE, DEVICE_CLASS_BATTERY]
-ATTR_ILLUMINANCE = ["Illuminance", UNIT_LUMEN, DEVICE_CLASS_ILLUMINANCE]
-ATTR_PRESSURE = ["Pressure", PRESSURE_BAR, DEVICE_CLASS_PRESSURE]
+def temperature_sensor(name_default = "Temperature", enabled_default = True): 
+    """Return standardized dict with temperature description."""
+    return {
+        "class": DEVICE_CLASS_TEMPERATURE,
+        "enabled_default": enabled_default,
+        "icon": None,
+        "name": name_default,
+        "unit": TEMP_CELCIUS,
+    }
 
-THERMOSTAT_SENSOR_MAP = {
-    "battery": ATTR_BATTERY_LEVEL,
-    "illuminance": ATTR_ILLUMINANCE,
-    "outdoor_temperature": ATTR_TEMPERATURE,
-    "setpoint": ATTR_TEMPERATURE,
-    "temperature": ATTR_TEMPERATURE,
-    "temperature_difference": ATTR_TEMPERATURE,
-    "valve_position": ["Valve Position", PERCENTAGE, None],
+def energy_sensor(name_default = "Power usage", unit_default = POWER_WATT, enabled_default = True): 
+    """Return standardized dict with energy description."""
+    return {
+        "class": DEVICE_CLASS_POWER,
+        "enabled_default": enabled_default,
+        "icon": None,
+        "name": name_default,
+        "unit": unit_default,
+    }
+
+THERMOSTAT_SENSORS = {
+    "battery": {
+        "class": DEVICE_CLASS_BATTERY,
+        "enabled_default": True,
+        "icon": None,
+        "name": "Charge",
+        "unit": PERCENTAGE,
+    },
+    "illuminance": {
+        "class": DEVICE_CLASS_ILLUMINANCE,
+        "enabled_default": True,
+        "icon": None,
+        "name": "Illuminance",
+        "unit": UNIT_LUMEN,
+    },
+    "outdoor_temperature": temperature_sensor(),
+    "setpoint": temperature_sensor(),
+    "temperature": temperature_sensor(),
+    "temperature_difference": temperature_sensor(),
+    "valve_position": {
+        "class": None,
+        "enabled_default": True,
+        "icon": "mdi:valve",
+        "name": "Valve position",
+        "unit": PERCENTAGE,
+    },
 }
 
-AUX_DEV_SENSOR_MAP = {
-    "intended_boiler_temperature": ATTR_TEMPERATURE,
-    "modulation_level": ["Heater Modulation Level", PERCENTAGE, None],
-    "return_temperature": ATTR_TEMPERATURE,
-    "water_pressure": ATTR_PRESSURE,
-    "water_temperature": ATTR_TEMPERATURE,
+AUX_DEV_SENSORS = {
+    "intended_boiler_temperature": temperature_sensor(),
+    "modulation_level": {
+        "class": None,
+        "enabled_default": False,
+        "icon": "mdi:percent",
+        "name": "Heater Modulation Level",
+        "unit": PERCENTAGE,
+    },
+    "return_temperature": temperature_sensor(False),
+    "water_pressure": {
+        "class": DEVICE_CLASS_PRESSURE,
+        "enabled_default": True,
+        "icon": None,
+        "name": "Pressure",
+        "unit": PRESSURE_BAR,
+    },
+    "water_temperature": temperature_sensor(),
 }
 
-ENERGY_SENSOR_MAP = {
-    "electricity_consumed": [
-        "Current Consumed Power",
-        POWER_WATT,
-        DEVICE_CLASS_POWER,
-    ],
-    "electricity_produced": [
-        "Current Produced Power",
-        POWER_WATT,
-        DEVICE_CLASS_POWER,
-    ],
-    "electricity_consumed_interval": [
-        "Consumed Power Interval",
-        ENERGY_WATT_HOUR,
-        DEVICE_CLASS_POWER,
-    ],
-    "electricity_consumed_peak_interval": [
-        "Consumed Power Interval",
-        ENERGY_WATT_HOUR,
-        DEVICE_CLASS_POWER,
-    ],
-    "electricity_consumed_off_peak_interval": [
-        "Consumed Power Interval (off peak)",
-        ENERGY_WATT_HOUR,
-        DEVICE_CLASS_POWER,
-    ],
-    "electricity_produced_interval": [
-        "Produced Power Interval",
-        ENERGY_WATT_HOUR,
-        DEVICE_CLASS_POWER,
-    ],
-    "electricity_produced_peak_interval": [
-        "Produced Power Interval",
-        ENERGY_WATT_HOUR,
-        DEVICE_CLASS_POWER,
-    ],
-    "electricity_produced_off_peak_interval": [
-        "Produced Power Interval (off peak)",
-        ENERGY_WATT_HOUR,
-        DEVICE_CLASS_POWER,
-    ],
-    "electricity_consumed_off_peak_point": [
-        "Current Consumed Power (off peak)",
-        POWER_WATT,
-        DEVICE_CLASS_POWER,
-    ],
-    "electricity_consumed_peak_point": [
-        "Current Consumed Power",
-        POWER_WATT,
-        DEVICE_CLASS_POWER,
-    ],
-    "electricity_consumed_off_peak_cumulative": [
-        "Cumulative Consumed Power (off peak)",
-        ENERGY_KILO_WATT_HOUR,
-        DEVICE_CLASS_POWER,
-    ],
-    "electricity_consumed_peak_cumulative": [
-        "Cumulative Consumed Power",
-        ENERGY_KILO_WATT_HOUR,
-        DEVICE_CLASS_POWER,
-    ],
-    "electricity_produced_off_peak_point": [
-        "Current Consumed Power (off peak)",
-        POWER_WATT,
-        DEVICE_CLASS_POWER,
-    ],
-    "electricity_produced_peak_point": [
-        "Current Consumed Power",
-        POWER_WATT,
-        DEVICE_CLASS_POWER,
-    ],
-    "electricity_produced_off_peak_cumulative": [
-        "Cumulative Consumed Power (off peak)",
-        ENERGY_KILO_WATT_HOUR,
-        DEVICE_CLASS_POWER,
-    ],
-    "electricity_produced_peak_cumulative": [
-        "Cumulative Consumed Power",
-        ENERGY_KILO_WATT_HOUR,
-        DEVICE_CLASS_POWER,
-    ],
-    "gas_consumed_interval": [
-        "Current Consumed Gas",
-        VOLUME_CUBIC_METERS,
-        None,
-    ],
-    "gas_consumed_cumulative": [
-        "Cumulative Consumed Gas",
-        VOLUME_CUBIC_METERS,
-        None,
-    ],
-    "net_electricity_point": [
-        "Current net Power",
-        POWER_WATT,
-        DEVICE_CLASS_POWER,
-    ],
-    "net_electricity_cumulative": [
-        "Cumulative net Power",
-        ENERGY_KILO_WATT_HOUR,
-        DEVICE_CLASS_POWER,
-    ],
-}
-
-CUSTOM_ICONS = {
-    "gas_consumed_interval": "mdi:fire",
-    "gas_consumed_cumulative": "mdi:fire",
-    "modulation_level": "mdi:percent",
-    "valve_position": "mdi:valve",
+ENERGY_SENSORS = {
+    "electricity_consumed": energy_sensor("Current Consumed Power"), 
+    "electricity_produced": energy_sensor("Current Produced Power"),
+    "electricity_consumed_interval": energy_sensor("Consumed Power Interval", ENERGY_WATT_HOUR),
+    "electricity_consumed_peak_interval": energy_sensor("Consumed Power Interval", ENERGY_WATT_HOUR),
+    "electricity_consumed_off_peak_interval": energy_sensor("Consumed Power Interval (off peak)", ENERGY_WATT_HOUR),
+    "electricity_produced_interval": energy_sensor("Produced Power Interval", ENERGY_WATT_HOUR),
+    "electricity_produced_peak_interval": energy_sensor("Produced Power Interval", ENERGY_WATT_HOUR),
+    "electricity_produced_off_peak_interval": energy_sensor("Produced Power Interval (off peak)", ENERGY_WATT_HOUR),
+    "electricity_consumed_off_peak_point": energy_sensor("Current Consumed Power (off peak)"),
+    "electricity_consumed_peak_point": energy_sensor("Current Consumed Power"),
+    "electricity_consumed_off_peak_cumulative": energy_sensor("Cumulative Consumed Power (off peak)", ENERGY_KILO_WATT_HOUR),
+    "electricity_consumed_peak_cumulative": energy_sensor("Cumulative Consumed Power", ENERGY_KILO_WATT_HOUR),
+    "electricity_produced_off_peak_point": energy_sensor("Current Consumed Power (off peak)"),
+    "electricity_produced_peak_point": energy_sensor("Current Consumed Power"),
+    "electricity_produced_off_peak_cumulative": energy_sensor("Cumulative Consumed Power (off peak)", ENERGY_KILO_WATT_HOUR),
+    "electricity_produced_peak_cumulative": energy_sensor("Cumulative Consumed Power", ENERGY_KILO_WATT_HOUR),
+    "gas_consumed_interval": {
+        "class": None,
+        "enabled_default": True,
+        "icon": "mdi:fire",
+        "name": "Current Consumed Gas",
+        "unit": VOLUME_CUBIC_METERS,
+    },
+    "gas_consumed_cumulative": {
+        "class": None,
+        "enabled_default": True,
+        "icon": "mdi:fire",
+        "name": "CUmulative Consumed Gas",
+        "unit": VOLUME_CUBIC_METERS,
+    },
+    "net_electricity_point": energy_sensor("Current net Power"),
+    "net_electricity_cumulative": energy_sensor("Current net Power", ENERGY_KILO_WATT_HOUR),
 }
 
 # switch const:

--- a/custom_components/plugwise/const.py
+++ b/custom_components/plugwise/const.py
@@ -3,6 +3,9 @@
 from homeassistant.components.binary_sensor import DEVICE_CLASS_MOTION
 from homeassistant.components.switch import DEVICE_CLASS_OUTLET
 from homeassistant.const import (
+    ATTR_DEVICE_CLASS,
+    ATTR_ICON,
+    ATTR_UNIT_OF_MEASUREMENT,
     DEVICE_CLASS_BATTERY,
     DEVICE_CLASS_ILLUMINANCE,
     DEVICE_CLASS_POWER,
@@ -37,11 +40,6 @@ FLOW_SMILE = "smile (Adam/Anna/P1)"
 FLOW_STRETCH = "stretch (Stretch)"
 
 UNDO_UPDATE_LISTENER = "undo_update_listener"
-
-# Sensor mapping
-SENSORS_DEVICE_CLASS = "class"
-SENSORS_ICON = "icon"
-SENSORS_UOM = "unit"
 
 # Default directives
 DEFAULT_MAX_TEMP = 30
@@ -110,67 +108,67 @@ ZEROCONF_MAP = {
 def temperature_sensor(name_default = "Temperature", enabled_default = True): 
     """Return standardized dict with temperature description."""
     return {
-        "class": DEVICE_CLASS_TEMPERATURE,
+        ATTR_DEVICE_CLASS: DEVICE_CLASS_TEMPERATURE,
         "enabled_default": enabled_default,
-        "icon": None,
+        ATTR_ICON: None,
         "name": name_default,
-        "unit": TEMP_CELSIUS,
+        ATTR_UNIT_OF_MEASUREMENT: TEMP_CELSIUS,
     }
 
 def energy_sensor(name_default = "Power usage", unit_default = POWER_WATT, enabled_default = True): 
     """Return standardized dict with energy description."""
     return {
-        "class": DEVICE_CLASS_POWER,
+        ATTR_DEVICE_CLASS: DEVICE_CLASS_POWER,
         "enabled_default": enabled_default,
-        "icon": None,
+        ATTR_ICON: None,
         "name": name_default,
-        "unit": unit_default,
+        ATTR_UNIT_OF_MEASUREMENT: unit_default,
     }
 
 THERMOSTAT_SENSORS = {
     "battery": {
-        "class": DEVICE_CLASS_BATTERY,
+        ATTR_DEVICE_CLASS: DEVICE_CLASS_BATTERY,
         "enabled_default": True,
-        "icon": None,
+        ATTR_ICON: None,
         "name": "Charge",
-        "unit": PERCENTAGE,
+        ATTR_UNIT_OF_MEASUREMENT: PERCENTAGE,
     },
     "illuminance": {
-        "class": DEVICE_CLASS_ILLUMINANCE,
+        ATTR_DEVICE_CLASS: DEVICE_CLASS_ILLUMINANCE,
         "enabled_default": True,
-        "icon": None,
+        ATTR_ICON: None,
         "name": "Illuminance",
-        "unit": UNIT_LUMEN,
+        ATTR_UNIT_OF_MEASUREMENT: UNIT_LUMEN,
     },
     "outdoor_temperature": temperature_sensor(),
     "setpoint": temperature_sensor(),
     "temperature": temperature_sensor(),
     "temperature_difference": temperature_sensor(),
     "valve_position": {
-        "class": None,
+        ATTR_DEVICE_CLASS: None,
         "enabled_default": True,
-        "icon": "mdi:valve",
+        ATTR_ICON: "mdi:valve",
         "name": "Valve position",
-        "unit": PERCENTAGE,
+        ATTR_UNIT_OF_MEASUREMENT: PERCENTAGE,
     },
 }
 
 AUX_DEV_SENSORS = {
     "intended_boiler_temperature": temperature_sensor(),
     "modulation_level": {
-        "class": None,
+        ATTR_DEVICE_CLASS: None,
         "enabled_default": False,
-        "icon": "mdi:percent",
+        ATTR_ICON: "mdi:percent",
         "name": "Heater Modulation Level",
-        "unit": PERCENTAGE,
+        ATTR_UNIT_OF_MEASUREMENT: PERCENTAGE,
     },
     "return_temperature": temperature_sensor(False),
     "water_pressure": {
-        "class": DEVICE_CLASS_PRESSURE,
+        ATTR_DEVICE_CLASS: DEVICE_CLASS_PRESSURE,
         "enabled_default": True,
-        "icon": None,
+        ATTR_ICON: None,
         "name": "Pressure",
-        "unit": PRESSURE_BAR,
+        ATTR_UNIT_OF_MEASUREMENT: PRESSURE_BAR,
     },
     "water_temperature": temperature_sensor(),
 }
@@ -193,18 +191,18 @@ ENERGY_SENSORS = {
     "electricity_produced_off_peak_cumulative": energy_sensor("Cumulative Consumed Power (off peak)", ENERGY_KILO_WATT_HOUR),
     "electricity_produced_peak_cumulative": energy_sensor("Cumulative Consumed Power", ENERGY_KILO_WATT_HOUR),
     "gas_consumed_interval": {
-        "class": None,
+        ATTR_DEVICE_CLASS: None,
         "enabled_default": True,
-        "icon": "mdi:fire",
+        ATTR_ICON: "mdi:fire",
         "name": "Current Consumed Gas",
-        "unit": VOLUME_CUBIC_METERS,
+        ATTR_UNIT_OF_MEASUREMENT: VOLUME_CUBIC_METERS,
     },
     "gas_consumed_cumulative": {
-        "class": None,
+        ATTR_DEVICE_CLASS: None,
         "enabled_default": True,
-        "icon": "mdi:fire",
+        ATTR_ICON: "mdi:fire",
         "name": "CUmulative Consumed Gas",
-        "unit": VOLUME_CUBIC_METERS,
+        ATTR_UNIT_OF_MEASUREMENT: VOLUME_CUBIC_METERS,
     },
     "net_electricity_point": energy_sensor("Current net Power"),
     "net_electricity_cumulative": energy_sensor("Current net Power", ENERGY_KILO_WATT_HOUR),
@@ -229,123 +227,123 @@ MOTION_SENSOR_ID = "motion"
 # Sensor types
 SENSORS = {
     AVAILABLE_SENSOR_ID: {
-        "class": None,
+        ATTR_DEVICE_CLASS: None,
         "enabled_default": False,
-        "icon": "mdi:signal-off",
+        ATTR_ICON: "mdi:signal-off",
         "name": "Available",
         "state": "get_available",
-        "unit": None,
+        ATTR_UNIT_OF_MEASUREMENT: None,
     },
     "ping": {
-        "class": None,
+        ATTR_DEVICE_CLASS: None,
         "enabled_default": False,
-        "icon": "mdi:speedometer",
+        ATTR_ICON: "mdi:speedometer",
         "name": "Ping roundtrip",
         "state": "get_ping",
-        "unit": TIME_MILLISECONDS,
+        ATTR_UNIT_OF_MEASUREMENT: TIME_MILLISECONDS,
     },
     CURRENT_POWER_SENSOR_ID: {
-        "class": DEVICE_CLASS_POWER,
+        ATTR_DEVICE_CLASS: DEVICE_CLASS_POWER,
         "enabled_default": True,
-        "icon": None,
+        ATTR_ICON: None,
         "name": "Power usage",
         "state": "get_power_usage",
-        "unit": POWER_WATT,
+        ATTR_UNIT_OF_MEASUREMENT: POWER_WATT,
     },
     "power_8s": {
-        "class": DEVICE_CLASS_POWER,
+        ATTR_DEVICE_CLASS: DEVICE_CLASS_POWER,
         "enabled_default": False,
-        "icon": None,
+        ATTR_ICON: None,
         "name": "Power usage 8 seconds",
         "state": "get_power_usage_8_sec",
-        "unit": POWER_WATT,
+        ATTR_UNIT_OF_MEASUREMENT: POWER_WATT,
     },
     "power_con_cur_hour": {
-        "class": DEVICE_CLASS_POWER,
+        ATTR_DEVICE_CLASS: DEVICE_CLASS_POWER,
         "enabled_default": True,
-        "icon": None,
+        ATTR_ICON: None,
         "name": "Power consumption current hour",
         "state": "get_power_consumption_current_hour",
-        "unit": ENERGY_KILO_WATT_HOUR,
+        ATTR_UNIT_OF_MEASUREMENT: ENERGY_KILO_WATT_HOUR,
     },
     "power_con_prev_hour": {
-        "class": DEVICE_CLASS_POWER,
+        ATTR_DEVICE_CLASS: DEVICE_CLASS_POWER,
         "enabled_default": True,
-        "icon": None,
+        ATTR_ICON: None,
         "name": "Power consumption previous hour",
         "state": "get_power_consumption_prev_hour",
-        "unit": ENERGY_KILO_WATT_HOUR,
+        ATTR_UNIT_OF_MEASUREMENT: ENERGY_KILO_WATT_HOUR,
     },
     TODAY_ENERGY_SENSOR_ID: {
-        "class": DEVICE_CLASS_POWER,
+        ATTR_DEVICE_CLASS: DEVICE_CLASS_POWER,
         "enabled_default": True,
-        "icon": None,
+        ATTR_ICON: None,
         "name": "Power consumption today",
         "state": "get_power_consumption_today",
-        "unit": ENERGY_KILO_WATT_HOUR,
+        ATTR_UNIT_OF_MEASUREMENT: ENERGY_KILO_WATT_HOUR,
     },
     "power_con_yesterday": {
-        "class": DEVICE_CLASS_POWER,
+        ATTR_DEVICE_CLASS: DEVICE_CLASS_POWER,
         "enabled_default": True,
-        "icon": None,
+        ATTR_ICON: None,
         "name": "Power consumption yesterday",
         "state": "get_power_consumption_yesterday",
-        "unit": ENERGY_KILO_WATT_HOUR,
+        ATTR_UNIT_OF_MEASUREMENT: ENERGY_KILO_WATT_HOUR,
     },
     "power_prod_cur_hour": {
-        "class": DEVICE_CLASS_POWER,
+        ATTR_DEVICE_CLASS: DEVICE_CLASS_POWER,
         "enabled_default": False,
-        "icon": None,
+        ATTR_ICON: None,
         "name": "Power production current hour",
         "state": "get_power_production_current_hour",
-        "unit": ENERGY_KILO_WATT_HOUR,
+        ATTR_UNIT_OF_MEASUREMENT: ENERGY_KILO_WATT_HOUR,
     },
     "power_prod_prev_hour": {
-        "class": DEVICE_CLASS_POWER,
+        ATTR_DEVICE_CLASS: DEVICE_CLASS_POWER,
         "enabled_default": False,
-        "icon": None,
+        ATTR_ICON: None,
         "name": "Power production previous hour",
         "state": "get_power_production_previous_hour",
-        "unit": ENERGY_KILO_WATT_HOUR,
+        ATTR_UNIT_OF_MEASUREMENT: ENERGY_KILO_WATT_HOUR,
     },
     "RSSI_in": {
-        "class": DEVICE_CLASS_SIGNAL_STRENGTH,
+        ATTR_DEVICE_CLASS: DEVICE_CLASS_SIGNAL_STRENGTH,
         "enabled_default": False,
-        "icon": None,
+        ATTR_ICON: None,
         "name": "Inbound RSSI",
         "state": "get_in_RSSI",
-        "unit": "dBm",
+        ATTR_UNIT_OF_MEASUREMENT: "dBm",
     },
     "RSSI_out": {
-        "class": DEVICE_CLASS_SIGNAL_STRENGTH,
+        ATTR_DEVICE_CLASS: DEVICE_CLASS_SIGNAL_STRENGTH,
         "enabled_default": False,
-        "icon": None,
+        ATTR_ICON: None,
         "name": "Outbound RSSI",
         "state": "get_out_RSSI",
-        "unit": "dBm",
+        ATTR_UNIT_OF_MEASUREMENT: "dBm",
     },
 }
 BINARY_SENSORS = {
     MOTION_SENSOR_ID: {
-        "class": DEVICE_CLASS_MOTION,
+        ATTR_DEVICE_CLASS: DEVICE_CLASS_MOTION,
         "enabled_default": True,
-        "icon": None,
+        ATTR_ICON: None,
         "name": "Motion",
         "state": "get_motion",
-        "unit": None,
+        ATTR_UNIT_OF_MEASUREMENT: None,
     }
 }
 
 # Switch types
 SWITCHES = {
     "relay": {
-        "class": DEVICE_CLASS_OUTLET,
+        ATTR_DEVICE_CLASS: DEVICE_CLASS_OUTLET,
         "enabled_default": True,
-        "icon": None,
+        ATTR_ICON: None,
         "name": "Relay state",
         "state": "get_relay_state",
         "switch": "set_relay_state",
-        "unit": "state",
+        ATTR_UNIT_OF_MEASUREMENT: "state",
     }
 }
 

--- a/custom_components/plugwise/const.py
+++ b/custom_components/plugwise/const.py
@@ -108,7 +108,7 @@ ZEROCONF_MAP = {
 }
 
 
-def temperature_sensor(name_default="Temperature", enabled_default=True):
+def _temperatureSensor(name_default="Temperature", enabled_default=True):
     """Return standardized dict with temperature description."""
     return {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_TEMPERATURE,
@@ -119,7 +119,7 @@ def temperature_sensor(name_default="Temperature", enabled_default=True):
     }
 
 
-def energy_sensor(
+def _energySensor(
     name_default="Power usage", unit_default=POWER_WATT, enabled_default=True
 ):
     """Return standardized dict with energy description."""
@@ -147,10 +147,10 @@ THERMOSTAT_SENSORS = {
         ATTR_NAME: "Illuminance",
         ATTR_UNIT_OF_MEASUREMENT: UNIT_LUMEN,
     },
-    "outdoor_temperature": temperature_sensor(),
-    "setpoint": temperature_sensor(),
-    "temperature": temperature_sensor(),
-    "temperature_difference": temperature_sensor(),
+    "outdoor_temperature": _temperatureSensor(),
+    "setpoint": _temperatureSensor(),
+    "temperature": _temperatureSensor(),
+    "temperature_difference": _temperatureSensor(),
     "valve_position": {
         ATTR_DEVICE_CLASS: None,
         ATTR_ENABLED_DEFAULT: True,
@@ -161,7 +161,7 @@ THERMOSTAT_SENSORS = {
 }
 
 AUX_DEV_SENSORS = {
-    "intended_boiler_temperature": temperature_sensor(),
+    "intended_boiler_temperature": _temperatureSensor(),
     "modulation_level": {
         ATTR_DEVICE_CLASS: None,
         ATTR_ENABLED_DEFAULT: False,
@@ -169,7 +169,7 @@ AUX_DEV_SENSORS = {
         ATTR_NAME: "Heater Modulation Level",
         ATTR_UNIT_OF_MEASUREMENT: PERCENTAGE,
     },
-    "return_temperature": temperature_sensor(False),
+    "return_temperature": _temperatureSensor(False),
     "water_pressure": {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_PRESSURE,
         ATTR_ENABLED_DEFAULT: True,
@@ -177,48 +177,48 @@ AUX_DEV_SENSORS = {
         ATTR_NAME: "Pressure",
         ATTR_UNIT_OF_MEASUREMENT: PRESSURE_BAR,
     },
-    "water_temperature": temperature_sensor(),
+    "water_temperature": _temperatureSensor(),
 }
 
 ENERGY_SENSORS = {
-    "electricity_consumed": energy_sensor("Current Consumed Power"),
-    "electricity_produced": energy_sensor("Current Produced Power"),
-    "electricity_consumed_interval": energy_sensor(
+    "electricity_consumed": _energySensor("Current Consumed Power"),
+    "electricity_produced": _energySensor("Current Produced Power"),
+    "electricity_consumed_interval": _energySensor(
         "Consumed Power Interval", ENERGY_WATT_HOUR
     ),
-    "electricity_consumed_peak_interval": energy_sensor(
+    "electricity_consumed_peak_interval": _energySensor(
         "Consumed Power Interval", ENERGY_WATT_HOUR
     ),
-    "electricity_consumed_off_peak_interval": energy_sensor(
+    "electricity_consumed_off_peak_interval": _energySensor(
         "Consumed Power Interval (off peak)", ENERGY_WATT_HOUR
     ),
-    "electricity_produced_interval": energy_sensor(
+    "electricity_produced_interval": _energySensor(
         "Produced Power Interval", ENERGY_WATT_HOUR
     ),
-    "electricity_produced_peak_interval": energy_sensor(
+    "electricity_produced_peak_interval": _energySensor(
         "Produced Power Interval", ENERGY_WATT_HOUR
     ),
-    "electricity_produced_off_peak_interval": energy_sensor(
+    "electricity_produced_off_peak_interval": _energySensor(
         "Produced Power Interval (off peak)", ENERGY_WATT_HOUR
     ),
-    "electricity_consumed_off_peak_point": energy_sensor(
+    "electricity_consumed_off_peak_point": _energySensor(
         "Current Consumed Power (off peak)"
     ),
-    "electricity_consumed_peak_point": energy_sensor("Current Consumed Power"),
-    "electricity_consumed_off_peak_cumulative": energy_sensor(
+    "electricity_consumed_peak_point": _energySensor("Current Consumed Power"),
+    "electricity_consumed_off_peak_cumulative": _energySensor(
         "Cumulative Consumed Power (off peak)", ENERGY_KILO_WATT_HOUR
     ),
-    "electricity_consumed_peak_cumulative": energy_sensor(
+    "electricity_consumed_peak_cumulative": _energySensor(
         "Cumulative Consumed Power", ENERGY_KILO_WATT_HOUR
     ),
-    "electricity_produced_off_peak_point": energy_sensor(
+    "electricity_produced_off_peak_point": _energySensor(
         "Current Consumed Power (off peak)"
     ),
-    "electricity_produced_peak_point": energy_sensor("Current Consumed Power"),
-    "electricity_produced_off_peak_cumulative": energy_sensor(
+    "electricity_produced_peak_point": _energySensor("Current Consumed Power"),
+    "electricity_produced_off_peak_cumulative": _energySensor(
         "Cumulative Consumed Power (off peak)", ENERGY_KILO_WATT_HOUR
     ),
-    "electricity_produced_peak_cumulative": energy_sensor(
+    "electricity_produced_peak_cumulative": _energySensor(
         "Cumulative Consumed Power", ENERGY_KILO_WATT_HOUR
     ),
     "gas_consumed_interval": {
@@ -235,8 +235,8 @@ ENERGY_SENSORS = {
         ATTR_NAME: "CUmulative Consumed Gas",
         ATTR_UNIT_OF_MEASUREMENT: VOLUME_CUBIC_METERS,
     },
-    "net_electricity_point": energy_sensor("Current net Power"),
-    "net_electricity_cumulative": energy_sensor(
+    "net_electricity_point": _energySensor("Current net Power"),
+    "net_electricity_cumulative": _energySensor(
         "Current net Power", ENERGY_KILO_WATT_HOUR
     ),
 }

--- a/custom_components/plugwise/gateway.py
+++ b/custom_components/plugwise/gateway.py
@@ -102,7 +102,7 @@ async def async_setup_entry_gw(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         """Update data via API endpoint."""
         _LOGGER.debug("Updating Smile %s", api.smile_name)
         try:
-            async with async_timeout.timeout(60):
+            async with async_timeout.timeout(update_interval.seconds):
                 await api.full_update_device()
                 _LOGGER.debug("Succesfully updated Smile %s", api.smile_name)
                 return True
@@ -229,19 +229,25 @@ class SmileGateway(CoordinatorEntity):
         """Initialise the gateway."""
         super().__init__(coordinator)
 
+        self._coordinator = coordinator
+
         self._api = api
-        self._name = name
         self._dev_id = dev_id
-
-        self._unique_id = None
-        self._model = None
-
         self._entity_name = self._name
+        self._model = None
+        self._name = name
+        self._unique_id = None
+
 
     @property
     def unique_id(self):
         """Return a unique ID."""
         return self._unique_id
+
+    @property
+     def available(self):
+         """Return True if entity is available."""
+         return self.coordinator.last_update_success
 
     @property
     def name(self):

--- a/custom_components/plugwise/gateway.py
+++ b/custom_components/plugwise/gateway.py
@@ -225,13 +225,14 @@ async def _update_listener(hass: HomeAssistant, entry: ConfigEntry):
 class SmileGateway(CoordinatorEntity):
     """Represent Smile Gateway."""
 
-    def __init__(self, api, coordinator, name, dev_id):
+    def __init__(self, api, coordinator, name, dev_id, enabled_default: bool = True):
         """Initialise the gateway."""
         super().__init__(coordinator)
 
         self._api = api
         self._name = name
         self._dev_id = dev_id
+        self._enabled_default = enabled_default
 
         self._unique_id = None
         self._model = None
@@ -242,6 +243,11 @@ class SmileGateway(CoordinatorEntity):
     def unique_id(self):
         """Return a unique ID."""
         return self._unique_id
+
+    @property
+    def entity_registry_enabled_default(self) -> bool:
+        """Return if the entity should be enabled when first added to the entity registry."""
+        return self._enabled_default
 
     @property
     def name(self):

--- a/custom_components/plugwise/gateway.py
+++ b/custom_components/plugwise/gateway.py
@@ -238,7 +238,6 @@ class SmileGateway(CoordinatorEntity):
         self._model = None
         self._unique_id = None
 
-
     @property
     def unique_id(self):
         """Return a unique ID."""

--- a/custom_components/plugwise/gateway.py
+++ b/custom_components/plugwise/gateway.py
@@ -245,9 +245,9 @@ class SmileGateway(CoordinatorEntity):
         return self._unique_id
 
     @property
-     def available(self):
-         """Return True if entity is available."""
-         return self.coordinator.last_update_success
+    def available(self):
+        """Return True if entity is available."""
+        return self.coordinator.last_update_success
 
     @property
     def name(self):

--- a/custom_components/plugwise/gateway.py
+++ b/custom_components/plugwise/gateway.py
@@ -230,12 +230,12 @@ class SmileGateway(CoordinatorEntity):
         super().__init__(coordinator)
 
         self._coordinator = coordinator
+        self._name = name
 
         self._api = api
         self._dev_id = dev_id
         self._entity_name = self._name
         self._model = None
-        self._name = name
         self._unique_id = None
 
 

--- a/custom_components/plugwise/gateway.py
+++ b/custom_components/plugwise/gateway.py
@@ -225,14 +225,13 @@ async def _update_listener(hass: HomeAssistant, entry: ConfigEntry):
 class SmileGateway(CoordinatorEntity):
     """Represent Smile Gateway."""
 
-    def __init__(self, api, coordinator, name, dev_id, enabled_default: bool = True):
+    def __init__(self, api, coordinator, name, dev_id):
         """Initialise the gateway."""
         super().__init__(coordinator)
 
         self._api = api
         self._name = name
         self._dev_id = dev_id
-        self._enabled_default = enabled_default
 
         self._unique_id = None
         self._model = None
@@ -243,11 +242,6 @@ class SmileGateway(CoordinatorEntity):
     def unique_id(self):
         """Return a unique ID."""
         return self._unique_id
-
-    @property
-    def entity_registry_enabled_default(self) -> bool:
-        """Return if the entity should be enabled when first added to the entity registry."""
-        return self._enabled_default
 
     @property
     def name(self):

--- a/custom_components/plugwise/manifest.json
+++ b/custom_components/plugwise/manifest.json
@@ -2,7 +2,7 @@
   "domain": "plugwise",
   "name": "Plugwise Beta",
   "documentation": "https://github.com/plugwise/plugwise-beta",
-  "requirements": ["Plugwise_Smile==1.6.0","python-plugwise==2.0.2"],
+  "requirements": ["plugwise==0.8.0"],
   "codeowners": ["@CoMPaTech","@bouwew","@brefra"],
   "config_flow": true
 }

--- a/custom_components/plugwise/sensor.py
+++ b/custom_components/plugwise/sensor.py
@@ -231,7 +231,7 @@ class GwThermostatSensor(SmileSensor, Entity):
         self._unit_of_measurement = sensor_type[ATTR_UNIT_OF_MEASUREMENT]
         self._dev_class = sensor_type[ATTR_DEVICE_CLASS]
         if not self._dev_class:
-            self._icon = sensor__type[ATTR_ICON]
+            self._icon = sensor_type[ATTR_ICON]
 
     @callback
     def _async_process_data(self):

--- a/custom_components/plugwise/sensor.py
+++ b/custom_components/plugwise/sensor.py
@@ -160,7 +160,7 @@ async def async_setup_entry_gateway(hass, config_entry, async_add_entities):
 class SmileSensor(SmileGateway):
     """Represent Smile Sensors."""
 
-    def __init__(self, api, coordinator, name, dev_id, sensor, enabled_default):
+    def __init__(self, api, coordinator, name, dev_id, enabled_default, sensor):
         """Initialise the sensor."""
         super().__init__(api, coordinator, name, dev_id, enabled_default)
 

--- a/custom_components/plugwise/sensor.py
+++ b/custom_components/plugwise/sensor.py
@@ -210,7 +210,7 @@ class GwThermostatSensor(SmileSensor, Entity):
         """Set up the Plugwise API."""
         _LOGGER.error("HOI sensor %s", sensor)
         _LOGGER.error("HOI type   %s", sensor_type)
-        self._enabled_default = True
+        self._enabled_default = sensor_type["enabled_default"]
 
         super().__init__(api, coordinator, name, dev_id, self._enabled_default, sensor)
 

--- a/custom_components/plugwise/sensor.py
+++ b/custom_components/plugwise/sensor.py
@@ -304,7 +304,7 @@ class GwPowerSensor(SmileSensor, Entity):
         self._unit_of_measurement = sensor_type[ATTR_UNIT_OF_MEASUREMENT]
         self._dev_class = sensor_type[ATTR_DEVICE_CLASS]
         if not self._dev_class:
-            self._icon = sensor__type[ATTR_ICON]
+            self._icon = sensor_type[ATTR_ICON]
 
         if dev_id == self._api.gateway_id:
             self._model = "P1 DSMR"

--- a/custom_components/plugwise/sensor.py
+++ b/custom_components/plugwise/sensor.py
@@ -32,6 +32,8 @@ from .const import (
     USB,
 )
 
+PARALLEL_UPDATES = 0
+
 _LOGGER = logging.getLogger(__name__)
 
 

--- a/custom_components/plugwise/sensor.py
+++ b/custom_components/plugwise/sensor.py
@@ -161,13 +161,14 @@ class SmileSensor(SmileGateway):
 
     def __init__(self, api, coordinator, name, dev_id, enabled_default, sensor):
         """Initialise the sensor."""
-        super().__init__(api, coordinator, name, dev_id, enabled_default)
+        super().__init__(api, coordinator, name, dev_id)
 
         self._sensor = sensor
 
         self._dev_class = None
-        self._state = None
+        self._enabled_default = enabled_default
         self._icon = None
+        self._state = None
         self._unit_of_measurement = None
 
         if dev_id == self._api.heater_id:
@@ -185,6 +186,12 @@ class SmileSensor(SmileGateway):
     def device_class(self):
         """Return the device class of this entity, if any."""
         return self._dev_class
+
+    @property
+    def entity_registry_enabled_default(self) -> bool:
+        """Return if the entity should be enabled when first added to the entity registry."""
+        return self._enabled_default
+
 
     @property
     def icon(self):

--- a/custom_components/plugwise/sensor.py
+++ b/custom_components/plugwise/sensor.py
@@ -116,7 +116,6 @@ async def async_setup_entry_gateway(hass, config_entry, async_add_entities):
                     dev_id,
                     sensor,
                     sensor_type,
-                    THERMOSTAT_SENSORS,
                 )
             )
             _LOGGER.info("Added sensor.%s", device_properties["name"])

--- a/custom_components/plugwise/sensor.py
+++ b/custom_components/plugwise/sensor.py
@@ -156,7 +156,7 @@ async def async_setup_entry_gateway(hass, config_entry, async_add_entities):
 class SmileSensor(SmileGateway):
     """Represent Smile Sensors."""
 
-    def __init__(self, api, coordinator, name, dev_id, sensor):
+    def __init__(self, api, coordinator, name, dev_id, sensor, enabled_default):
         """Initialise the sensor."""
         super().__init__(api, coordinator, name, dev_id, enabled_default)
 

--- a/custom_components/plugwise/sensor.py
+++ b/custom_components/plugwise/sensor.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from homeassistant.const import ENERGY_KILO_WATT_HOUR, PERCENTAGE
+from homeassistant.const import ENERGY_KILO_WATT_HOUR, PERCENTAGE, ATTR_UNIT_OF_MEASUREMENT, ATTR_DEVICE_CLASS, ATTR_ICON
 from homeassistant.components.climate.const import (
     CURRENT_HVAC_COOL,
     CURRENT_HVAC_HEAT,
@@ -20,15 +20,12 @@ from .const import (
     CB_NEW_NODE,
     COOL_ICON,
     COORDINATOR,
-    CUSTOM_ICONS,
     DEVICE_STATE,
     DOMAIN,
     ENERGY_SENSORS,
     FLAME_ICON,
     IDLE_ICON,
     PW_TYPE,
-    SENSORS_DEVICE_CLASS,
-    SENSORS_UOM,
     SENSORS,
     STICK,
     THERMOSTAT_SENSORS,
@@ -213,10 +210,11 @@ class GwThermostatSensor(SmileSensor, Entity):
 
         super().__init__(api, coordinator, name, dev_id, self._enabled_default, sensor)
 
-        self._icon = None
         self._model = sensor
-        self._unit_of_measurement = sensor_type[SENSORS_UOM]
-        self._dev_class = sensor_type[SENSORS_DEVICE_CLASS]
+        self._unit_of_measurement = sensor_type[ATTR_UNIT_OF_MEASUREMENT]
+        self._dev_class = sensor_type[ATTR_DEVICE_CLASS]
+        if not self._dev_class:
+            self._icon = sensor__type[ATTR_ICON]
 
     @callback
     def _async_process_data(self):
@@ -232,7 +230,6 @@ class GwThermostatSensor(SmileSensor, Entity):
         if self._unit_of_measurement == PERCENTAGE:
             measurement = int(measurement * 100)
         self._state = measurement
-        self._icon = CUSTOM_ICONS.get(self._sensor, self._icon)
 
         self.async_write_ha_state()
 
@@ -287,8 +284,10 @@ class GwPowerSensor(SmileSensor, Entity):
         if model is None:
             self._model = sensor
 
-        self._unit_of_measurement = sensor_type[SENSORS_UOM]
-        self._dev_class = sensor_type[SENSORS_DEVICE_CLASS]
+        self._unit_of_measurement = sensor_type[ATTR_UNIT_OF_MEASUREMENT]
+        self._dev_class = sensor_type[ATTR_DEVICE_CLASS]
+        if not self._dev_class:
+            self._icon = sensor__type[ATTR_ICON]
 
         if dev_id == self._api.gateway_id:
             self._model = "P1 DSMR"
@@ -307,7 +306,6 @@ class GwPowerSensor(SmileSensor, Entity):
         if self._unit_of_measurement == ENERGY_KILO_WATT_HOUR:
             measurement = round((measurement / 1000), 1)
         self._state = measurement
-        self._icon = CUSTOM_ICONS.get(self._sensor, self._icon)
 
         self.async_write_ha_state()
 

--- a/custom_components/plugwise/sensor.py
+++ b/custom_components/plugwise/sensor.py
@@ -2,7 +2,13 @@
 
 import logging
 
-from homeassistant.const import ENERGY_KILO_WATT_HOUR, PERCENTAGE, ATTR_UNIT_OF_MEASUREMENT, ATTR_DEVICE_CLASS, ATTR_ICON
+from homeassistant.const import (
+    ENERGY_KILO_WATT_HOUR,
+    PERCENTAGE,
+    ATTR_UNIT_OF_MEASUREMENT,
+    ATTR_DEVICE_CLASS,
+    ATTR_ICON,
+)
 from homeassistant.components.climate.const import (
     CURRENT_HVAC_COOL,
     CURRENT_HVAC_HEAT,
@@ -193,7 +199,6 @@ class SmileSensor(SmileGateway):
     def entity_registry_enabled_default(self) -> bool:
         """Return if the entity should be enabled when first added to the entity registry."""
         return self._enabled_default
-
 
     @property
     def icon(self):

--- a/custom_components/plugwise/sensor.py
+++ b/custom_components/plugwise/sensor.py
@@ -106,6 +106,8 @@ async def async_setup_entry_gateway(hass, config_entry, async_add_entities):
             if data.get(sensor) is None:
                 continue
 
+            _LOGGER.error("HOI sensor %s", sensor)
+            _LOGGER.error("HOI type   %s", sensor_type)
             entities.append(
                 GwThermostatSensor(
                     api,
@@ -123,6 +125,8 @@ async def async_setup_entry_gateway(hass, config_entry, async_add_entities):
             if data.get(sensor) is None or not api.active_device_present:
                 continue
 
+            _LOGGER.error("HOI sensor %s", sensor)
+            _LOGGER.error("HOI type   %s", sensor_type)
             entities.append(
                 GwThermostatSensor(
                     api,

--- a/custom_components/plugwise/sensor.py
+++ b/custom_components/plugwise/sensor.py
@@ -223,7 +223,7 @@ class GwThermostatSensor(SmileSensor, Entity):
         """Set up the Plugwise API."""
         _LOGGER.error("HOI sensor %s", sensor)
         _LOGGER.error("HOI type   %s", sensor_type)
-        self._enabled_default = sensor_type["enabled_default"]
+        self._enabled_default = sensor_type[ATTR_ENABLED_DEFAULT]
 
         super().__init__(api, coordinator, name, dev_id, self._enabled_default, sensor)
 

--- a/custom_components/plugwise/switch.py
+++ b/custom_components/plugwise/switch.py
@@ -97,7 +97,9 @@ class GwSwitch(SmileGateway, SwitchEntity):
 
     def __init__(self, api, coordinator, name, dev_id, members, model):
         """Set up the Plugwise API."""
-        super().__init__(api, coordinator, name, dev_id)
+        self._enabled_default = True
+
+        super().__init__(api, coordinator, name, dev_id, self._enabled_default)
 
         self._members = members
         self._model = model

--- a/custom_components/plugwise/switch.py
+++ b/custom_components/plugwise/switch.py
@@ -12,6 +12,7 @@ from .gateway import SmileGateway
 from .usb import NodeEntity
 from .const import (
     API,
+    ATTR_ENABLED_DEFAULT,
     AVAILABLE_SENSOR_ID,
     CB_NEW_NODE,
     COORDINATOR,
@@ -197,7 +198,7 @@ class USBSwitch(NodeEntity, SwitchEntity):
     @property
     def entity_registry_enabled_default(self):
         """Return the switch registration state."""
-        return self.switch_type["enabled_default"]
+        return self.switch_type[ATTR_ENABLED_DEFAULT]
 
     @property
     def icon(self):

--- a/custom_components/plugwise/switch.py
+++ b/custom_components/plugwise/switch.py
@@ -80,12 +80,7 @@ async def async_setup_entry_gateway(hass, config_entry, async_add_entities):
             _LOGGER.debug("Plugwise switch Dev %s", device_properties["name"])
             entities.append(
                 GwSwitch(
-                    api,
-                    coordinator,
-                    device_properties["name"],
-                    dev_id,
-                    members,
-                    model,
+                    api, coordinator, device_properties["name"], dev_id, members, model,
                 )
             )
             _LOGGER.info("Added switch.%s", "{}".format(device_properties["name"]))


### PR DESCRIPTION
Including #129 as requested by @bouwew 

# Changes

- Availability (as per #129) handling
- Introduce `ATTR_ENABLED_DEFAULT` and included on the Entity classes
- Rewrite gateway sensoric maps to dictionaries as with stick - superceeding introduced `CUSTOM_ICONS`
- Handle icon only if no DEVICE_CLASS is set (as per Core decision)
- Set `PARALLEL_UPDATES` on `sensor` and `binary_sensor` as first included platforms
- Import more ATTR consts from core

# Checklist:

**Silver**

- [x] Connection/configuration is handled via a component.
- Yes, using the 'hub' approach and DataUpdateCoordinator to talk to our module
- [x] Set an appropriate SCAN_INTERVAL (if a polling integration)
- Yes, dependent on type of hub (e.g. climate devices every minute, DSMR every 10 seconds)
- [x] Raise PlatformNotReady if unable to connect during platform setup (if appropriate)
- Yes, handled appropriately
- [ ] Handles expiration of auth credentials. Refresh if possible or print correct error and fail setup. If based on a config entry, should trigger a new config entry flow to re-authorize.
- n/a there is a static password printed on the back of the devices
- [ ] Handles internet unavailable. Log a warning once when unavailable, log once when reconnected.
- n/a local devices
- [x] Handles device/service unavailable. Log a warning once when unavailable, log once when reconnected.
- Per 'hub' using DataUpdateCoordinator
- [x] Set available property to False if appropriate
- Per 'hub' using DataUpdateCoordinator with UpdateFailed
- [x] Entities have unique ID (if available)
- IDs are based on the unique ID of the 'hub' (i.e. Smile) and the unique id's in the API data, where appropriate a descriptive string has been added.

**Gold**

- [x] Configurable via config entries.
- Yes, implemented accordingly
- [x] Don't allow configuring already configured device/service (example: no 2 entries for same hub)
- Checking the unique_ids
- [x] Tests for the config flow
- Covered fully as per requirement for PRs nowadays
- [x] Discoverable (if available)
- Yes, implemented accordingly
- [x] Set unique ID in config flow (if available)
- Yes, implemented accordingly
- [x] Entities have device info (if available)
- Yes, implemented accordingly
- [x] Tests for fetching data from the integration and controlling it
- Yes, using (selected) fixtures generated from actual data also used for testing our module
- [x] Has a code owner
- @bouwew and @CoMPaTech (and soon including @brefra)
- [x] Entities only subscribe to updates inside async_added_to_hass and unsubscribe inside async_will_remove_from_hass
- Yes, implemented accordingly
- [x] Entities have correct device classes where appropriate
- Yes, where available
- [x] Supports entities being disabled and leverages Entity.entity_registry_enabled_default to disable less popular entities
- We already limit the amount of entities being created using the dicts in the consts. We have implemented the `enabled_default` structure into the dicts on const to allow for this!
- Plugwise actually has lots more available not deemed neccesary by our testing-community nor recent HA-core issue requests.
- [ ] If the device/service API can remove entities, the integration should make sure to clean up the entity and device registry.
- Our module does not support removal of entities therefor no service has been implemented in the integration yet

**Platinum**

- [x] Set appropriate PARALLEL_UPDATES constant
- Included in `binary_sensor` and `sensor` as these are the first platforms loaded through our platforms_list
- [x] Support config entry unloading (called when config entry is removed)
- Yes, implemented accordingly
- [x] Integration + dependency are async
- Yes, implemented accordingly
- [x] Uses aiohttp and allows passing in websession (if making HTTP requests)
- Yes, implemented accordingly