### PR TITLE
Add shellcheck and dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -219,3 +219,11 @@ jobs:
         echo "Running hassfest (plugwise-only)"
         echo ""
         python3 -m script.hassfest --integration-path homeassistant/components/plugwise
+
+  shellcheck:
+    name: Shellcheck
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Run ShellCheck
+      uses: ludeeus/action-shellcheck@master

--- a/scripts/core-testing.sh
+++ b/scripts/core-testing.sh
@@ -1,46 +1,88 @@
-#!/bin/sh
+#!/usr/bin/env bash
+set -eu
 
 # If you want to test a single file
-# run as "scripts/core_testing.sh test_config_flow.py" or 
+# run as "scripts/core_testing.sh test_config_flow.py" or
 # "scripts/core_testing.sh test_sensor.py"
 #
 # if you fancy more options (i.e. show test results)
 # run as "scripts/core_testing.sh test_config_flow.py -rP"
 
-which python3.9 || ( echo "You should have python3.9 installed, or change the script yourself, exiting"; exit 1)
+echo ""
+echo "Checking for neccesary tools and prearing setup:"
+
 which git || ( echo "You should have git installed, exiting"; exit 1)
+
+# Cloned/adjusted code from python-plugwise, note that we don't actually
+# use the 'venv', but instantiate it to ensure it works in the
+# ha-core testing later on
+
+
+pyversions=(3.9 dummy) # HA-Core is pinned to 3.8
+my_path=$(git rev-parse --show-toplevel)
+my_venv=${my_path}/venv
+
+# Ensures a python virtualenv is available at the highest available python3 version
+for pv in "${pyversions[@]};"; do
+    if [ "$(which "python$pv")" ]; then
+        # If not (yet) available instantiate python virtualenv
+        if [ ! -d "${my_venv}" ]; then
+            "python${pv}" -m venv "${my_venv}"
+            # Ensure wheel is installed (preventing local issues)
+            # shellcheck disable=SC1091
+            . "${my_venv}/bin/activate"
+        fi
+        break
+    fi
+done
+
+# shellcheck source=/dev/null
+. "${my_venv}/bin/activate"
+# shellcheck disable=2145
+which python3 || ( echo "You should have python3 (${pyversions[@]}) installed, or change the script yourself, exiting"; exit 1)
+python3 --version
+
+# Failsafe
+if [ ! -d "${my_venv}" ]; then
+    echo "Unable to instantiate venv, check your base python3 version and if you have python3-venv installed"
+    exit 1
+fi
+# /Cloned code
+
+# Handle variables
+subject=""
+basedir=""
+if [ $# -eq 2 ]; then
+	subject=$2
+fi
+if [ $# -gt 0 ]; then
+	basedir=$1
+fi
 
 # Handle sed on macos
 sedmac=""
-if [ $(uname -s) == "Darwin" ]; then sedmac="''"; fi
+# shellcheck disable=SC2089
+if [ "$(uname -s)" = "Darwin" ]; then sedmac="''"; fi
 
-if [ ! -d ha-core ]; then
-	echo ""
-	echo "This script expects to be executed from the 'root' of the cloned plugwise-beta directory"
-	echo "Then 'mkdir ha-core' and rerun this script (which will take some time, disk-space and prayers)"
-	echo ""
-	echo "Cowardly stopping now ... ow, and you *should* have python3.9 and virtualenv installed"
-	echo ""
-	echo "(this script largely resembles the 'Test with HA-core' action on github stored in .github/workflows/test.yml in the repo"
-	echo ""
-	exit 1
-fi
+# Ensure ha-core exists
+coredir="${my_path}/ha-core/"
+mkdir -p "${coredir}"
 
 # If only dir exists, but not cloned yet
-if [ ! -f ha-core/requirements_test_all.txt ]; then
+if [ ! -f "${coredir}/requirements_test_all.txt" ]; then
 	echo ""
 	echo " ** Cloning HA core **"
 	echo ""
-	git clone https://github.com/home-assistant/core.git ./ha-core
-        if [ ! -f ha-core/requirements_test_all.txt ]; then
+	git clone https://github.com/home-assistant/core.git "${coredir}"
+        if [ ! -f "${coredir}/requirements_test_all.txt" ]; then
 		echo ""
-		echo "Cloning failed .. make sure ./ha-core exists and is an empty directory"
+		echo "Cloning failed .. make sure ${coredir} exists and is an empty directory"
 		echo ""
 		echo "Stopping"
 		echo ""
 		exit 1
         fi
-	cd ./ha-core
+	cd "${coredir}" || exit
 	echo ""
 	echo " ** Resetting to dev **"
 	echo ""
@@ -49,15 +91,18 @@ if [ ! -f ha-core/requirements_test_all.txt ]; then
 	echo ""
 	echo " ** Running setup scrvipt from HA core **"
 	echo ""
-        python3.9 -m venv venv
+	# shellcheck source=/dev/null
+        . "${my_path}/venv/bin/activate"
+        python3 -m venv venv
 	script/setup
+	# shellcheck source=/dev/null
         . venv/bin/activate
 	echo ""
 	echo " ** Installing test requirements **"
 	echo ""
         pip install -r requirements_test.txt
 else
-        cd ./ha-core
+        cd "${coredir}" || exit
 	echo ""
 	echo " ** Restting/rebasing core **"
 	echo ""
@@ -79,6 +124,7 @@ cp -r ../tests/components/plugwise ./tests/components/
 echo ""
 echo "Activating venv and installing selected test modules (zeroconf,pyserial, etc)"
 echo ""
+# shellcheck source=/dev/null
 . venv/bin/activate
 mkdir -p ./tmp
 grep -hEi "pyroute2|sqlalchemy|zeroconf|pyserial|pytest-socket" requirements_test_all.txt requirements_test.txt > ./tmp/requirements_test_extra.txt
@@ -87,25 +133,36 @@ pip install -q flake8
 echo ""
 echo "Checking manifest for current python-plugwise to install"
 echo ""
-pip install -q --disable-pip-version-check $(grep require ../custom_components/plugwise/manifest.json | cut -f 4 -d '"')
+pip install -q --disable-pip-version-check "$(grep require ../custom_components/plugwise/manifest.json | cut -f 4 -d '"')"
 echo ""
 echo "Test commencing ..."
 echo ""
-pytest $2 --cov=homeassistant/components/plugwise/ --cov-report term-missing -- tests/components/plugwise/$1 && echo "" && echo "... flake8-ing ..." && flake8 homeassistant/components/plugwise/*py && echo "..." && flake8 tests/components/plugwise/*py && echo "... pylint-ing ..." && pylint homeassistant/components/plugwise/*py && echo "... black-ing ..." && black homeassistant/components/plugwise/*py tests/components/plugwise/*py
+# shellcheck disable=SC2086
+pytest ${subject} --cov=homeassistant/components/plugwise/ --cov-report term-missing -- "tests/components/plugwise/${basedir}" || exit
+echo ""
+echo "... flake8-ing component..."
+flake8 homeassistant/components/plugwise/*py|| exit
+echo "... flak8-ing tests..."
+flake8 tests/components/plugwise/*py || exit
+echo "... pylint-ing component ..."
+pylint homeassistant/components/plugwise/*py || exit
+echo "... black-ing ..."
+black homeassistant/components/plugwise/*py tests/components/plugwise/*py || exit
 echo ""
 echo "Copy back modified files ..."
 echo ""
 cp -r ./homeassistant/components/plugwise ../custom_components/
 cp -r ./tests/components/plugwise ../tests/components/
-echo "Removing 'version' from manifest for hassfest-ing (no version in core components)"
+echo "Removing 'version' from manifest for hassfest-ing, version not allowed in core components"
 echo ""
-sed -i ${sedmac} "/version.:/d" ./homeassistant/components/plugwise/manifest.json
-grep -q -E "require.*http.*test-files.pythonhosted.*#" ./homeassistant/components/plugwise/manifest.json && (
-  echo "Changing requirement for hassfest pass .... :("
-  sed -i ${sedmac} "s/http.*test-files.pythonhosted.*#//g" ./homeassistant/components/plugwise/manifest.json
+# shellcheck disable=SC2090
+sed -i ${sedmac} '/version.:/d' ./homeassistant/components/plugwise/manifest.json
+grep -q -E 'require.*http.*test-files.pythonhosted.*#' ./homeassistant/components/plugwise/manifest.json && (
+  echo "Changing requirement for hassfest pass ...."
+  # shellcheck disable=SC2090
+  sed -i ${sedmac} 's/http.*test-files.pythonhosted.*#//g' ./homeassistant/components/plugwise/manifest.json
 )
 echo "Running hassfest for plugwise"
-echo ""
 python3 -m script.hassfest --integration-path homeassistant/components/plugwise
 deactivate
 

--- a/scripts/core-testing.sh
+++ b/scripts/core-testing.sh
@@ -18,7 +18,7 @@ which git || ( echo "You should have git installed, exiting"; exit 1)
 # ha-core testing later on
 
 
-pyversions=(3.9 dummy) # HA-Core is pinned to 3.8
+pyversions=(3.9 dummy) # HA-Core is pinned to 3.9
 my_path=$(git rev-parse --show-toplevel)
 my_venv=${my_path}/venv
 


### PR DESCRIPTION
Tiny (cleanup) PR to add dependabot for the build actions and improve on our shell testcode.

Also makes running the test/coverage script easier (handling of ha-core directory)