### PR TITLE
Add usb testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,7 @@ jobs:
             git checkout dev
             script/setup
             . venv/bin/activate
-            pip install -r requirements_test.txt
+            pip install -r -q requirements_test.txt
         fi
         git log -1 | head -1 > ~/ha-core/.git/plugwise-tracking
 
@@ -119,8 +119,8 @@ jobs:
         . venv/bin/activate
         mkdir ~/tmp
         egrep -i "sqlalchemy|zeroconf|pyserial" requirements_test_all.txt > ~/tmp/requirements_test_extra.txt
-        pip install -r ~/tmp/requirements_test_extra.txt
-        pip install $(grep require ~/work/plugwise-beta/plugwise-beta/custom_components/plugwise/manifest.json | cut -f 4 -d '"')
+        pip install -r -q ~/tmp/requirements_test_extra.txt
+        pip install -q $(grep require ~/work/plugwise-beta/plugwise-beta/custom_components/plugwise/manifest.json | cut -f 4 -d '"')
     - name: pytest
       run: |
         cd ~/ha-core

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,7 @@ jobs:
             git checkout dev
             script/setup
             . venv/bin/activate
-            pip install -r -q requirements_test.txt
+            pip install -q -r requirements_test.txt
         fi
         git log -1 | head -1 > ~/ha-core/.git/plugwise-tracking
 
@@ -119,7 +119,7 @@ jobs:
         . venv/bin/activate
         mkdir ~/tmp
         egrep -i "sqlalchemy|zeroconf|pyserial" requirements_test_all.txt > ~/tmp/requirements_test_extra.txt
-        pip install -r -q ~/tmp/requirements_test_extra.txt
+        pip install -q -r ~/tmp/requirements_test_extra.txt
         pip install -q $(grep require ~/work/plugwise-beta/plugwise-beta/custom_components/plugwise/manifest.json | cut -f 4 -d '"')
     - name: pytest
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -121,7 +121,12 @@ jobs:
         egrep -i "sqlalchemy|zeroconf|pyserial" requirements_test_all.txt > ~/tmp/requirements_test_extra.txt
         pip install -q -r ~/tmp/requirements_test_extra.txt
         pip install -q $(grep require ~/work/plugwise-beta/plugwise-beta/custom_components/plugwise/manifest.json | cut -f 4 -d '"')
