### PR TITLE
Adapt to changed storage format of "system options" in HA 2021.6

### DIFF
--- a/custom_components/plugwise/manifest.json
+++ b/custom_components/plugwise/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "plugwise",
   "name": "Plugwise Beta",
-  "version": "0.14.6",
+  "version": "0.15.0b2",
   "documentation": "https://github.com/plugwise/plugwise-beta",
   "requirements": ["plugwise==0.9.4"],
   "codeowners": ["@CoMPaTech","@bouwew","@brefra"],

--- a/custom_components/plugwise/manifest.json
+++ b/custom_components/plugwise/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "plugwise",
   "name": "Plugwise Beta",
-  "version": "0.15.0b2",
+  "version": "0.14.7",
   "documentation": "https://github.com/plugwise/plugwise-beta",
   "requirements": ["plugwise==0.9.4"],
   "codeowners": ["@CoMPaTech","@bouwew","@brefra"],

--- a/tests/components/plugwise/test_binary_sensor.py
+++ b/tests/components/plugwise/test_binary_sensor.py
@@ -1,6 +1,6 @@
 """Tests for the Plugwise binary_sensor integration."""
 
-from homeassistant.config_entries import ENTRY_STATE_LOADED
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.helpers.entity_registry import async_get_registry
 
@@ -10,7 +10,7 @@ from tests.components.plugwise.common import async_init_integration
 async def test_anna_climate_binary_sensor_entities(hass, mock_smile_anna):
     """Test creation of climate related binary_sensor entities."""
     entry = await async_init_integration(hass, mock_smile_anna)
-    assert entry.state == ENTRY_STATE_LOADED
+    assert entry.state == ConfigEntryState.LOADED
 
     state = hass.states.get("binary_sensor.auxiliary_secondary_heater_device_state")
     assert str(state.state) == STATE_OFF
@@ -22,7 +22,7 @@ async def test_anna_climate_binary_sensor_entities(hass, mock_smile_anna):
 async def test_anna_climate_binary_sensor_change(hass, mock_smile_anna):
     """Test change of climate related binary_sensor entities."""
     entry = await async_init_integration(hass, mock_smile_anna)
-    assert entry.state == ENTRY_STATE_LOADED
+    assert entry.state == ConfigEntryState.LOADED
 
     hass.states.async_set("binary_sensor.auxiliary_dhw_state", STATE_ON, {})
     await hass.async_block_till_done()
@@ -44,7 +44,7 @@ async def test_adam_climate_binary_sensor_change(hass, mock_smile_adam):
     n_sensor = "binary_sensor.adam_plugwise_notification"
 
     entry = await async_init_integration(hass, mock_smile_adam)
-    assert entry.state == ENTRY_STATE_LOADED
+    assert entry.state == ConfigEntryState.LOADED
 
     # Enable the notification sensor
     registry = await async_get_registry(hass)

--- a/tests/components/plugwise/test_climate.py
+++ b/tests/components/plugwise/test_climate.py
@@ -7,7 +7,7 @@ from homeassistant.components.climate.const import (
     HVAC_MODE_HEAT,
     HVAC_MODE_OFF,
 )
-from homeassistant.config_entries import ENTRY_STATE_LOADED
+from homeassistant.config_entries import ConfigEntryState
 
 from tests.components.plugwise.common import async_init_integration
 
@@ -15,7 +15,7 @@ from tests.components.plugwise.common import async_init_integration
 async def test_adam_climate_entity_attributes(hass, mock_smile_adam):
     """Test creation of adam climate device environment."""
     entry = await async_init_integration(hass, mock_smile_adam)
-    assert entry.state == ENTRY_STATE_LOADED
+    assert entry.state == ConfigEntryState.LOADED
 
     state = hass.states.get("climate.zone_lisa_wk")
     attrs = state.attributes
