### PR TITLE
Complete config_flow coverage

### DIFF
--- a/.bandit
+++ b/.bandit
@@ -1,0 +1,2 @@
+[bandit]
+skips: B105

--- a/custom_components/plugwise/config_flow.py
+++ b/custom_components/plugwise/config_flow.py
@@ -213,6 +213,10 @@ class PlugwiseConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 device_path = await self.hass.async_add_executor_job(
                     get_serial_by_id, port.device
                 )
+            else:
+                 device_path = await self.hass.async_add_executor_job(
+                     get_serial_by_id, user_selection
+                 )
             errors, api_stick = await validate_usb_connection(self.hass, device_path)
             if not errors:
                 await self.async_set_unique_id(api_stick.mac)

--- a/custom_components/plugwise/config_flow.py
+++ b/custom_components/plugwise/config_flow.py
@@ -206,17 +206,14 @@ class PlugwiseConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             user_input.pop(FLOW_TYPE, None)
             user_selection = user_input[CONF_USB_PATH]
+
             if user_selection == CONF_MANUAL_PATH:
                 return await self.async_step_manual_path()
-            if user_selection in list_of_ports:
-                port = ports[list_of_ports.index(user_selection)]
-                device_path = await self.hass.async_add_executor_job(
-                    get_serial_by_id, port.device
-                )
-            else:
-                 device_path = await self.hass.async_add_executor_job(
-                     get_serial_by_id, user_selection
-                 )
+
+            port = ports[list_of_ports.index(user_selection)]
+            device_path = await self.hass.async_add_executor_job(
+                get_serial_by_id, port.device
+            )
             errors, api_stick = await validate_usb_connection(self.hass, device_path)
             if not errors:
                 await self.async_set_unique_id(api_stick.mac)

--- a/custom_components/plugwise/config_flow.py
+++ b/custom_components/plugwise/config_flow.py
@@ -213,10 +213,6 @@ class PlugwiseConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 device_path = await self.hass.async_add_executor_job(
                     get_serial_by_id, port.device
                 )
-            else:
-                device_path = await self.hass.async_add_executor_job(
-                    get_serial_by_id, user_selection
-                )
             errors, api_stick = await validate_usb_connection(self.hass, device_path)
             if not errors:
                 await self.async_set_unique_id(api_stick.mac)

--- a/scripts/core-testing.sh
+++ b/scripts/core-testing.sh
@@ -80,6 +80,7 @@ echo ""
 mkdir -p ./tmp
 grep -Ei "sqlalchemy|zeroconf|pyserial" requirements_test_all.txt > ./tmp/requirements_test_extra.txt
 pip install -q --disable-pip-version-check -r ./tmp/requirements_test_extra.txt
+pip install -q flake8
 echo ""
 echo "Checking manifest for current python-plugwise to install"
 echo ""
