### PR TITLE
Fix device naming, add enabled_default

### DIFF
--- a/custom_components/plugwise/switch.py
+++ b/custom_components/plugwise/switch.py
@@ -78,6 +78,7 @@ async def async_setup_entry_gateway(hass, config_entry, async_add_entities):
                     coordinator,
                     devices[dev_id][ATTR_NAME],
                     dev_id,
+                    True,
                     members,
                     devices[dev_id][PW_MODEL],
                 )
@@ -91,10 +92,11 @@ async def async_setup_entry_gateway(hass, config_entry, async_add_entities):
                     GwSwitch(
                         api,
                         coordinator,
-                        "dhw_comfort_mode",
+                        "Auxiliary",
                         dev_id,
+                        True,
                         None,
-                        "dhw_cm_switch"
+                    devices[dev_id][PW_MODEL],
                 )
             )
 
@@ -105,18 +107,27 @@ async def async_setup_entry_gateway(hass, config_entry, async_add_entities):
 class GwSwitch(SmileGateway, SwitchEntity):
     """Representation of a Smile Gateway switch."""
 
-    def __init__(self, api, coordinator, name, dev_id, members, model):
+    def __init__(self, api, coordinator, name, dev_id, enabled_default, members, model):
         """Set up the Plugwise API."""
-        self._enabled_default = True
 
         super().__init__(api, coordinator, name, dev_id)
 
         self._is_on = False
+        self._enabled_default = enabled_default
         self._members = members
         self._model = model
         self._name = f"{name}"
 
+        if dev_id == self._api.heater_id:
+            self._entity_name = "Auxiliary"
+            self._name = f"{self._entity_name} DHW Comfort Mode"
+
         self._unique_id = f"{dev_id}-{self._model.lower()}"
+
+    @property
+    def entity_registry_enabled_default(self) -> bool:
+        """Return if the entity should be enabled when first added to the entity registry."""
+        return self._enabled_default
 
     @property
     def icon(self):


### PR DESCRIPTION
Sorry, I didn't test properly, the new `dhw_comf_mode` switch implementation renames the Auxiliary-device.

With these changes it works on my system.
But, there's one **breaking-change** I've also found: the unique_id of the Switch Groups is changed, this will cause `_2` switches. This only impacts users that have grouped Plugs(Adam) and Circles, Stealths (Stretches), not too many users.
I could work around this but I'd prefer not too as this will add more code.