### PR TITLE
Update to new API stick 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-** Read the release notes (https://github.com/plugwise/plugwise-beta/releases) before upgrading, in case there are BREAKING changes! **
+** Read the release notes (<https://github.com/plugwise/plugwise-beta/releases>) before upgrading, in case there are BREAKING changes! **
 
 # Plugwise Smile custom_component (BETA)
 
@@ -15,12 +15,14 @@ A fully asynchronous approach to supporting Plugwise devices. This repository is
 ## NEW Oct 2020 ##
 The developer of the Plugwise Stick integration, @brefra, has joined the team. As a result we have added support for the Plugwise Stick.
 
-## Sept 2020 ##
+## Sept 2020
+
 - Add a service: plugwise.delete_notification, this allows you to dismiss a Plugwise Notification from HA Core.
 - Support for switching groups created on the Plugwise App has been added, these are available on the Adam with Plugs and on the Stretch.
 - Support for the Plugwise Stretch v2 and v3 has been added.
 
-## Aug 2020 ##
+## Aug 2020
+
 This custom_component can be installed to replace the HA Core Plugwise component. It can NO LONGER be installed next to the HA Core Plugwise component.
 Due to this it behaves exactly as the HA Core Plugwise component: discovery works. But this beta-version has extra features and improvements!
 
@@ -35,61 +37,59 @@ PLEASE NOTE: ~~at the moment you will need to remove the existing Core Plugwise 
 
 ## What do we support (in short)?
 
-  - Thermostats
-    - Adam (firmware 2.x and 3.x) and the accompanying Lisa's, Tom's, Floor's, Koen's and Plugs.
-    - Anna (firmware 1.x, 3.x and 4.x)
-    - Notifications for both types
-  - Power-related
-    - Smile P1 (firmware 2.x, 3.x and 4.x)
-    - Stretch (firmware 2.x and 3.x, legacy Circle's and Stealth's)
-    - Stick (legacy Circle's, Stealth's and Scan's)
+- Thermostats
+  - Adam (firmware 2.x and 3.x) and the accompanying Lisa's, Tom's, Floor's, Koen's and Plugs.
+  - Anna (firmware 1.x, 3.x and 4.x)
+  - Notifications for both types
+- Power-related
+  - Smile P1 (firmware 2.x, 3.x and 4.x)
+  - Stretch (firmware 2.x and 3.x, legacy Circle's and Stealth's)
+  - Stick (legacy Circle's, Stealth's and Scan's)
 
 ## What can I expect in HA Core from this component
 
-  - `climate`: A (number of) thermostat(s) visible in HA, including temperature, presets and heating-demand status, per thermostat. Also, setting of temperature, preset and switching the active schedule on and off. Cooling is only supported in combination with an Anna (fw 3.1 and 4.0).
-  - `sensor` and `binary_sensor`: A number of sensoric values depending on your hardware: outdoor temperature, Anna's illuminance, Tom's valve postion, Plug's and Circle/Stealth's power-values, P1 power- and gas-values, Plugwise Notifications.
-  - `switch`: The switch-parts of Plugs/Circles are available as switches, also switching them on/off is supported.
+- `climate`: A (number of) thermostat(s) visible in HA, including temperature, presets and heating-demand status, per thermostat. Also, setting of temperature, preset and switching the active schedule on and off. Cooling is only supported in combination with an Anna (fw 3.1 and 4.0).
+- `sensor` and `binary_sensor`: A number of sensoric values depending on your hardware: outdoor temperature, Anna's illuminance, Tom's valve postion, Plug's and Circle/Stealth's power-values, P1 power- and gas-values, Plugwise Notifications.
+- `switch`: The switch-parts of Plugs/Circles are available as switches, also switching them on/off is supported.
 
 The `water_heater`-device present in previous releases has been replaced by an Auxiliary Device state-sensor. This sensor will only show up when there are more (than one) thermostats present in your climate-system.
 
 ## How to install?
 
- - Use [HACS](https://hacs.xyz) 
- - Use the link to this page and add it on the `custom repo` page .
- - Look for `Plugwise beta custom component ` in `integrations` and install it!
+- Use [HACS](https://hacs.xyz)
+- Use the link to this page and add it on the `custom repo` page .
+- Look for `Plugwise beta custom component` in `integrations` and install it!
 
 ## How to add the integration to HA Core
 
 For each Plugwise Smile (i.e. gateway) you will have to add it as an integration. For instance if you have an Adam and a Smile P1, you have to add them individually. If you have an Anna and an Adam, **do not add the Anna**, only add the Adam.
 
- - [ ] In Home Assitant click on `Configuration`
- - [ ] Click on `Integrations`
- - [ ] You should see one or more discovered Smiles
- - [ ] Click the `Configure` button and enter the Smile ID
- - [ ] Click Add to see the magic happens
- 
- If there is no discovered Smile present or you are using the USB stick:
+- [ ] In Home Assitant click on `Configuration`
+- [ ] Click on `Integrations`
+- [ ] You should see one or more discovered Smiles
+- [ ] Click the `Configure` button and enter the Smile ID
+- [ ] Click Add to see the magic happens
 
- - [ ] Hit the `+` button in the right lower corner
- - [ ] Search or browse for 'Plugwise beta' and click it
- - [ ] Select the type of integration: Network or USB
+If there is no discovered Smile present or you are using the USB stick:
 
- - For the Network-selection:
+- [ ] Hit the `+` button in the right lower corner
+- [ ] Search or browse for 'Plugwise beta' and click it
+- [ ] Select the type of integration: Network or USB
 
-   - [ ] Enter your Smile IP-address and the 8 character ID of the smile
-   - [ ] Click SUBMIT and FINISH and hopefully the magic happens
-   - [ ] Repeat this process to add more Smiles
+- For the Network-selection:
+- [ ] Enter your Smile IP-address and the 8 character ID of the smile
+- [ ] Click SUBMIT and FINISH and hopefully the magic happens
+- [ ] Repeat this process to add more Smiles
 
- - For the USB-selection:
-
-   - [ ] Select or enter the USB-path
-   - [ ] Click SUBMIT and FINISH
+- For the USB-selection:
+- [ ] Select or enter the USB-path
+- [ ] Click SUBMIT and FINISH
 
 The config flow will then continue to ask you if you want to put your Smile and detected other devices in area's and presto, things should be available to configure in lovelace.
 
-## Options ##
+## Options
 
-Using the OPTIONS-button, the default Smile-data refresh-interval can be modified. There are no OPTIONS available for the Stick.
+Using the OPTIONS-button, the default Smile-data refresh-interval can be modified. There are no OPTIONS available for the Stick. The refresh interval of the devices connected to the Stick is automatically determined on the number of devices connecteda
 
 # I don't like the name of the sensor or the icon
 
@@ -101,11 +101,10 @@ Please note that you can also click the cogwheel right top corner to rename all 
 
 # It doesn't work
 
-If you notice issuess, we are on Discord and on the (Community forums)[https://community.home-assistant.io/t/plugwise-smile-custom-component-beta/183560]. You can also create an Issue in these repos:
+If you notice issues, we are on Discord and on the [Community forums](https://community.home-assistant.io/t/plugwise-core-and-custom-component/236250). You can also create an Issue in these repositories:
 
-  - [plugwise-beta](https://github.com/plugwise/plugwise-beta) - the `custom_component` for HA Core
-  - [Plugwise-Smile](https://github.com/plugwise/Plugwise-Smile) - the python module interfacing between the plugwise component and your Smile
-  - [python-plugwise](https://github.com/plugwise/python-plugwise) - the python module interfacing with the plugwise USB-stick
+- [plugwise-beta](https://github.com/plugwise/plugwise-beta) - the `custom_component` for HA Core
+- [python-plugwise](https://github.com/plugwise/python-plugwise) - the python module interfacing with the plugwise Smile or USB-stick
 
 # Smile?
 
@@ -113,19 +112,21 @@ We use the term Smile for the 'device connected to your home network', called Sm
 
 # Testing
 
-While we try to make sure that everyting works as intended, we can't really test out changes happening to hardware devices. Our testing is done through testing against files from community members (see [Plugwise-Smile tests](https://github.com/plugwise/Plugwise-Smile/tree/master/tests)) and if you have a setup you are willing to share we highly welcome that. Just send us the files or submit a PR. Including your testcode into the `tests/test_Smile.py` code is highly recommended.
+While we try to make sure that everything works as intended, we can't really test out changes happening to hardware devices. Our testing is done through testing against files from community members (see [python-plugwise tests](https://github.com/plugwise/python-plugwise/tree/main/tests)) and if you have a setup you are willing to share we highly welcome that. Just send us the files or submit a PR. Including your test code into the `tests/test_Smile.py` code is highly recommended.
 
-Results of our tests are checked by Travis, click the left button (the one that should say 'Build passing' :)) on the [Plugwise-Smile repository](https://github.com/plugwise/Plugwise-Smile/).
+Results of our tests are checked by Travis, click the left button (the one that should say 'Build passing' :)) on the [python-plugwise repository](https://github.com/plugwise/python-plugwise/).
 
-# ~~There is Anna support in HA Core already~~ Replaced by the new Plugwise component, based on this beta-version.
+# ~~There is Anna support in HA Core already~~ Replaced by the new Plugwise component, based on this beta-version
 
 From the original sources by @laetificat it was improved upon and upstreamed by @CoMPaTech. Right after that @bouwew joined to improve and help maintain the code. As of 2020 @brefra joined so we have a full range of Plugwise products supported.
 
 As things like async were in high demand from HA Core, desired by the original author and a great challenge for us we rewrote it largely. The Plugwise Smile Beta repository (accompanying the Plugwise-Smile python module) is intended for development purposes, just as `anna-ha` was for `haanna` (respectively the original before upstreaming and original python module).
 
 With the three combined forces we now support, maintain and improve on:
- - `plugwise-beta` (this repository) for beta-testing new features to go into the `plugwise`-integration for HA
- - `Plugwise-Smile` for connectivity with the Smile (Adam, Anna and P1) and Stretch products (i.e. the new Plugs)
- - `python-plugwise` for connectivity with the Stick (USB-device) (i.e. the old Plugs: Circle(+), Stealths and Scans)
+
+- `plugwise-beta` (this repository) for beta-testing new features to go into the `plugwise`-integration for HA
+- `python-plugwise` for connectivity with
+  - Smile (Adam, Anna and P1) and Stretch products (i.e. the new Plugs)
+  - Stick (USB-device) (i.e. the old Plugs: Circle(+), Stealths and Scans)
 
 And yes anna-ha with haanna (to some degree) support Anna v1.8 - but they don't support Adam nor the Smile P1

--- a/README.md
+++ b/README.md
@@ -12,7 +12,21 @@ Our main usage for this module is supporting [Home Assistant](https://www.home-a
 
 A fully asynchronous approach to supporting Plugwise devices. This repository is **meant** for use of beta-testing.
 
-## NEW Oct 2020 ##
+## NEW Jan 2021 [0.14.0]
+
+- USB-Stick
+  - New: Automatically accepting of joining request of new Plugwise devices if the `Enable newly added entries` system option is turned on (default). A notification will be popup after a new devices is joined.
+  - Improved: For quicker response switch (relay) requests are handled with priority
+  - Improved: Dynamically set the refresh interval based on the actual discovered devices with power measurement capabilities
+  - Improved: Response messages received from Plugwise devices are now validated to their checksums.
+  - Improved: Using the `device_remove` services will remove the devices from the device registry too.
+  - Improved: Better handling of timeout issues and reduced communication messages.
+  - Improved: Corrected log level assignments (debug, info, warning, errors)
+  - Fixed: Missing power history values during last week of the month.
+  - Fixed: Prevent a few rarely occurring communication failures.
+
+## Oct 2020 [0.13.1]
+
 The developer of the Plugwise Stick integration, @brefra, has joined the team. As a result we have added support for the Plugwise Stick.
 
 ## Sept 2020

--- a/custom_components/plugwise/binary_sensor.py
+++ b/custom_components/plugwise/binary_sensor.py
@@ -66,7 +66,6 @@ async def async_setup_entry_usb(hass, config_entry, async_add_entities):
     api_stick = hass.data[DOMAIN][config_entry.entry_id][STICK]
     platform = entity_platform.current_platform.get()
 
-    async def async_add_sensor(mac):
         """Add plugwise sensor."""
         _LOGGER.debug("Add binary_sensors for %s", mac)
 
@@ -109,13 +108,14 @@ async def async_setup_entry_usb(hass, config_entry, async_add_entities):
                         },
                         "_service_configure_battery_savings",
                     )
+    async def async_add_binary_sensor(mac):
 
     for mac in hass.data[DOMAIN][config_entry.entry_id]["binary_sensor"]:
-        hass.async_create_task(async_add_sensor(mac))
+        hass.async_create_task(async_add_binary_sensor(mac))
 
     def discoved_binary_sensor(mac):
         """Add newly discovered binary sensor."""
-        hass.async_create_task(async_add_sensor(mac))
+        hass.async_create_task(async_add_binary_sensor(mac))
 
     # Listen for discovered nodes
     api_stick.subscribe_stick_callback(discoved_binary_sensor, CB_NEW_NODE)

--- a/custom_components/plugwise/binary_sensor.py
+++ b/custom_components/plugwise/binary_sensor.py
@@ -71,12 +71,12 @@ async def async_setup_entry_usb(hass, config_entry, async_add_entities):
         _LOGGER.debug("Add binary_sensors for %s", mac)
 
         node = stick.node(mac)
-        for sensor_type in node.get_sensors():
+        for sensor_type in node.sensors:
             if sensor_type in USB_BINARY_SENSORS:
                 async_add_entities([USBBinarySensor(node, mac, sensor_type)])
                 _LOGGER.debug("Added %s as binary_sensor", sensor_type)
 
-                if node.get_node_type() == "Scan" and sensor_type == MOTION_SENSOR_ID:
+                if node.hardware_model == "Scan" and sensor_type == MOTION_SENSOR_ID:
                     platform.async_register_entity_service(
                         SERVICE_CONFIGURE_SCAN,
                         {
@@ -333,7 +333,7 @@ class USBBinarySensor(NodeEntity, BinarySensorEntity):
     @property
     def is_on(self):
         """Return true if the binary_sensor is on."""
-        return getattr(self._node, self.sensor_type[ATTR_STATE])()
+        return getattr(self._node, self.sensor_type[ATTR_STATE])
 
     @property
     def unique_id(self):

--- a/custom_components/plugwise/binary_sensor.py
+++ b/custom_components/plugwise/binary_sensor.py
@@ -12,7 +12,6 @@ from homeassistant.helpers import config_validation as cv, entity_platform
 
 from .const import (
     API,
-    ATTR_ENABLED_DEFAULT,
     ATTR_SCAN_DAYLIGHT_MODE,
     ATTR_SCAN_SENSITIVITY_MODE,
     ATTR_SCAN_RESET_TIMER,
@@ -21,7 +20,6 @@ from .const import (
     ATTR_SED_MAINTENANCE_INTERVAL,
     ATTR_SED_CLOCK_SYNC,
     ATTR_SED_CLOCK_INTERVAL,
-    AVAILABLE_SENSOR_ID,
     CB_NEW_NODE,
     COORDINATOR,
     DOMAIN,
@@ -30,7 +28,6 @@ from .const import (
     FLOW_ON_ICON,
     GW_BINARY_SENSORS,
     IDLE_ICON,
-    MOTION_SENSOR_ID,
     NO_NOTIFICATION_ICON,
     NOTIFICATION_ICON,
     PW_CLASS,
@@ -41,8 +38,10 @@ from .const import (
     SERVICE_CONFIGURE_SCAN,
     SEVERITIES,
     STICK,
+    STICK_API,
     USB,
-    USB_BINARY_SENSORS,
+    USB_AVAILABLE_ID,
+    USB_MOTION_ID,
 )
 
 from .gateway import SmileGateway
@@ -66,49 +65,45 @@ async def async_setup_entry_usb(hass, config_entry, async_add_entities):
     api_stick = hass.data[DOMAIN][config_entry.entry_id][STICK]
     platform = entity_platform.current_platform.get()
 
-        """Add plugwise sensor."""
-        _LOGGER.debug("Add binary_sensors for %s", mac)
-
-        node = api_stick.node(mac)
-        for sensor_type in node.sensors:
-            if sensor_type in USB_BINARY_SENSORS:
-                async_add_entities([USBBinarySensor(node, mac, sensor_type)])
-                _LOGGER.debug("Added %s as binary_sensor", sensor_type)
-
-                if node.hardware_model == "Scan" and sensor_type == MOTION_SENSOR_ID:
-                    platform.async_register_entity_service(
-                        SERVICE_CONFIGURE_SCAN,
-                        {
-                            vol.Required(ATTR_SCAN_SENSITIVITY_MODE): vol.In(
-                                SCAN_SENSITIVITY_MODES
-                            ),
-                            vol.Required(ATTR_SCAN_RESET_TIMER): vol.All(
-                                vol.Coerce(int), vol.Range(min=1, max=240)
-                            ),
-                            vol.Required(ATTR_SCAN_DAYLIGHT_MODE): cv.boolean,
-                        },
-                        "_service_configure_scan",
-                    )
-                    platform.async_register_entity_service(
-                        SERVICE_CONFIGURE_BATTERY,
-                        {
-                            vol.Required(ATTR_SED_STAY_ACTIVE): vol.All(
-                                vol.Coerce(int), vol.Range(min=1, max=120)
-                            ),
-                            vol.Required(ATTR_SED_SLEEP_FOR): vol.All(
-                                vol.Coerce(int), vol.Range(min=10, max=60)
-                            ),
-                            vol.Required(ATTR_SED_MAINTENANCE_INTERVAL): vol.All(
-                                vol.Coerce(int), vol.Range(min=5, max=1440)
-                            ),
-                            vol.Required(ATTR_SED_CLOCK_SYNC): cv.boolean,
-                            vol.Required(ATTR_SED_CLOCK_INTERVAL): vol.All(
-                                vol.Coerce(int), vol.Range(min=60, max=10080)
-                            ),
-                        },
-                        "_service_configure_battery_savings",
-                    )
     async def async_add_binary_sensor(mac):
+        """Add plugwise binary sensor."""
+        if USB_MOTION_ID in api_stick.node(mac).features:
+            _LOGGER.debug("Add binary_sensors for %s", mac)
+            async_add_entities([USBBinarySensor(api_stick.node(mac))])
+
+            # Register services
+            platform.async_register_entity_service(
+                SERVICE_CONFIGURE_SCAN,
+                {
+                    vol.Required(ATTR_SCAN_SENSITIVITY_MODE): vol.In(
+                        SCAN_SENSITIVITY_MODES
+                    ),
+                    vol.Required(ATTR_SCAN_RESET_TIMER): vol.All(
+                        vol.Coerce(int), vol.Range(min=1, max=240)
+                    ),
+                    vol.Required(ATTR_SCAN_DAYLIGHT_MODE): cv.boolean,
+                },
+                "_service_configure_scan",
+            )
+            platform.async_register_entity_service(
+                SERVICE_CONFIGURE_BATTERY,
+                {
+                    vol.Required(ATTR_SED_STAY_ACTIVE): vol.All(
+                        vol.Coerce(int), vol.Range(min=1, max=120)
+                    ),
+                    vol.Required(ATTR_SED_SLEEP_FOR): vol.All(
+                        vol.Coerce(int), vol.Range(min=10, max=60)
+                    ),
+                    vol.Required(ATTR_SED_MAINTENANCE_INTERVAL): vol.All(
+                        vol.Coerce(int), vol.Range(min=5, max=1440)
+                    ),
+                    vol.Required(ATTR_SED_CLOCK_SYNC): cv.boolean,
+                    vol.Required(ATTR_SED_CLOCK_INTERVAL): vol.All(
+                        vol.Coerce(int), vol.Range(min=60, max=10080)
+                    ),
+                },
+                "_service_configure_battery_savings",
+            )
 
     for mac in hass.data[DOMAIN][config_entry.entry_id]["binary_sensor"]:
         hass.async_create_task(async_add_binary_sensor(mac))
@@ -303,42 +298,20 @@ class GwNotifySensor(SmileBinarySensor, BinarySensorEntity):
 class USBBinarySensor(NodeEntity, BinarySensorEntity):
     """Representation of a Stick Node Binary Sensor."""
 
-    def __init__(self, node, mac, sensor_id):
+    def __init__(self, node):
         """Initialize a Node entity."""
-        super().__init__(node, mac)
-        self.sensor_id = sensor_id
-        self.sensor_type = USB_BINARY_SENSORS[sensor_id]
-        self.node_callbacks = (AVAILABLE_SENSOR_ID, sensor_id)
-
-    @property
-    def device_class(self):
-        """Return the device class of the sensor."""
-        return self.sensor_type[ATTR_DEVICE_CLASS]
-
-    @property
-    def entity_registry_enabled_default(self):
-        """Return the sensor registration state."""
-        return self.sensor_type[ATTR_ENABLED_DEFAULT]
-
-    @property
-    def icon(self):
-        """Icon to use in the frontend, if any."""
-        return self.sensor_type[ATTR_ICON]
-
-    @property
-    def name(self):
-        """Return the display name of this sensor."""
-        return f"{self.sensor_type[ATTR_NAME]} ({self._mac[-5:]})"
+        super().__init__(node, USB_MOTION_ID)
+        self.node_callbacks = (USB_AVAILABLE_ID, USB_MOTION_ID)
 
     @property
     def is_on(self):
         """Return true if the binary_sensor is on."""
-        return getattr(self._node, self.sensor_type[ATTR_STATE])
+        return getattr(self._node, STICK_API[USB_MOTION_ID][ATTR_STATE])
 
     @property
     def unique_id(self):
         """Get unique ID."""
-        return f"{self._mac}-{self.sensor_id}"
+        return f"{self._node.mac}-{USB_MOTION_ID}"
 
     def _service_configure_scan(self, **kwargs):
         """Service call to configure motion sensor of Scan device."""

--- a/custom_components/plugwise/binary_sensor.py
+++ b/custom_components/plugwise/binary_sensor.py
@@ -67,9 +67,9 @@ async def async_setup_entry_usb(hass, config_entry, async_add_entities):
 
     async def async_add_binary_sensor(mac):
         """Add plugwise binary sensor."""
-        if USB_MOTION_ID in api_stick.node(mac).features:
+        if USB_MOTION_ID in api_stick.devices[mac].features:
             _LOGGER.debug("Add binary_sensors for %s", mac)
-            async_add_entities([USBBinarySensor(api_stick.node(mac))])
+            async_add_entities([USBBinarySensor(api_stick.devices[mac])])
 
             # Register services
             platform.async_register_entity_service(

--- a/custom_components/plugwise/binary_sensor.py
+++ b/custom_components/plugwise/binary_sensor.py
@@ -4,7 +4,7 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.components.binary_sensor import BinarySensorEntity
+from homeassistant.components.binary_sensor import BinarySensorEntity, DOMAIN as BINARY_SENSOR_DOMAIN
 from homeassistant.const import ATTR_DEVICE_CLASS, ATTR_ICON, ATTR_NAME, ATTR_STATE
 
 from homeassistant.core import callback
@@ -105,7 +105,7 @@ async def async_setup_entry_usb(hass, config_entry, async_add_entities):
                 "_service_configure_battery_savings",
             )
 
-    for mac in hass.data[DOMAIN][config_entry.entry_id]["binary_sensor"]:
+    for mac in hass.data[DOMAIN][config_entry.entry_id][BINARY_SENSOR_DOMAIN]:
         hass.async_create_task(async_add_binary_sensor(mac))
 
     def discoved_binary_sensor(mac):

--- a/custom_components/plugwise/binary_sensor.py
+++ b/custom_components/plugwise/binary_sensor.py
@@ -63,14 +63,14 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
 async def async_setup_entry_usb(hass, config_entry, async_add_entities):
     """Set up Plugwise binary sensor based on config_entry."""
-    stick = hass.data[DOMAIN][config_entry.entry_id][STICK]
+    api_stick = hass.data[DOMAIN][config_entry.entry_id][STICK]
     platform = entity_platform.current_platform.get()
 
     async def async_add_sensor(mac):
         """Add plugwise sensor."""
         _LOGGER.debug("Add binary_sensors for %s", mac)
 
-        node = stick.node(mac)
+        node = api_stick.node(mac)
         for sensor_type in node.sensors:
             if sensor_type in USB_BINARY_SENSORS:
                 async_add_entities([USBBinarySensor(node, mac, sensor_type)])
@@ -118,7 +118,7 @@ async def async_setup_entry_usb(hass, config_entry, async_add_entities):
         hass.async_create_task(async_add_sensor(mac))
 
     # Listen for discovered nodes
-    stick.subscribe_stick_callback(discoved_binary_sensor, CB_NEW_NODE)
+    api_stick.subscribe_stick_callback(discoved_binary_sensor, CB_NEW_NODE)
 
 
 async def async_setup_entry_gateway(hass, config_entry, async_add_entities):

--- a/custom_components/plugwise/config_flow.py
+++ b/custom_components/plugwise/config_flow.py
@@ -99,7 +99,7 @@ async def validate_usb_connection(self, device_path=None) -> Dict[str, str]:
         errors[CONF_BASE] = "network_down"
     except TimeoutException:
         errors[CONF_BASE] = "network_timeout"
-    return errors, stick
+    return errors, api_stick
 
 
 def get_serial_by_id(dev_path: str) -> str:

--- a/custom_components/plugwise/config_flow.py
+++ b/custom_components/plugwise/config_flow.py
@@ -6,8 +6,6 @@ from typing import Dict
 
 import voluptuous as vol
 
-import plugwise
-from plugwise.smile import Smile
 from plugwise.exceptions import (
     InvalidAuthentication,
     NetworkDown,
@@ -16,6 +14,8 @@ from plugwise.exceptions import (
     StickInitError,
     TimeoutException,
 )
+from plugwise.stick import stick
+from plugwise.smile import Smile
 
 from homeassistant import config_entries, core, exceptions
 from homeassistant.const import (
@@ -86,7 +86,7 @@ async def validate_usb_connection(self, device_path=None) -> Dict[str, str]:
         errors[CONF_BASE] = "already_configured"
         return errors, None
 
-    api_stick = await self.async_add_executor_job(plugwise.stick, device_path)
+    api_stick = await self.async_add_executor_job(stick, device_path)
     try:
         await self.async_add_executor_job(api_stick.connect)
         await self.async_add_executor_job(api_stick.initialize_stick)

--- a/custom_components/plugwise/config_flow.py
+++ b/custom_components/plugwise/config_flow.py
@@ -86,11 +86,11 @@ async def validate_usb_connection(self, device_path=None) -> Dict[str, str]:
         errors[CONF_BASE] = "already_configured"
         return errors, None
 
-    stick = await self.async_add_executor_job(plugwise.stick, device_path)
+    api_stick = await self.async_add_executor_job(plugwise.stick, device_path)
     try:
-        await self.async_add_executor_job(stick.connect)
-        await self.async_add_executor_job(stick.initialize_stick)
-        await self.async_add_executor_job(stick.disconnect)
+        await self.async_add_executor_job(api_stick.connect)
+        await self.async_add_executor_job(api_stick.initialize_stick)
+        await self.async_add_executor_job(api_stick.disconnect)
     except PortError:
         errors[CONF_BASE] = "cannot_connect"
     except StickInitError:
@@ -219,9 +219,9 @@ class PlugwiseConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 device_path = await self.hass.async_add_executor_job(
                     get_serial_by_id, user_selection
                 )
-            errors, stick = await validate_usb_connection(self.hass, device_path)
+            errors, api_stick = await validate_usb_connection(self.hass, device_path)
             if not errors:
-                await self.async_set_unique_id(stick.get_mac_stick())
+                await self.async_set_unique_id(api_stick.get_mac_stick())
                 return self.async_create_entry(
                     title="Stick", data={CONF_USB_PATH: device_path, PW_TYPE: STICK}
                 )
@@ -241,9 +241,9 @@ class PlugwiseConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             device_path = await self.hass.async_add_executor_job(
                 get_serial_by_id, user_input.get(CONF_USB_PATH)
             )
-            errors, stick = await validate_usb_connection(self.hass, device_path)
+            errors, api_stick = await validate_usb_connection(self.hass, device_path)
             if not errors:
-                await self.async_set_unique_id(stick.mac)
+                await self.async_set_unique_id(api_stick.mac)
                 return self.async_create_entry(
                     title="Stick", data={CONF_USB_PATH: device_path}
                 )

--- a/custom_components/plugwise/config_flow.py
+++ b/custom_components/plugwise/config_flow.py
@@ -243,7 +243,7 @@ class PlugwiseConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             )
             errors, stick = await validate_usb_connection(self.hass, device_path)
             if not errors:
-                await self.async_set_unique_id(stick.get_mac_stick())
+                await self.async_set_unique_id(stick.mac)
                 return self.async_create_entry(
                     title="Stick", data={CONF_USB_PATH: device_path}
                 )

--- a/custom_components/plugwise/const.py
+++ b/custom_components/plugwise/const.py
@@ -374,14 +374,16 @@ CONF_USB_PATH = "usb_path"
 CB_NEW_NODE = "NEW_NODE"
 
 # Sensor IDs
-AVAILABLE_SENSOR_ID = "available"
-CURRENT_POWER_SENSOR_ID = "power_1s"
-TODAY_ENERGY_SENSOR_ID = "power_con_today"
-MOTION_SENSOR_ID = "motion"
+USB_AVAILABLE_ID = "available"
+USB_CURRENT_POWER_ID = "power_1s"
+USB_CURRENT_POWER_8S_ID = "power_8s"
+USB_POWER_CONSUMPTION_TODAY_ID = "power_con_today"
+USB_MOTION_ID = "motion"
+USB_RELAY_ID = "relay"
 
 # Sensor types
-USB_SENSORS = {
-    AVAILABLE_SENSOR_ID: {
+STICK_API = {
+    USB_AVAILABLE_ID: {
         ATTR_DEVICE_CLASS: None,
         ATTR_ENABLED_DEFAULT: False,
         ATTR_ICON: "mdi:signal-off",
@@ -397,7 +399,7 @@ USB_SENSORS = {
         ATTR_STATE: "ping",
         ATTR_UNIT_OF_MEASUREMENT: TIME_MILLISECONDS,
     },
-    CURRENT_POWER_SENSOR_ID: {
+    USB_CURRENT_POWER_ID: {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_POWER,
         ATTR_ENABLED_DEFAULT: True,
         ATTR_ICON: None,
@@ -405,7 +407,7 @@ USB_SENSORS = {
         ATTR_STATE: "current_power_usage",
         ATTR_UNIT_OF_MEASUREMENT: POWER_WATT,
     },
-    "power_8s": {
+    USB_CURRENT_POWER_8S_ID: {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_POWER,
         ATTR_ENABLED_DEFAULT: False,
         ATTR_ICON: None,
@@ -429,7 +431,7 @@ USB_SENSORS = {
         ATTR_STATE: "power_consumption_previous_hour",
         ATTR_UNIT_OF_MEASUREMENT: ENERGY_KILO_WATT_HOUR,
     },
-    TODAY_ENERGY_SENSOR_ID: {
+    USB_POWER_CONSUMPTION_TODAY_ID: {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_POWER,
         ATTR_ENABLED_DEFAULT: True,
         ATTR_ICON: None,
@@ -477,21 +479,15 @@ USB_SENSORS = {
         ATTR_STATE: "rssi_out",
         ATTR_UNIT_OF_MEASUREMENT: SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
     },
-}
-USB_BINARY_SENSORS = {
-    MOTION_SENSOR_ID: {
+    USB_MOTION_ID: {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_MOTION,
         ATTR_ENABLED_DEFAULT: True,
         ATTR_ICON: None,
         ATTR_NAME: "Motion",
         ATTR_STATE: "motion",
         ATTR_UNIT_OF_MEASUREMENT: None,
-    }
-}
-
-# Switch types
-SWITCHES = {
-    "relay": {
+    },
+    USB_RELAY_ID: {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_OUTLET,
         ATTR_ENABLED_DEFAULT: True,
         ATTR_ICON: None,

--- a/custom_components/plugwise/const.py
+++ b/custom_components/plugwise/const.py
@@ -385,14 +385,6 @@ USB_RELAY_ID = "relay"
 
 # Sensor types
 STICK_API = {
-    USB_AVAILABLE_ID: {
-        ATTR_DEVICE_CLASS: None,
-        ATTR_ENABLED_DEFAULT: False,
-        ATTR_ICON: "mdi:signal-off",
-        ATTR_NAME: "Available",
-        ATTR_STATE: "available",
-        ATTR_UNIT_OF_MEASUREMENT: None,
-    },
     "ping": {
         ATTR_DEVICE_CLASS: None,
         ATTR_ENABLED_DEFAULT: False,

--- a/custom_components/plugwise/const.py
+++ b/custom_components/plugwise/const.py
@@ -1,7 +1,8 @@
 """Constants for Plugwise beta component."""
 
-from homeassistant.components.binary_sensor import DEVICE_CLASS_MOTION
-from homeassistant.components.switch import DEVICE_CLASS_OUTLET
+from homeassistant.components.binary_sensor import DEVICE_CLASS_MOTION, DOMAIN as BINARY_SENSOR_DOMAIN
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.components.switch import DEVICE_CLASS_OUTLET, DOMAIN as SWITCH_DOMAIN
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
     ATTR_ICON,
@@ -84,8 +85,8 @@ SEVERITIES = ["other", "info", "warning", "error"]
 
 # --- Const for Plugwise Smile and Stretch
 
-PLATFORMS_GATEWAY = ["binary_sensor", "climate", "sensor", "switch"]
-SENSOR_PLATFORMS = ["sensor", "switch"]
+PLATFORMS_GATEWAY = [BINARY_SENSOR_DOMAIN, "climate", SENSOR_DOMAIN, SWITCH_DOMAIN]
+SENSOR_PLATFORMS = [SENSOR_DOMAIN, SWITCH_DOMAIN]
 SERVICE_DELETE = "delete_notification"
 
 # Climate const:
@@ -367,7 +368,7 @@ SWITCH_CLASSES = ["plug", "switch_group"]
 
 # --- Const for Plugwise USB-stick.
 
-PLATFORMS_USB = ["binary_sensor", "sensor", "switch"]
+PLATFORMS_USB = [BINARY_SENSOR_DOMAIN, SENSOR_DOMAIN, SWITCH_DOMAIN]
 CONF_USB_PATH = "usb_path"
 
 # Callback types

--- a/custom_components/plugwise/const.py
+++ b/custom_components/plugwise/const.py
@@ -372,6 +372,7 @@ CONF_USB_PATH = "usb_path"
 
 # Callback types
 CB_NEW_NODE = "NEW_NODE"
+CB_JOIN_REQUEST = "JOIN_REQUEST"
 
 # Sensor IDs
 USB_AVAILABLE_ID = "available"

--- a/custom_components/plugwise/const.py
+++ b/custom_components/plugwise/const.py
@@ -386,7 +386,7 @@ USB_SENSORS = {
         ATTR_ENABLED_DEFAULT: False,
         ATTR_ICON: "mdi:signal-off",
         ATTR_NAME: "Available",
-        ATTR_STATE: "get_available",
+        ATTR_STATE: "available",
         ATTR_UNIT_OF_MEASUREMENT: None,
     },
     "ping": {
@@ -394,7 +394,7 @@ USB_SENSORS = {
         ATTR_ENABLED_DEFAULT: False,
         ATTR_ICON: "mdi:speedometer",
         ATTR_NAME: "Ping roundtrip",
-        ATTR_STATE: "get_ping",
+        ATTR_STATE: "ping",
         ATTR_UNIT_OF_MEASUREMENT: TIME_MILLISECONDS,
     },
     CURRENT_POWER_SENSOR_ID: {
@@ -402,7 +402,7 @@ USB_SENSORS = {
         ATTR_ENABLED_DEFAULT: True,
         ATTR_ICON: None,
         ATTR_NAME: "Power usage",
-        ATTR_STATE: "get_power_usage",
+        ATTR_STATE: "current_power_usage",
         ATTR_UNIT_OF_MEASUREMENT: POWER_WATT,
     },
     "power_8s": {
@@ -410,7 +410,7 @@ USB_SENSORS = {
         ATTR_ENABLED_DEFAULT: False,
         ATTR_ICON: None,
         ATTR_NAME: "Power usage 8 seconds",
-        ATTR_STATE: "get_power_usage_8_sec",
+        ATTR_STATE: "current_power_usage_8_sec",
         ATTR_UNIT_OF_MEASUREMENT: POWER_WATT,
     },
     "power_con_cur_hour": {
@@ -418,7 +418,7 @@ USB_SENSORS = {
         ATTR_ENABLED_DEFAULT: True,
         ATTR_ICON: None,
         ATTR_NAME: "Power consumption current hour",
-        ATTR_STATE: "get_power_consumption_current_hour",
+        ATTR_STATE: "power_consumption_current_hour",
         ATTR_UNIT_OF_MEASUREMENT: ENERGY_KILO_WATT_HOUR,
     },
     "power_con_prev_hour": {
@@ -426,7 +426,7 @@ USB_SENSORS = {
         ATTR_ENABLED_DEFAULT: True,
         ATTR_ICON: None,
         ATTR_NAME: "Power consumption previous hour",
-        ATTR_STATE: "get_power_consumption_prev_hour",
+        ATTR_STATE: "power_consumption_previous_hour",
         ATTR_UNIT_OF_MEASUREMENT: ENERGY_KILO_WATT_HOUR,
     },
     TODAY_ENERGY_SENSOR_ID: {
@@ -434,7 +434,7 @@ USB_SENSORS = {
         ATTR_ENABLED_DEFAULT: True,
         ATTR_ICON: None,
         ATTR_NAME: "Power consumption today",
-        ATTR_STATE: "get_power_consumption_today",
+        ATTR_STATE: "power_consumption_today",
         ATTR_UNIT_OF_MEASUREMENT: ENERGY_KILO_WATT_HOUR,
     },
     "power_con_yesterday": {
@@ -442,7 +442,7 @@ USB_SENSORS = {
         ATTR_ENABLED_DEFAULT: True,
         ATTR_ICON: None,
         ATTR_NAME: "Power consumption yesterday",
-        ATTR_STATE: "get_power_consumption_yesterday",
+        ATTR_STATE: "power_consumption_yesterday",
         ATTR_UNIT_OF_MEASUREMENT: ENERGY_KILO_WATT_HOUR,
     },
     "power_prod_cur_hour": {
@@ -450,7 +450,7 @@ USB_SENSORS = {
         ATTR_ENABLED_DEFAULT: False,
         ATTR_ICON: None,
         ATTR_NAME: "Power production current hour",
-        ATTR_STATE: "get_power_production_current_hour",
+        ATTR_STATE: "power_production_current_hour",
         ATTR_UNIT_OF_MEASUREMENT: ENERGY_KILO_WATT_HOUR,
     },
     "power_prod_prev_hour": {
@@ -458,7 +458,7 @@ USB_SENSORS = {
         ATTR_ENABLED_DEFAULT: False,
         ATTR_ICON: None,
         ATTR_NAME: "Power production previous hour",
-        ATTR_STATE: "get_power_production_previous_hour",
+        ATTR_STATE: "power_production_previous_hour",
         ATTR_UNIT_OF_MEASUREMENT: ENERGY_KILO_WATT_HOUR,
     },
     "RSSI_in": {
@@ -466,7 +466,7 @@ USB_SENSORS = {
         ATTR_ENABLED_DEFAULT: False,
         ATTR_ICON: None,
         ATTR_NAME: "Inbound RSSI",
-        ATTR_STATE: "get_in_RSSI",
+        ATTR_STATE: "rssi_in",
         ATTR_UNIT_OF_MEASUREMENT: SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
     },
     "RSSI_out": {
@@ -474,7 +474,7 @@ USB_SENSORS = {
         ATTR_ENABLED_DEFAULT: False,
         ATTR_ICON: None,
         ATTR_NAME: "Outbound RSSI",
-        ATTR_STATE: "get_out_RSSI",
+        ATTR_STATE: "rssi_out",
         ATTR_UNIT_OF_MEASUREMENT: SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
     },
 }
@@ -484,7 +484,7 @@ USB_BINARY_SENSORS = {
         ATTR_ENABLED_DEFAULT: True,
         ATTR_ICON: None,
         ATTR_NAME: "Motion",
-        ATTR_STATE: "get_motion",
+        ATTR_STATE: "motion",
         ATTR_UNIT_OF_MEASUREMENT: None,
     }
 }
@@ -496,8 +496,7 @@ SWITCHES = {
         ATTR_ENABLED_DEFAULT: True,
         ATTR_ICON: None,
         ATTR_NAME: "Relay state",
-        ATTR_STATE: "get_relay_state",
-        "switch": "set_relay_state",
+        ATTR_STATE: "relay_state",
         ATTR_UNIT_OF_MEASUREMENT: "state",
     }
 }

--- a/custom_components/plugwise/manifest.json
+++ b/custom_components/plugwise/manifest.json
@@ -2,7 +2,7 @@
   "domain": "plugwise",
   "name": "Plugwise Beta",
   "documentation": "https://github.com/plugwise/plugwise-beta",
-  "requirements": ["https://test-files.pythonhosted.org/packages/5c/41/2186991f7a99d9c96d7cae17dd937c91dc3a2cea0e826c2a96d76f4a4b03/plugwise-0.9.0a2.tar.gz#plugwise==0.9.0a2"],
+  "requirements": ["plugwise==0.9.0"],
   "codeowners": ["@CoMPaTech","@bouwew","@brefra"],
   "config_flow": true
 }

--- a/custom_components/plugwise/manifest.json
+++ b/custom_components/plugwise/manifest.json
@@ -2,7 +2,7 @@
   "domain": "plugwise",
   "name": "Plugwise Beta",
   "documentation": "https://github.com/plugwise/plugwise-beta",
-  "requirements": ["plugwise==0.8.3"],
+  "requirements": ["https://test-files.pythonhosted.org/packages/b5/49/56fc2ef5c3d09942be8342ef89b64094fb5c31abc3b15299dda3b248f77a/plugwise-0.9.0a1.tar.gz#plugwise==0.9.0a1"],
   "codeowners": ["@CoMPaTech","@bouwew","@brefra"],
   "config_flow": true
 }

--- a/custom_components/plugwise/manifest.json
+++ b/custom_components/plugwise/manifest.json
@@ -2,7 +2,7 @@
   "domain": "plugwise",
   "name": "Plugwise Beta",
   "documentation": "https://github.com/plugwise/plugwise-beta",
-  "requirements": ["https://test-files.pythonhosted.org/packages/b5/49/56fc2ef5c3d09942be8342ef89b64094fb5c31abc3b15299dda3b248f77a/plugwise-0.9.0a1.tar.gz#plugwise==0.9.0a1"],
+  "requirements": ["https://test-files.pythonhosted.org/packages/5c/41/2186991f7a99d9c96d7cae17dd937c91dc3a2cea0e826c2a96d76f4a4b03/plugwise-0.9.0a2.tar.gz#plugwise==0.9.0a2"],
   "codeowners": ["@CoMPaTech","@bouwew","@brefra"],
   "config_flow": true
 }

--- a/custom_components/plugwise/sensor.py
+++ b/custom_components/plugwise/sensor.py
@@ -63,7 +63,7 @@ async def async_setup_entry_usb(hass, config_entry, async_add_entities):
     async def async_add_sensor(mac):
         """Add plugwise sensor."""
         node = stick.node(mac)
-        for sensor_type in node.get_sensors():
+        for sensor_type in node.sensors:
             if sensor_type in USB_SENSORS and sensor_type != AVAILABLE_SENSOR_ID:
                 async_add_entities([USBSensor(node, mac, sensor_type)])
 
@@ -314,7 +314,7 @@ class USBSensor(NodeEntity):
     @property
     def state(self):
         """Return the state of the sensor."""
-        state_value = getattr(self._node, self.sensor_type[ATTR_STATE])()
+        state_value = getattr(self._node, self.sensor_type[ATTR_STATE])
         if state_value is not None:
             return float(round(state_value, 3))
         return None

--- a/custom_components/plugwise/sensor.py
+++ b/custom_components/plugwise/sensor.py
@@ -24,7 +24,6 @@ from .usb import NodeEntity
 from .const import (
     API,
     ATTR_ENABLED_DEFAULT,
-    AVAILABLE_SENSOR_ID,
     AUX_DEV_SENSORS,
     CB_NEW_NODE,
     COOL_ICON,
@@ -38,9 +37,12 @@ from .const import (
     PW_MODEL,
     PW_TYPE,
     STICK,
+    STICK_API,
     THERMOSTAT_SENSORS,
     USB,
-    USB_SENSORS,
+    USB_AVAILABLE_ID,
+    USB_MOTION_ID,
+    USB_RELAY_ID,
 )
 
 PARALLEL_UPDATES = 0
@@ -62,10 +64,9 @@ async def async_setup_entry_usb(hass, config_entry, async_add_entities):
 
     async def async_add_sensor(mac):
         """Add plugwise sensor."""
-        node = api_stick.node(mac)
-        for sensor_type in node.sensors:
-            if sensor_type in USB_SENSORS and sensor_type != AVAILABLE_SENSOR_ID:
-                async_add_entities([USBSensor(node, mac, sensor_type)])
+        for feature in api_stick.node(mac).features:
+            if feature not in (USB_MOTION_ID, USB_RELAY_ID):
+                async_add_entities([USBSensor(api_stick.node(mac), feature)])
 
     for mac in hass.data[DOMAIN][config_entry.entry_id]["sensor"]:
         hass.async_create_task(async_add_sensor(mac))
@@ -284,37 +285,16 @@ class GwAuxDeviceSensor(SmileSensor, Entity):
 class USBSensor(NodeEntity):
     """Representation of a Stick Node sensor."""
 
-    def __init__(self, node, mac, sensor_id):
+    def __init__(self, node, sensor_id):
         """Initialize a Node entity."""
-        super().__init__(node, mac)
+        super().__init__(node, sensor_id)
         self.sensor_id = sensor_id
-        self.sensor_type = USB_SENSORS[sensor_id]
-        self.node_callbacks = (AVAILABLE_SENSOR_ID, sensor_id)
-
-    @property
-    def device_class(self):
-        """Return the device class of the sensor."""
-        return self.sensor_type[ATTR_DEVICE_CLASS]
-
-    @property
-    def entity_registry_enabled_default(self):
-        """Return the sensor registration state."""
-        return self.sensor_type[ATTR_ENABLED_DEFAULT]
-
-    @property
-    def icon(self):
-        """Icon to use in the frontend, if any."""
-        return self.sensor_type[ATTR_ICON]
-
-    @property
-    def name(self):
-        """Return the display name of this sensor."""
-        return f"{self.sensor_type[ATTR_NAME]} ({self._mac[-5:]})"
+        self.node_callbacks = (USB_AVAILABLE_ID, sensor_id)
 
     @property
     def state(self):
         """Return the state of the sensor."""
-        state_value = getattr(self._node, self.sensor_type[ATTR_STATE])
+        state_value = getattr(self._node, STICK_API[self.sensor_id][ATTR_STATE])
         if state_value is not None:
             return float(round(state_value, 3))
         return None
@@ -322,9 +302,9 @@ class USBSensor(NodeEntity):
     @property
     def unique_id(self):
         """Get unique ID."""
-        return f"{self._mac}-{self.sensor_id}"
+        return f"{self._node.mac}-{self.sensor_id}"
 
     @property
     def unit_of_measurement(self):
         """Return the unit this state is expressed in."""
-        return self.sensor_type[ATTR_UNIT_OF_MEASUREMENT]
+        return STICK_API[self.sensor_id][ATTR_UNIT_OF_MEASUREMENT]

--- a/custom_components/plugwise/sensor.py
+++ b/custom_components/plugwise/sensor.py
@@ -18,6 +18,7 @@ from homeassistant.components.climate.const import (
 )
 from homeassistant.core import callback
 from homeassistant.helpers.entity import Entity
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 
 from .gateway import SmileGateway
 from .usb import NodeEntity
@@ -68,7 +69,7 @@ async def async_setup_entry_usb(hass, config_entry, async_add_entities):
             if feature not in (USB_MOTION_ID, USB_RELAY_ID):
                 async_add_entities([USBSensor(api_stick.node(mac), feature)])
 
-    for mac in hass.data[DOMAIN][config_entry.entry_id]["sensor"]:
+    for mac in hass.data[DOMAIN][config_entry.entry_id][SENSOR_DOMAIN]:
         hass.async_create_task(async_add_sensor(mac))
 
     def discoved_sensor(mac):

--- a/custom_components/plugwise/sensor.py
+++ b/custom_components/plugwise/sensor.py
@@ -65,9 +65,9 @@ async def async_setup_entry_usb(hass, config_entry, async_add_entities):
 
     async def async_add_sensor(mac):
         """Add plugwise sensor."""
-        for feature in api_stick.node(mac).features:
+        for feature in api_stick.devices[mac].features:
             if feature not in (USB_MOTION_ID, USB_RELAY_ID):
-                async_add_entities([USBSensor(api_stick.node(mac), feature)])
+                async_add_entities([USBSensor(api_stick.devices[mac], feature)])
 
     for mac in hass.data[DOMAIN][config_entry.entry_id][SENSOR_DOMAIN]:
         hass.async_create_task(async_add_sensor(mac))

--- a/custom_components/plugwise/sensor.py
+++ b/custom_components/plugwise/sensor.py
@@ -58,11 +58,11 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
 async def async_setup_entry_usb(hass, config_entry, async_add_entities):
     """Set up Plugwise sensor based on config_entry."""
-    stick = hass.data[DOMAIN][config_entry.entry_id][STICK]
+    api_stick = hass.data[DOMAIN][config_entry.entry_id][STICK]
 
     async def async_add_sensor(mac):
         """Add plugwise sensor."""
-        node = stick.node(mac)
+        node = api_stick.node(mac)
         for sensor_type in node.sensors:
             if sensor_type in USB_SENSORS and sensor_type != AVAILABLE_SENSOR_ID:
                 async_add_entities([USBSensor(node, mac, sensor_type)])
@@ -75,7 +75,7 @@ async def async_setup_entry_usb(hass, config_entry, async_add_entities):
         hass.async_create_task(async_add_sensor(mac))
 
     # Listen for discovered nodes
-    stick.subscribe_stick_callback(discoved_sensor, CB_NEW_NODE)
+    api_stick.subscribe_stick_callback(discoved_sensor, CB_NEW_NODE)
 
 
 async def async_setup_entry_gateway(hass, config_entry, async_add_entities):

--- a/custom_components/plugwise/switch.py
+++ b/custom_components/plugwise/switch.py
@@ -2,18 +2,10 @@
 
 import logging
 
-from plugwise.smile import Smile
 from plugwise.exceptions import PlugwiseException
 
-from homeassistant.const import (
-    ATTR_DEVICE_CLASS,
-    ATTR_ICON,
-    ATTR_NAME,
-    ATTR_STATE,
-    STATE_OFF,
-    STATE_ON,
-)
 from homeassistant.components.switch import SwitchEntity
+from homeassistant.const import ATTR_NAME, ATTR_STATE, STATE_OFF, STATE_ON
 from homeassistant.core import callback
 
 from .gateway import SmileGateway

--- a/custom_components/plugwise/switch.py
+++ b/custom_components/plugwise/switch.py
@@ -55,7 +55,7 @@ async def async_setup_entry_usb(hass, config_entry, async_add_entities):
     async def async_add_switch(mac):
         """Add plugwise switch."""
         node = stick.node(mac)
-        for switch_type in node.get_switches():
+        for switch_type in node.switches:
             if switch_type in SWITCHES:
                 async_add_entities([USBSwitch(node, mac, switch_type)])
 
@@ -174,8 +174,8 @@ class USBSwitch(NodeEntity, SwitchEntity):
         super().__init__(node, mac)
         self.switch_id = switch_id
         self.switch_type = SWITCHES[self.switch_id]
-        if (CURRENT_POWER_SENSOR_ID in node.get_sensors()) and (
-            TODAY_ENERGY_SENSOR_ID in node.get_sensors()
+        if (CURRENT_POWER_SENSOR_ID in node.sensors) and (
+            TODAY_ENERGY_SENSOR_ID in node.sensors
         ):
             self.node_callbacks = (
                 AVAILABLE_SENSOR_ID,
@@ -191,7 +191,7 @@ class USBSwitch(NodeEntity, SwitchEntity):
         """Return the current power usage in W."""
         current_power = getattr(
             self._node, USB_SENSORS[CURRENT_POWER_SENSOR_ID][ATTR_STATE]
-        )()
+        )
         if current_power:
             return float(round(current_power, 2))
         return None
@@ -216,25 +216,25 @@ class USBSwitch(NodeEntity, SwitchEntity):
     @property
     def is_on(self):
         """Return true if the switch is on."""
-        return getattr(self._node, self.switch_type[ATTR_STATE])()
+        return getattr(self._node, self.switch_type[ATTR_STATE])
 
     @property
     def today_energy_kwh(self):
         """Return the today total energy usage in kWh."""
         today_energy = getattr(
             self._node, USB_SENSORS[TODAY_ENERGY_SENSOR_ID][ATTR_STATE]
-        )()
+        )
         if today_energy:
             return float(round(today_energy, 3))
         return None
 
     def turn_off(self, **kwargs):
         """Instruct the switch to turn off."""
-        getattr(self._node, self.switch_type["switch"])(False)
+        setattr(self._node, self.switch_type[ATTR_STATE], False)
 
     def turn_on(self, **kwargs):
         """Instruct the switch to turn on."""
-        getattr(self._node, self.switch_type["switch"])(True)
+        setattr(self._node, self.switch_type[ATTR_STATE], True)
 
     @property
     def unique_id(self):

--- a/custom_components/plugwise/switch.py
+++ b/custom_components/plugwise/switch.py
@@ -4,7 +4,7 @@ import logging
 
 from plugwise.exceptions import PlugwiseException
 
-from homeassistant.components.switch import SwitchEntity
+from homeassistant.components.switch import SwitchEntity, DOMAIN as SWITCH_DOMAIN
 from homeassistant.const import ATTR_NAME, ATTR_STATE, STATE_OFF, STATE_ON
 from homeassistant.core import callback
 
@@ -48,7 +48,7 @@ async def async_setup_entry_usb(hass, config_entry, async_add_entities):
         if USB_RELAY_ID in api_stick.node(mac).features:
             async_add_entities([USBSwitch(api_stick.node(mac))])
 
-    for mac in hass.data[DOMAIN][config_entry.entry_id]["switch"]:
+    for mac in hass.data[DOMAIN][config_entry.entry_id][SWITCH_DOMAIN]:
         hass.async_create_task(async_add_switch(mac))
 
     def discoved_switch(mac):

--- a/custom_components/plugwise/switch.py
+++ b/custom_components/plugwise/switch.py
@@ -50,11 +50,11 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
 async def async_setup_entry_usb(hass, config_entry, async_add_entities):
     """Set up the USB switches from a config entry."""
-    stick = hass.data[DOMAIN][config_entry.entry_id][STICK]
+    api_stick = hass.data[DOMAIN][config_entry.entry_id][STICK]
 
     async def async_add_switch(mac):
         """Add plugwise switch."""
-        node = stick.node(mac)
+        node = api_stick.node(mac)
         for switch_type in node.switches:
             if switch_type in SWITCHES:
                 async_add_entities([USBSwitch(node, mac, switch_type)])
@@ -67,7 +67,7 @@ async def async_setup_entry_usb(hass, config_entry, async_add_entities):
         hass.async_create_task(async_add_switch(mac))
 
     # Listen for discovered nodes
-    stick.subscribe_stick_callback(discoved_switch, CB_NEW_NODE)
+    api_stick.subscribe_stick_callback(discoved_switch, CB_NEW_NODE)
 
 
 async def async_setup_entry_gateway(hass, config_entry, async_add_entities):

--- a/custom_components/plugwise/switch.py
+++ b/custom_components/plugwise/switch.py
@@ -20,21 +20,20 @@ from .gateway import SmileGateway
 from .usb import NodeEntity
 from .const import (
     API,
-    ATTR_ENABLED_DEFAULT,
-    AVAILABLE_SENSOR_ID,
     CB_NEW_NODE,
     COORDINATOR,
-    CURRENT_POWER_SENSOR_ID,
     DOMAIN,
     PW_MODEL,
     PW_TYPE,
-    USB_SENSORS,
     STICK,
+    STICK_API,
     SWITCH_CLASSES,
     SWITCH_ICON,
-    SWITCHES,
-    TODAY_ENERGY_SENSOR_ID,
     USB,
+    USB_AVAILABLE_ID,
+    USB_CURRENT_POWER_ID,
+    USB_POWER_CONSUMPTION_TODAY_ID,
+    USB_RELAY_ID,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -54,10 +53,8 @@ async def async_setup_entry_usb(hass, config_entry, async_add_entities):
 
     async def async_add_switch(mac):
         """Add plugwise switch."""
-        node = api_stick.node(mac)
-        for switch_type in node.switches:
-            if switch_type in SWITCHES:
-                async_add_entities([USBSwitch(node, mac, switch_type)])
+        if USB_RELAY_ID in api_stick.node(mac).features:
+            async_add_entities([USBSwitch(api_stick.node(mac))])
 
     for mac in hass.data[DOMAIN][config_entry.entry_id]["switch"]:
         hass.async_create_task(async_add_switch(mac))
@@ -169,60 +166,34 @@ class GwSwitch(SmileGateway, SwitchEntity):
 class USBSwitch(NodeEntity, SwitchEntity):
     """Representation of a Stick Node switch."""
 
-    def __init__(self, node, mac, switch_id):
+    def __init__(self, node):
         """Initialize a Node entity."""
-        super().__init__(node, mac)
-        self.switch_id = switch_id
-        self.switch_type = SWITCHES[self.switch_id]
-        if (CURRENT_POWER_SENSOR_ID in node.sensors) and (
-            TODAY_ENERGY_SENSOR_ID in node.sensors
-        ):
-            self.node_callbacks = (
-                AVAILABLE_SENSOR_ID,
-                switch_id,
-                CURRENT_POWER_SENSOR_ID,
-                TODAY_ENERGY_SENSOR_ID,
-            )
-        else:
-            self.node_callbacks = (AVAILABLE_SENSOR_ID, self.switch_id)
+        super().__init__(node, USB_RELAY_ID)
+        self.node_callbacks = (
+            USB_AVAILABLE_ID,
+            USB_CURRENT_POWER_ID,
+            USB_POWER_CONSUMPTION_TODAY_ID,
+            USB_RELAY_ID,
+        )
 
     @property
     def current_power_w(self):
         """Return the current power usage in W."""
-        current_power = getattr(
-            self._node, USB_SENSORS[CURRENT_POWER_SENSOR_ID][ATTR_STATE]
-        )
+        current_power = getattr(self._node, STICK_API[USB_CURRENT_POWER_ID][ATTR_STATE])
         if current_power:
             return float(round(current_power, 2))
         return None
 
     @property
-    def device_class(self):
-        """Return the device class of this switch."""
-        return self.switch_type[ATTR_DEVICE_CLASS]
-
-    @property
-    def entity_registry_enabled_default(self):
-        """Return the switch registration state."""
-        return self.switch_type[ATTR_ENABLED_DEFAULT]
-
-    @property
-    def icon(self):
-        """Return the icon."""
-        return (
-            None if self.switch_type[ATTR_DEVICE_CLASS] else self.switch_type[ATTR_ICON]
-        )
-
-    @property
     def is_on(self):
         """Return true if the switch is on."""
-        return getattr(self._node, self.switch_type[ATTR_STATE])
+        return getattr(self._node, STICK_API[USB_RELAY_ID][ATTR_STATE])
 
     @property
     def today_energy_kwh(self):
         """Return the today total energy usage in kWh."""
         today_energy = getattr(
-            self._node, USB_SENSORS[TODAY_ENERGY_SENSOR_ID][ATTR_STATE]
+            self._node, STICK_API[USB_POWER_CONSUMPTION_TODAY_ID][ATTR_STATE]
         )
         if today_energy:
             return float(round(today_energy, 3))
@@ -230,13 +201,13 @@ class USBSwitch(NodeEntity, SwitchEntity):
 
     def turn_off(self, **kwargs):
         """Instruct the switch to turn off."""
-        setattr(self._node, self.switch_type[ATTR_STATE], False)
+        setattr(self._node, STICK_API[USB_RELAY_ID][ATTR_STATE], False)
 
     def turn_on(self, **kwargs):
         """Instruct the switch to turn on."""
-        setattr(self._node, self.switch_type[ATTR_STATE], True)
+        setattr(self._node, STICK_API[USB_RELAY_ID][ATTR_STATE], True)
 
     @property
     def unique_id(self):
         """Get unique ID."""
-        return f"{self._mac}-{self.switch_id}"
+        return f"{self._node.mac}-{USB_RELAY_ID}"

--- a/custom_components/plugwise/switch.py
+++ b/custom_components/plugwise/switch.py
@@ -45,8 +45,8 @@ async def async_setup_entry_usb(hass, config_entry, async_add_entities):
 
     async def async_add_switch(mac):
         """Add plugwise switch."""
-        if USB_RELAY_ID in api_stick.node(mac).features:
-            async_add_entities([USBSwitch(api_stick.node(mac))])
+        if USB_RELAY_ID in api_stick.devices[mac].features:
+            async_add_entities([USBSwitch(api_stick.devices[mac])])
 
     for mac in hass.data[DOMAIN][config_entry.entry_id][SWITCH_DOMAIN]:
         hass.async_create_task(async_add_switch(mac))

--- a/custom_components/plugwise/switch.py
+++ b/custom_components/plugwise/switch.py
@@ -167,7 +167,7 @@ class GwSwitch(SmileGateway, SwitchEntity):
 
 
 class USBSwitch(NodeEntity, SwitchEntity):
-    """Representation of a Sitck Node switch."""
+    """Representation of a Stick Node switch."""
 
     def __init__(self, node, mac, switch_id):
         """Initialize a Node entity."""

--- a/custom_components/plugwise/usb.py
+++ b/custom_components/plugwise/usb.py
@@ -216,7 +216,7 @@ class NodeEntity(Entity):
     @property
     def available(self):
         """Return the availability of this entity."""
-        return getattr(self._node, STICK_API[USB_AVAILABLE_ID][ATTR_STATE])
+        return self._node.available
 
     @property
     def device_class(self):

--- a/custom_components/plugwise/usb.py
+++ b/custom_components/plugwise/usb.py
@@ -3,7 +3,6 @@ import asyncio
 import logging
 import voluptuous as vol
 
-import plugwise
 from plugwise.exceptions import (
     CirclePlusError,
     NetworkDown,
@@ -11,6 +10,7 @@ from plugwise.exceptions import (
     StickInitError,
     TimeoutException,
 )
+from plugwise.stick import stick
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_STATE, EVENT_HOMEASSISTANT_STOP
@@ -96,7 +96,7 @@ async def async_setup_entry_usb(hass: HomeAssistant, config_entry: ConfigEntry):
     def shutdown(event):
         hass.async_add_executor_job(api_stick.disconnect)
 
-    api_stick = plugwise.stick(config_entry.data[CONF_USB_PATH])
+    api_stick = stick(config_entry.data[CONF_USB_PATH])
     hass.data[DOMAIN][config_entry.entry_id] = {PW_TYPE: USB, STICK: api_stick}
     try:
         _LOGGER.debug("Connect to USB-Stick")

--- a/custom_components/plugwise/usb.py
+++ b/custom_components/plugwise/usb.py
@@ -84,8 +84,6 @@ async def async_setup_entry_usb(hass: HomeAssistant, config_entry: ConfigEntry):
             )
 
         api_stick.auto_update()
-        # Subscribe listener for new node joined to Plugwise network
-        api_stick.subscribe_stick_callback(add_new_node, CB_JOIN_REQUEST)
 
         if config_entry.system_options.disable_new_entities:
             _LOGGER.debug("Configuring stick NOT to accept any new join requests")
@@ -93,6 +91,7 @@ async def async_setup_entry_usb(hass: HomeAssistant, config_entry: ConfigEntry):
         else:
             _LOGGER.debug("Configuring stick to automatically accept new join requests")
             api_stick.allow_join_requests(True, True)
+            api_stick.subscribe_stick_callback(add_new_node, CB_JOIN_REQUEST)
 
     def shutdown(event):
         hass.async_add_executor_job(api_stick.disconnect)

--- a/custom_components/plugwise/usb.py
+++ b/custom_components/plugwise/usb.py
@@ -56,16 +56,18 @@ async def async_setup_entry_usb(hass: HomeAssistant, config_entry: ConfigEntry):
         """Create entities for all discovered nodes."""
         _LOGGER.debug(
             "Successfully discovered %s out of %s registered nodes",
-            str(len(api_stick.discovered_nodes)),
+            str(len(api_stick.devices)),
             str(api_stick.joined_nodes),
         )
         for component in PLATFORMS_USB:
             hass.data[DOMAIN][config_entry.entry_id][component] = []
 
-        for mac in api_stick.discovered_nodes:
-            if USB_RELAY_ID in api_stick.node(mac).features:
-            if USB_MOTION_ID in api_stick.node(mac).features:
+        for mac in api_stick.devices:
+            # Skip unsupported devices
+            if api_stick.devices[mac]:
+                if USB_RELAY_ID in api_stick.devices[mac].features:
                     hass.data[DOMAIN][config_entry.entry_id][SWITCH_DOMAIN].append(mac)
+                if USB_MOTION_ID in api_stick.devices[mac].features:
                     hass.data[DOMAIN][config_entry.entry_id][BINARY_SENSOR_DOMAIN].append(mac)
                 hass.data[DOMAIN][config_entry.entry_id][SENSOR_DOMAIN].append(mac)
 

--- a/custom_components/plugwise/usb.py
+++ b/custom_components/plugwise/usb.py
@@ -12,6 +12,9 @@ from plugwise.exceptions import (
 )
 from plugwise.stick import stick
 
+from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_STATE, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import HomeAssistant
@@ -61,10 +64,10 @@ async def async_setup_entry_usb(hass: HomeAssistant, config_entry: ConfigEntry):
 
         for mac in api_stick.discovered_nodes:
             if USB_RELAY_ID in api_stick.node(mac).features:
-                hass.data[DOMAIN][config_entry.entry_id]["switch"].append(mac)
             if USB_MOTION_ID in api_stick.node(mac).features:
-                hass.data[DOMAIN][config_entry.entry_id]["binary_sensor"].append(mac)
-            hass.data[DOMAIN][config_entry.entry_id]["sensor"].append(mac)
+                    hass.data[DOMAIN][config_entry.entry_id][SWITCH_DOMAIN].append(mac)
+                    hass.data[DOMAIN][config_entry.entry_id][BINARY_SENSOR_DOMAIN].append(mac)
+                hass.data[DOMAIN][config_entry.entry_id][SENSOR_DOMAIN].append(mac)
 
         for component in PLATFORMS_USB:
             hass.async_create_task(


### PR DESCRIPTION
- USB-Stick
  - New: Automatically accepting of joining request of new Plugwise devices if the `Enable newly added entries` system option is turned on (default). A notification will be popup after a new devices is joined.
  - Improved: For quicker response switch (relay) requests are handled with priority
  - Improved: Dynamically set the refresh interval based on the actual discovered devices with power measurement capabilities
  - Improved: Response messages received from Plugwise devices are now validated to their checksums.
  - Improved: Using the `device_remove` services will remove the devices from the device registry too.
  - Improved: Better handling of timeout issues and reduced communication messages.
  - Improved: Corrected log level assignments (debug, info, warning, errors)
  - Fixed: Missing power history values during last week of the month.
  - Fixed: Prevent a few rarely occurring communication failures.