@@ -54,7 +54,7 @@ async def test_adam_climate_adjust_negative_testing(hass, mock_smile_adam):
     mock_smile_adam.set_schedule_state.side_effect = PlugwiseException
     mock_smile_adam.set_temperature.side_effect = PlugwiseException
     entry = await async_init_integration(hass, mock_smile_adam)
-    assert entry.state == ENTRY_STATE_LOADED
+    assert entry.state == ConfigEntryState.LOADED
 
     await hass.services.async_call(
         "climate",
@@ -89,7 +89,7 @@ async def test_adam_climate_adjust_negative_testing(hass, mock_smile_adam):
 async def test_adam_climate_entity_climate_changes(hass, mock_smile_adam):
     """Test handling of user requests in adam climate device environment."""
     entry = await async_init_integration(hass, mock_smile_adam)
-    assert entry.state == ENTRY_STATE_LOADED
+    assert entry.state == ConfigEntryState.LOADED
 
     await hass.services.async_call(
         "climate",
@@ -142,7 +142,7 @@ async def test_adam_climate_entity_climate_changes(hass, mock_smile_adam):
 async def test_anna_climate_entity_attributes(hass, mock_smile_anna):
     """Test creation of anna climate device environment."""
     entry = await async_init_integration(hass, mock_smile_anna)
-    assert entry.state == ENTRY_STATE_LOADED
+    assert entry.state == ConfigEntryState.LOADED
 
     state = hass.states.get("climate.anna")
     attrs = state.attributes
@@ -167,7 +167,7 @@ async def test_anna_climate_entity_attributes(hass, mock_smile_anna):
 async def test_anna_climate_entity_climate_changes(hass, mock_smile_anna):
     """Test handling of user requests in anna climate device environment."""
     entry = await async_init_integration(hass, mock_smile_anna)
-    assert entry.state == ENTRY_STATE_LOADED
+    assert entry.state == ConfigEntryState.LOADED
 
     await hass.services.async_call(
         "climate",

--- a/tests/components/plugwise/test_init.py
+++ b/tests/components/plugwise/test_init.py
@@ -5,11 +5,7 @@ import asyncio
 from plugwise.exceptions import XMLDataMissingError
 
 from homeassistant.components.plugwise.const import DOMAIN
-from homeassistant.config_entries import (
-    ENTRY_STATE_NOT_LOADED,
-    ENTRY_STATE_SETUP_ERROR,
-    ENTRY_STATE_SETUP_RETRY,
-)
+from homeassistant.config_entries import ConfigEntryState
 
 from tests.common import AsyncMock, MockConfigEntry
 from tests.components.plugwise.common import async_init_integration
@@ -18,34 +14,34 @@ from tests.components.plugwise.common import async_init_integration
 async def test_smile_unauthorized(hass, mock_smile_unauth):
     """Test failing unauthorization by Smile."""
     entry = await async_init_integration(hass, mock_smile_unauth)
-    assert entry.state == ENTRY_STATE_SETUP_ERROR
+    assert entry.state == ConfigEntryState.SETUP_ERROR
 
 
 async def test_smile_error(hass, mock_smile_error):
     """Test server error handling by Smile."""
     entry = await async_init_integration(hass, mock_smile_error)
-    assert entry.state == ENTRY_STATE_SETUP_RETRY
+    assert entry.state == ConfigEntryState.SETUP_RETRY
 
 
 async def test_smile_notconnect(hass, mock_smile_notconnect):
     """Connection failure error handling by Smile."""
     mock_smile_notconnect.connect.return_value = False
     entry = await async_init_integration(hass, mock_smile_notconnect)
-    assert entry.state == ENTRY_STATE_SETUP_RETRY
+    assert entry.state == ConfigEntryState.SETUP_RETRY
 
 
 async def test_smile_timeout(hass, mock_smile_notconnect):
     """Timeout error handling by Smile."""
     mock_smile_notconnect.connect.side_effect = asyncio.TimeoutError
     entry = await async_init_integration(hass, mock_smile_notconnect)
-    assert entry.state == ENTRY_STATE_SETUP_RETRY
+    assert entry.state == ConfigEntryState.SETUP_RETRY
 
 
 async def test_smile_adam_xmlerror(hass, mock_smile_adam):
     """Detect malformed XML by Smile in Adam environment."""
     mock_smile_adam.update_device.side_effect = XMLDataMissingError
     entry = await async_init_integration(hass, mock_smile_adam)
-    assert entry.state == ENTRY_STATE_SETUP_RETRY
+    assert entry.state == ConfigEntryState.SETUP_RETRY
 
 
 async def test_unload_entry(hass, mock_smile_adam):
@@ -55,7 +51,7 @@ async def test_unload_entry(hass, mock_smile_adam):
     mock_smile_adam.async_reset = AsyncMock(return_value=True)
     await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
-    assert entry.state == ENTRY_STATE_NOT_LOADED
+    assert entry.state == ConfigEntryState.NOT_LOADED
     assert not hass.data[DOMAIN]
 
 
@@ -66,4 +62,4 @@ async def test_async_setup_entry_fail(hass):
     entry.add_to_hass(hass)
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
-    assert entry.state == ENTRY_STATE_SETUP_ERROR
+    assert entry.state == ConfigEntryState.SETUP_ERROR

--- a/tests/components/plugwise/test_sensor.py
+++ b/tests/components/plugwise/test_sensor.py
@@ -1,6 +1,6 @@
 """Tests for the Plugwise Sensor integration."""
 
-from homeassistant.config_entries import ENTRY_STATE_LOADED
+from homeassistant.config_entries import ConfigEntryState
 
 from tests.common import Mock
 from tests.components.plugwise.common import async_init_integration
@@ -9,7 +9,7 @@ from tests.components.plugwise.common import async_init_integration
 async def test_adam_climate_sensor_entities(hass, mock_smile_adam):
     """Test creation of climate related sensor entities."""
     entry = await async_init_integration(hass, mock_smile_adam)
-    assert entry.state == ENTRY_STATE_LOADED
+    assert entry.state == ConfigEntryState.LOADED
 
     state = hass.states.get("sensor.adam_outdoor_temperature")
     assert float(state.state) == 7.81
@@ -31,7 +31,7 @@ async def test_adam_climate_sensor_entities(hass, mock_smile_adam):
 async def test_anna_as_smt_climate_sensor_entities(hass, mock_smile_anna):
     """Test creation of climate related sensor entities."""
     entry = await async_init_integration(hass, mock_smile_anna)
-    assert entry.state == ENTRY_STATE_LOADED
+    assert entry.state == ConfigEntryState.LOADED
 
     state = hass.states.get("sensor.auxiliary_outdoor_temperature")
     assert float(state.state) == 18.0
@@ -47,7 +47,7 @@ async def test_anna_climate_sensor_entities(hass, mock_smile_anna):
     """Test creation of climate related sensor entities as single master thermostat."""
     mock_smile_anna.single_master_thermostat.side_effect = Mock(return_value=False)
     entry = await async_init_integration(hass, mock_smile_anna)
-    assert entry.state == ENTRY_STATE_LOADED
+    assert entry.state == ConfigEntryState.LOADED
 
     state = hass.states.get("sensor.auxiliary_outdoor_temperature")
     assert float(state.state) == 18.0
@@ -56,7 +56,7 @@ async def test_anna_climate_sensor_entities(hass, mock_smile_anna):
 async def test_p1_dsmr_sensor_entities(hass, mock_smile_p1):
     """Test creation of power related sensor entities."""
     entry = await async_init_integration(hass, mock_smile_p1)
-    assert entry.state == ENTRY_STATE_LOADED
+    assert entry.state == ConfigEntryState.LOADED
 
     state = hass.states.get("sensor.p1_net_electricity_point")
     assert float(state.state) == -2761.0
@@ -77,7 +77,7 @@ async def test_p1_dsmr_sensor_entities(hass, mock_smile_p1):
 async def test_stretch_sensor_entities(hass, mock_stretch):
     """Test creation of power related sensor entities."""
     entry = await async_init_integration(hass, mock_stretch)
-    assert entry.state == ENTRY_STATE_LOADED
+    assert entry.state == ConfigEntryState.LOADED
 
     state = hass.states.get("sensor.koelkast_92c4a_electricity_consumed")
     assert float(state.state) == 50.5

--- a/tests/components/plugwise/test_switch.py
+++ b/tests/components/plugwise/test_switch.py
@@ -2,7 +2,7 @@
 
 from plugwise.exceptions import PlugwiseException
 
-from homeassistant.config_entries import ENTRY_STATE_LOADED
+from homeassistant.config_entries import ConfigEntryState
 
 from tests.components.plugwise.common import async_init_integration
 
@@ -10,7 +10,7 @@ from tests.components.plugwise.common import async_init_integration
 async def test_adam_climate_switch_entities(hass, mock_smile_adam):
     """Test creation of climate related switch entities."""
     entry = await async_init_integration(hass, mock_smile_adam)
-    assert entry.state == ENTRY_STATE_LOADED
+    assert entry.state == ConfigEntryState.LOADED
 
     state = hass.states.get("switch.cv_pomp")
     assert str(state.state) == "on"
@@ -23,7 +23,7 @@ async def test_adam_climate_switch_negative_testing(hass, mock_smile_adam):
     """Test exceptions of climate related switch entities."""
     mock_smile_adam.set_switch_state.side_effect = PlugwiseException
     entry = await async_init_integration(hass, mock_smile_adam)
-    assert entry.state == ENTRY_STATE_LOADED
+    assert entry.state == ConfigEntryState.LOADED
 
     await hass.services.async_call(
         "switch", "turn_off", {"entity_id": "switch.cv_pomp"}, blocking=True,
@@ -41,7 +41,7 @@ async def test_adam_climate_switch_negative_testing(hass, mock_smile_adam):
 async def test_adam_climate_switch_changes(hass, mock_smile_adam):
     """Test changing of climate related switch entities."""
     entry = await async_init_integration(hass, mock_smile_adam)
-    assert entry.state == ENTRY_STATE_LOADED
+    assert entry.state == ConfigEntryState.LOADED
 
     await hass.services.async_call(
         "switch", "turn_off", {"entity_id": "switch.cv_pomp"}, blocking=True,
@@ -65,7 +65,7 @@ async def test_adam_climate_switch_changes(hass, mock_smile_adam):
 async def test_stretch_switch_entities(hass, mock_stretch):
     """Test creation of climate related switch entities."""
     entry = await async_init_integration(hass, mock_stretch)
-    assert entry.state == ENTRY_STATE_LOADED
+    assert entry.state == ConfigEntryState.LOADED
 
     state = hass.states.get("switch.koelkast_92c4a")
     assert str(state.state) == "on"
@@ -77,7 +77,7 @@ async def test_stretch_switch_entities(hass, mock_stretch):
 async def test_stretch_switch_changes(hass, mock_stretch):
     """Test changing of power related switch entities."""
     entry = await async_init_integration(hass, mock_stretch)
-    assert entry.state == ENTRY_STATE_LOADED
+    assert entry.state == ConfigEntryState.LOADED
 
     await hass.services.async_call(
         "switch", "turn_off", {"entity_id": "switch.koelkast_92c4a"}, blocking=True,


### PR DESCRIPTION
This PR will fix issue #174

At Home Assistant version 2021.6 the stored format of "system options" [has changed](https://github.com/home-assistant/core/pull/51347). This PR will check for the HA version and use the proper stored field to retrieve the configured setting for "Enable newly added entities".