@@ -87,13 +88,8 @@ pip install -q --disable-pip-version-check $(grep require ../custom_components/p
 echo ""
 echo "Test commencing ..."
 echo ""
-pytest $2 --cov=homeassistant/components/plugwise/ --cov-report term-missing -- tests/components/plugwise/$1
+pytest $2 --cov=homeassistant/components/plugwise/ --cov-report term-missing -- tests/components/plugwise/$1 && echo "" && echo "... flake8-ing ..." && flake8 homeassistant/components/plugwise/*py && echo "..." && flake8 tests/components/plugwise/*py && echo "... pylint-ing ..." && pylint homeassistant/components/plugwise/*py && echo "... black-ing ..." && black homeassistant/components/plugwise/*py tests/components/plugwise/*py
 deactivate
 
-# Future, flake/pylint as well (not rewritten yet from test.yml workflow)
-#        pip install flake8
-#        flake8 homeassistant/components/plugwise/*py
-#        flake8 tests/components/plugwise/*py
-#        pylint homeassistant/components/plugwise/*py
 #        # disable for further figuring out, apparently HA doesn't pylint against test
 #        #pylint tests/components/plugwise/*py

--- a/scripts/core-testing.sh
+++ b/scripts/core-testing.sh
@@ -1,5 +1,12 @@
 #!/bin/sh
 
+# If you want to test a single file
+# run as "scripts/core_testing.sh test_config_flow.py" or 
+# "scripts/core_testing.sh test_sensor.py"
+#
+# if you fancy more options (i.e. show test results)
+# run as "scripts/core_testing.sh test_config_flow.py -rP"
+
 which python3.9 || ( echo "You should have python3.9 installed, or change the script yourself, exiting"; exit 1)
 which git || ( echo "You should have git installed, exiting"; exit 1)
 
@@ -80,7 +87,7 @@ pip install -q --disable-pip-version-check $(grep require ../custom_components/p
 echo ""
 echo "Test commencing ..."
 echo ""
-pytest --cov=homeassistant/components/plugwise/ --cov-report term-missing -- tests/components/plugwise/$1
+pytest $2 --cov=homeassistant/components/plugwise/ --cov-report term-missing -- tests/components/plugwise/$1
 deactivate
 
 # Future, flake/pylint as well (not rewritten yet from test.yml workflow)

--- a/tests/components/plugwise/test_config_flow.py
+++ b/tests/components/plugwise/test_config_flow.py
@@ -744,15 +744,3 @@ async def test_options_flow_stick_with_input(hass) -> None:
         assert result["type"] == RESULT_TYPE_CREATE_ENTRY
         assert result["title"] == ""
 
-
-async def test_user_flow_manual_usb2(hass):
-    """Test user step form when manual path is selected."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={CONF_SOURCE: SOURCE_USER}, data={FLOW_TYPE: FLOW_USB}
-    )
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        user_input={CONF_USB_PATH: TEST_USBPORT2},
-    )
-    assert result["type"] == RESULT_TYPE_FORM
-    assert result["step_id"] == "manual_path"

--- a/tests/components/plugwise/test_config_flow.py
+++ b/tests/components/plugwise/test_config_flow.py
@@ -743,4 +743,3 @@ async def test_options_flow_stick_with_input(hass) -> None:
 
         assert result["type"] == RESULT_TYPE_CREATE_ENTRY
         assert result["title"] == ""
-

--- a/tests/components/plugwise/test_config_flow.py
+++ b/tests/components/plugwise/test_config_flow.py
@@ -696,3 +696,49 @@ def test_get_serial_by_id():
         assert res is sentinel.matched_link
         assert is_dir_mock.call_count == 2
         assert scan_mock.call_count == 2
+
+async def test_options_flow_stick(hass) -> None:
+    """Test config flow options lack for stick environments."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title=CONF_NAME,
+        data={FLOW_TYPE: FLOW_USB},
+    )
+    hass.data[DOMAIN] = {entry.entry_id: {"api_stick": MagicMock()}}
+    entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.plugwise.async_setup_entry", return_value=True
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        result = await hass.config_entries.options.async_init(entry.entry_id)
+
+        assert result["type"] == RESULT_TYPE_FORM
+        assert result["step_id"] == "none"
+
+async def test_options_flow_stick_with_input(hass) -> None:
+    """Test config flow options lack for stick environments."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title=CONF_NAME,
+        data={FLOW_TYPE: FLOW_USB},
+    )
+    hass.data[DOMAIN] = {entry.entry_id: {"api_stick": MagicMock()}}
+    entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.plugwise.async_setup_entry", return_value=True
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        result = await hass.config_entries.options.async_init(entry.entry_id)
+        result = await hass.config_entries.options.async_configure(
+             result["flow_id"], user_input={CONF_USB_PATH: TEST_USBPORT2},
+        )
+
+        assert result["type"] == RESULT_TYPE_CREATE_ENTRY
+        assert result["title"] == ""
+

--- a/tests/components/plugwise/test_config_flow.py
+++ b/tests/components/plugwise/test_config_flow.py
@@ -743,3 +743,16 @@ async def test_options_flow_stick_with_input(hass) -> None:
 
         assert result["type"] == RESULT_TYPE_CREATE_ENTRY
         assert result["title"] == ""
+
+
+async def test_user_flow_manual_usb2(hass):
+    """Test user step form when manual path is selected."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={CONF_SOURCE: SOURCE_USER}, data={FLOW_TYPE: FLOW_USB}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_USB_PATH: TEST_USBPORT2},
+    )
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["step_id"] == "manual_path"

--- a/tests/components/plugwise/test_config_flow.py
+++ b/tests/components/plugwise/test_config_flow.py
@@ -697,6 +697,7 @@ def test_get_serial_by_id():
         assert is_dir_mock.call_count == 2
         assert scan_mock.call_count == 2
 
+
 async def test_options_flow_stick(hass) -> None:
     """Test config flow options lack for stick environments."""
     entry = MockConfigEntry(
@@ -718,6 +719,7 @@ async def test_options_flow_stick(hass) -> None:
         assert result["type"] == RESULT_TYPE_FORM
         assert result["step_id"] == "none"
 
+
 async def test_options_flow_stick_with_input(hass) -> None:
     """Test config flow options lack for stick environments."""
     entry = MockConfigEntry(
@@ -736,9 +738,8 @@ async def test_options_flow_stick_with_input(hass) -> None:
 
         result = await hass.config_entries.options.async_init(entry.entry_id)
         result = await hass.config_entries.options.async_configure(
-             result["flow_id"], user_input={CONF_USB_PATH: TEST_USBPORT2},
+            result["flow_id"], user_input={CONF_USB_PATH: TEST_USBPORT2},
         )
 
         assert result["type"] == RESULT_TYPE_CREATE_ENTRY
         assert result["title"] == ""
-


### PR DESCRIPTION
Forementioned (#158 and #160) lines were all about stick (usb), L217 wasn't reachable as per design (user can only select from listed ports or manual) so that part was removed. Added testing part for options while using a stick.

Should result in 100% coverage on config_flow (and therefore for upstreaming)