-    - name: pytest
+    - name: Run tests
+      run: |
+        cd ~/ha-core
+        . venv/bin/activate
+        pytest -- tests/components/plugwise/
+    - name: Show coverage
       run: |
         cd ~/ha-core
         . venv/bin/activate

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.formatting.provider": "black"
+}

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 @laetificat, 2019-2021 @CoMPaTech & @bouwew & @brefra
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-** Read the release notes (<https://github.com/plugwise/plugwise-beta/releases>) before upgrading, in case there are BREAKING changes! **
+**:warning::warning::warning:Read the release notes (<https://github.com/plugwise/plugwise-beta/releases>) before upgrading, in case there are BREAKING changes!:warning::warning::warning:**
 
 # Plugwise Smile custom_component (BETA)
 
@@ -11,7 +11,7 @@ Our main usage for this module is supporting [Home Assistant](https://www.home-a
  [![HA-Core](https://github.com/plugwise/plugwise-beta/workflows/Test%20with%20HA-core/badge.svg)](https://github.com/plugwise/plugwise-beta/actions)
  [![Generic badge](https://img.shields.io/github/v/release/plugwise/plugwise-beta)](https://github.com/plugwise/plugwise-beta)
 
-A fully asynchronous approach to supporting Plugwise devices. This repository is **meant** for use of beta-testing.
+A fully asynchronous approach to supporting Plugwise devices. This repository is **meant** for use of beta-testing. As of March 2021 we include testing against latest `dev` in Home-Assistant Core, the above batches should indicate compatibility and compliance.
 
 ## New Mar 2021 [0.14.5]
 - Smile/Stretch

--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@
 Our main usage for this module is supporting [Home Assistant](https://www.home-assistant.io) / [home-assistant](http://github.com/home-assistant/core/)
 
  [![Maintenance](https://img.shields.io/badge/Maintained%3F-yes-green.svg)](https://github.com/plugwise)
- [![CodeFactor](https://www.codefactor.io/repository/github/plugwise/python-plugwise/badge)](https://www.codefactor.io/repository/github/plugwise/python-plugwise)
+ [![CodeFactor](https://www.codefactor.io/repository/github/plugwise/plugwise-beta/badge)](https://www.codefactor.io/repository/github/plugwise/plugwise-beta)
+ [![HASSfest](https://github.com/plugwise/plugwise-beta/workflows/Validate%20with%20hassfest/badge.svg)](https://github.com/plugwise/plugwise-beta/actions)
+ [![HA-Core](https://github.com/plugwise/plugwise-beta/workflows/Test%20with%20HA-core/badge.svg)](https://github.com/plugwise/plugwise-beta/actions)
  [![Generic badge](https://img.shields.io/github/v/release/plugwise/plugwise-beta)](https://github.com/plugwise/plugwise-beta)
- [![HASSfest](https://img.shields.io/badge/HASSfest%3F-view-blue.svg)](https://github.com/plugwise/plugwise-beta/actions)
 
 A fully asynchronous approach to supporting Plugwise devices. This repository is **meant** for use of beta-testing.
 

--- a/custom_components/plugwise/config_flow.py
+++ b/custom_components/plugwise/config_flow.py
@@ -222,7 +222,7 @@ class PlugwiseConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 )
             errors, api_stick = await validate_usb_connection(self.hass, device_path)
             if not errors:
-                await self.async_set_unique_id(api_stick.get_mac_stick())
+                await self.async_set_unique_id(api_stick.mac)
                 return self.async_create_entry(
                     title="Stick", data={CONF_USB_PATH: device_path, PW_TYPE: STICK}
                 )
@@ -310,7 +310,9 @@ class PlugwiseConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 return await self.async_step_user_usb()
 
         return self.async_show_form(
-            step_id="user", data_schema=CONNECTION_SCHEMA, errors=errors,
+            step_id="user",
+            data_schema=CONNECTION_SCHEMA,
+            errors=errors,
         )
 
     @staticmethod

--- a/custom_components/plugwise/config_flow.py
+++ b/custom_components/plugwise/config_flow.py
@@ -77,9 +77,6 @@ def plugwise_stick_entries(hass):
 async def validate_usb_connection(self, device_path=None) -> Dict[str, str]:
     """Test if device_path is a real Plugwise USB-Stick."""
     errors = {}
-    if device_path is None:
-        errors[CONF_BASE] = "connection_failed"
-        return errors, None
 
     # Avoid creating a 2nd connection to an already configured stick
     if device_path in plugwise_stick_entries(self):

--- a/scripts/core-testing.sh
+++ b/scripts/core-testing.sh
@@ -70,13 +70,13 @@ echo ""
 echo "Activating venv and installing selected test modules (zeroconf,pyserial, etc)"
 echo ""
 . venv/bin/activate
-mkdir ./tmp
+mkdir -p ./tmp
 grep -Ei "sqlalchemy|zeroconf|pyserial" requirements_test_all.txt > ./tmp/requirements_test_extra.txt
-pip install -q -r ./tmp/requirements_test_extra.txt
+pip install -q --disable-pip-version-check -r ./tmp/requirements_test_extra.txt
 echo ""
 echo "Checking manifest for current python-plugwise to install"
 echo ""
-pip install -q $(grep require ../custom_components/plugwise/manifest.json | cut -f 4 -d '"')
+pip install -q --disable-pip-version-check $(grep require ../custom_components/plugwise/manifest.json | cut -f 4 -d '"')
 echo ""
 echo "Test commencing ..."
 echo ""

--- a/scripts/core-testing.sh
+++ b/scripts/core-testing.sh
@@ -72,11 +72,11 @@ echo ""
 . venv/bin/activate
 mkdir ./tmp
 grep -Ei "sqlalchemy|zeroconf|pyserial" requirements_test_all.txt > ./tmp/requirements_test_extra.txt
-pip install -r ./tmp/requirements_test_extra.txt
+pip install -q -r ./tmp/requirements_test_extra.txt
 echo ""
 echo "Checking manifest for current python-plugwise to install"
 echo ""
-pip install $(grep require ../custom_components/plugwise/manifest.json | cut -f 4 -d '"')
+pip install -q $(grep require ../custom_components/plugwise/manifest.json | cut -f 4 -d '"')
 echo ""
 echo "Test commencing ..."
 echo ""

--- a/tests/components/plugwise/test_config_flow.py
+++ b/tests/components/plugwise/test_config_flow.py
@@ -654,9 +654,9 @@ async def test_timeout_exception(hass):
 
 def test_get_serial_by_id_no_dir():
     """Test serial by id conversion if there's no /dev/serial/by-id."""
-    p1 = patch("os.path.isdir", MagicMock(return_value=False))
-    p2 = patch("os.scandir")
-    with p1 as is_dir_mock, p2 as scan_mock:
+    with patch("os.path.isdir", MagicMock(return_value=False)) as is_dir_mock, patch(
+        "os.scandir"
+    ) as scan_mock:
         res = get_serial_by_id(sentinel.path)
         assert res is sentinel.path
         assert is_dir_mock.call_count == 1
@@ -665,16 +665,15 @@ def test_get_serial_by_id_no_dir():
 
 def test_get_serial_by_id():
     """Test serial by id conversion."""
-    p1 = patch("os.path.isdir", MagicMock(return_value=True))
-    p2 = patch("os.scandir")
 
     def _realpath(path):
         if path is sentinel.matched_link:
             return sentinel.path
         return sentinel.serial_link_path
 
-    p3 = patch("os.path.realpath", side_effect=_realpath)
-    with p1 as is_dir_mock, p2 as scan_mock, p3:
+    with patch("os.path.isdir", MagicMock(return_value=True)) as is_dir_mock, patch(
+        "os.scandir"
+    ) as scan_mock, patch("os.path.realpath", side_effect=_realpath):
         res = get_serial_by_id(sentinel.path)
         assert res is sentinel.path
         assert is_dir_mock.call_count == 1

--- a/tests/components/plugwise/test_config_flow.py
+++ b/tests/components/plugwise/test_config_flow.py
@@ -1,22 +1,35 @@
 """Test the Plugwise config flow."""
-from unittest.mock import AsyncMock, MagicMock, patch
+import os
+from unittest.mock import AsyncMock, MagicMock, patch, sentinel
 
 from plugwise.exceptions import (
     ConnectionFailedError,
     InvalidAuthentication,
+    NetworkDown,
     PlugwiseException,
+    StickInitError,
+    TimeoutException,
 )
 import pytest
+import serial.tools.list_ports
+from voluptuous.error import MultipleInvalid
 
 from homeassistant import setup
+from homeassistant.components.plugwise.config_flow import (
+    CONF_MANUAL_PATH,
+    get_serial_by_id,
+)
 from homeassistant.components.plugwise.const import (
     API,
+    CONF_USB_PATH,
     DEFAULT_PORT,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
     FLOW_TYPE,
     FLOW_NET,
+    FLOW_USB,
     PW_TYPE,
+    STICK,
 )
 from homeassistant.config_entries import SOURCE_USER, SOURCE_ZEROCONF
 from homeassistant.const import (
@@ -37,6 +50,8 @@ TEST_HOSTNAME = "smileabcdef"
 TEST_HOSTNAME2 = "stretchabc"
 TEST_PASSWORD = "test_password"
 TEST_PORT = 81
+TEST_USBPORT = "/dev/ttyUSB1"
+TEST_USBPORT2 = "/dev/ttyUSB2"
 TEST_USERNAME = "smile"
 TEST_USERNAME2 = "stretch"
 
@@ -77,6 +92,16 @@ def mock_smile():
         yield smile_mock.return_value
 
 
+def com_port():
+    """Mock of a serial port."""
+    port = serial.tools.list_ports_common.ListPortInfo(TEST_USBPORT)
+    port.serial_number = "1234"
+    port.manufacturer = "Virtual serial port"
+    port.device = TEST_USBPORT
+    port.description = "Some serial port"
+    return port
+
+
 async def test_form_flow_gateway(hass):
     """Test we get the form for Plugwise Gateway product type."""
     await setup.async_setup_component(hass, "persistent_notification", {})
@@ -93,6 +118,24 @@ async def test_form_flow_gateway(hass):
     assert result["type"] == RESULT_TYPE_FORM
     assert result["errors"] == {}
     assert result["step_id"] == "user_gateway"
+
+
+async def test_form_flow_usb(hass):
+    """Test we get the form for Plugwise USB product type."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={CONF_SOURCE: SOURCE_USER}
+    )
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["errors"] == {}
+    assert result["step_id"] == "user"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={FLOW_TYPE: FLOW_USB}
+    )
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["errors"] == {}
+    assert result["step_id"] == "user_usb"
 
 
 async def test_form(hass):
@@ -434,3 +477,223 @@ async def test_options_flow_thermo(hass, mock_smile) -> None:
         assert result["data"] == {
             CONF_SCAN_INTERVAL: 60,
         }
+
+
+@patch("serial.tools.list_ports.comports", MagicMock(return_value=[com_port()]))
+@patch("plugwise.stick.connect", MagicMock(return_value=None))
+@patch("plugwise.stick.initialize_stick", MagicMock(return_value=None))
+@patch("plugwise.stick.disconnect", MagicMock(return_value=None))
+async def test_user_flow_select(hass):
+    """Test user flow when USB-stick is selected from list."""
+    port = com_port()
+    port_select = f"{port}, s/n: {port.serial_number} - {port.manufacturer}"
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={CONF_SOURCE: SOURCE_USER}, data={FLOW_TYPE: FLOW_USB}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={CONF_USB_PATH: port_select}
+    )
+    assert result["type"] == RESULT_TYPE_CREATE_ENTRY
+    assert result["data"] == {PW_TYPE: STICK, CONF_USB_PATH: TEST_USBPORT}
+
+    # Retry to ensure configuring the same port is not allowed
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={CONF_SOURCE: SOURCE_USER}, data={FLOW_TYPE: FLOW_USB}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={CONF_USB_PATH: port_select}
+    )
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["errors"] == {"base": "already_configured"}
+
+
+async def test_user_flow_manual_selected_show_form(hass):
+    """Test user step form when manual path is selected."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={CONF_SOURCE: SOURCE_USER}, data={FLOW_TYPE: FLOW_USB}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_USB_PATH: CONF_MANUAL_PATH},
+    )
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["step_id"] == "manual_path"
+
+
+async def test_user_flow_manual(hass):
+    """Test user flow when USB-stick is manually entered."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={CONF_SOURCE: SOURCE_USER}, data={FLOW_TYPE: FLOW_USB}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_USB_PATH: CONF_MANUAL_PATH},
+    )
+
+    with patch(
+        "homeassistant.components.plugwise.config_flow.stick",
+    ) as usb_mock:
+        usb_mock.return_value.connect = MagicMock(return_value=True)
+        usb_mock.return_value.initialize_stick = MagicMock(return_value=True)
+        usb_mock.return_value.disconnect = MagicMock(return_value=True)
+        usb_mock.return_value.mac = "01:23:45:67:AB"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={CONF_USB_PATH: TEST_USBPORT2},
+        )
+    assert result["type"] == RESULT_TYPE_CREATE_ENTRY
+    assert result["data"] == {CONF_USB_PATH: TEST_USBPORT2}
+
+
+async def test_invalid_connection(hass):
+    """Test invalid connection."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={CONF_SOURCE: SOURCE_USER}, data={FLOW_TYPE: FLOW_USB}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_USB_PATH: CONF_MANUAL_PATH},
+    )
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_USB_PATH: "/dev/null"},
+    )
+
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["errors"] == {"base": "cannot_connect"}
+
+
+async def test_empty_connection(hass):
+    """Test empty connection."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={CONF_SOURCE: SOURCE_USER}, data={FLOW_TYPE: FLOW_USB}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_USB_PATH: CONF_MANUAL_PATH},
+    )
+
+    try:
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_USB_PATH: None},
+        )
+        assert False
+    except MultipleInvalid:
+        assert True
+
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["errors"] == {}
+
+
+@patch("plugwise.stick.connect", MagicMock(return_value=None))
+@patch("plugwise.stick.initialize_stick", MagicMock(side_effect=(StickInitError)))
+async def test_failed_initialization(hass):
+    """Test we handle failed initialization of Plugwise USB-stick."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={CONF_SOURCE: SOURCE_USER},
+        data={FLOW_TYPE: FLOW_USB},
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_USB_PATH: CONF_MANUAL_PATH},
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_USB_PATH: "/dev/null"},
+    )
+    assert result["type"] == "form"
+    assert result["errors"] == {"base": "stick_init"}
+
+
+@patch("plugwise.stick.connect", MagicMock(return_value=None))
+@patch("plugwise.stick.initialize_stick", MagicMock(side_effect=(NetworkDown)))
+async def test_network_down_exception(hass):
+    """Test we handle network_down exception."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={CONF_SOURCE: SOURCE_USER},
+        data={FLOW_TYPE: FLOW_USB},
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_USB_PATH: CONF_MANUAL_PATH},
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_USB_PATH: "/dev/null"},
+    )
+    assert result["type"] == "form"
+    assert result["errors"] == {"base": "network_down"}
+
+
+@patch("plugwise.stick.connect", MagicMock(return_value=None))
+@patch("plugwise.stick.initialize_stick", MagicMock(side_effect=(TimeoutException)))
+async def test_timeout_exception(hass):
+    """Test we handle time exception."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={CONF_SOURCE: SOURCE_USER},
+        data={FLOW_TYPE: FLOW_USB},
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_USB_PATH: CONF_MANUAL_PATH},
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_USB_PATH: "/dev/null"},
+    )
+    assert result["type"] == "form"
+    assert result["errors"] == {"base": "network_timeout"}
+
+
+def test_get_serial_by_id_no_dir():
+    """Test serial by id conversion if there's no /dev/serial/by-id."""
+    p1 = patch("os.path.isdir", MagicMock(return_value=False))
+    p2 = patch("os.scandir")
+    with p1 as is_dir_mock, p2 as scan_mock:
+        res = get_serial_by_id(sentinel.path)
+        assert res is sentinel.path
+        assert is_dir_mock.call_count == 1
+        assert scan_mock.call_count == 0
+
+
+def test_get_serial_by_id():
+    """Test serial by id conversion."""
+    p1 = patch("os.path.isdir", MagicMock(return_value=True))
+    p2 = patch("os.scandir")
+
+    def _realpath(path):
+        if path is sentinel.matched_link:
+            return sentinel.path
+        return sentinel.serial_link_path
+
+    p3 = patch("os.path.realpath", side_effect=_realpath)
+    with p1 as is_dir_mock, p2 as scan_mock, p3:
+        res = get_serial_by_id(sentinel.path)
+        assert res is sentinel.path
+        assert is_dir_mock.call_count == 1
+        assert scan_mock.call_count == 1
+
+        entry1 = MagicMock(spec_set=os.DirEntry)
+        entry1.is_symlink.return_value = True
+        entry1.path = sentinel.some_path
+
+        entry2 = MagicMock(spec_set=os.DirEntry)
+        entry2.is_symlink.return_value = False
+        entry2.path = sentinel.other_path
+
+        entry3 = MagicMock(spec_set=os.DirEntry)
+        entry3.is_symlink.return_value = True
+        entry3.path = sentinel.matched_link
+
+        scan_mock.return_value = [entry1, entry2, entry3]
+        res = get_serial_by_id(sentinel.path)
+        assert res is sentinel.matched_link
+        assert is_dir_mock.call_count == 2
+        assert scan_mock.call_count == 2


### PR DESCRIPTION
Add tests from 'plugwise-usb' commits (PR at core)

Quiesce testing some more

Rework 'with p1 as ...' as codefactor found these pylint-confusing

Rework the PlugwiseNode->FakeStick construction of plugwise-usb to inline patching (and follow conformant use of mac vs get_mac_stick)