### PR TITLE
Fix missed parameter-change

### DIFF
--- a/custom_components/plugwise/switch.py
+++ b/custom_components/plugwise/switch.py
@@ -122,7 +122,7 @@ class GwSwitch(SmileGateway, SwitchEntity):
         self._icon = None
         self._is_on = False
         self._members = None
-        if "members" in api.devices[dev_id]:
+        if "members" in api.gw_devices[dev_id]:
             self._members = api.gw_devices[dev_id].get("members")
         self._name = f"{name} {sw_data.get(ATTR_NAME)}"
         self._switch = sw_data.get(ATTR_ID)


### PR DESCRIPTION
This faulty code still works with plugwise v0.16.0 but will no longer work with the next planned update, v0.16.1 (see the changes in https://github.com/plugwise/python-plugwise/tree/smile_private)