### PR TITLE
Schedule service **POTENTIALLY BREAKING**

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,12 @@ Our [`python-plugwise`](https://github.com/plugwise/python-plugwise) python modu
 
 # Changelog
 
-## NEW MAR 2022 [0.21.5] (in development)
+## NEW MAR 2022 [0.21.5]
  - Smile:
   - **BREAKING** improved naming of the locally present outdoor temp sensor connected to the OpenTherm device: `outdoor_air_temperature`. The former `sensor.opentherm_outdoor_temperature` is now visible as `sensor.opentherm_outdoor_air_temperature`. Use of the zipcode based `outdoor_temperature` has not changed.
+  - **POTENTIALLY BREAKING** for consistency renamed schema to schedule, i.e. the attributes will now be `available_schedules` and `selected_schedule`
   - Link to plugwise v0.16.9 - https://github.com/plugwise/python-plugwise/releases/tag/v0.16.9
+  - Added schedule selector per thermostat using the new `select` platform
 
 ## NEW MAR 2022 [0.21.4]
 - Smile:

--- a/custom_components/plugwise/climate.py
+++ b/custom_components/plugwise/climate.py
@@ -141,8 +141,8 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity):
     def extra_state_attributes(self) -> Mapping[str, Any] | None:
         """Return entity specific state attributes."""
         return {
-            "available_schemas": self.device.get("available_schedules"),
-            "selected_schema": self.device.get("selected_schedule"),
+            "available_schedule": self.device.get("available_schedules"),
+            "selected_schedule": self.device.get("selected_schedule"),
         }
 
     @plugwise_command

--- a/custom_components/plugwise/const.py
+++ b/custom_components/plugwise/const.py
@@ -62,8 +62,10 @@ SENSOR_PLATFORMS = [Platform.SENSOR, Platform.SWITCH]
 SERVICE_DELETE = "delete_notification"
 SEVERITIES = ["other", "info", "warning", "error"]
 CONF_HOMEKIT_EMULATION = "homekit_emulation"  # pw-beta
+
+ATTR_SCHEMA_NAME = "name"
 SERVICE_SELECT = "select_schema"
-SERVICE_SELECT_SCHEMA = vol.Schema({vol.Required(ATTR_SCHEMA_NAME): cv.string})
+SERVICE_SELECT_SCHEMA = ({vol.Schema({vol.Required(ATTR_SCHEMA_NAME): cv.string}))}
 
 # Climate const:
 MASTER_THERMOSTATS = [
@@ -156,7 +158,6 @@ CB_JOIN_REQUEST = "JOIN_REQUEST"
 USB_AVAILABLE_ID = "available"
 
 ATTR_MAC_ADDRESS = "mac"
-ATTR_SCHEMA_NAME = "name"
 
 SERVICE_USB_DEVICE_ADD = "device_add"
 SERVICE_USB_DEVICE_REMOVE = "device_remove"

--- a/custom_components/plugwise/const.py
+++ b/custom_components/plugwise/const.py
@@ -55,12 +55,15 @@ PLATFORMS_GATEWAY = [
     Platform.BINARY_SENSOR,
     Platform.CLIMATE,
     Platform.SENSOR,
+    Platform.SELECT,
     Platform.SWITCH,
 ]
 SENSOR_PLATFORMS = [Platform.SENSOR, Platform.SWITCH]
 SERVICE_DELETE = "delete_notification"
 SEVERITIES = ["other", "info", "warning", "error"]
 CONF_HOMEKIT_EMULATION = "homekit_emulation"  # pw-beta
+SERVICE_SELECT = "select_schema"
+SERVICE_SELECT_SCHEMA = vol.Schema({vol.Required(ATTR_SCHEMA_NAME): cv.string})
 
 # Climate const:
 MASTER_THERMOSTATS = [
@@ -153,6 +156,7 @@ CB_JOIN_REQUEST = "JOIN_REQUEST"
 USB_AVAILABLE_ID = "available"
 
 ATTR_MAC_ADDRESS = "mac"
+ATTR_SCHEMA_NAME = "name"
 
 SERVICE_USB_DEVICE_ADD = "device_add"
 SERVICE_USB_DEVICE_REMOVE = "device_remove"

--- a/custom_components/plugwise/const.py
+++ b/custom_components/plugwise/const.py
@@ -63,10 +63,6 @@ SERVICE_DELETE = "delete_notification"
 SEVERITIES = ["other", "info", "warning", "error"]
 CONF_HOMEKIT_EMULATION = "homekit_emulation"  # pw-beta
 
-ATTR_SCHEMA_NAME = "schema"
-SERVICE_SELECT = "select_schema"
-SERVICE_SELECT_SCHEMA = vol.Schema({vol.Required(ATTR_SCHEMA_NAME): cv.string})
-
 # Climate const:
 MASTER_THERMOSTATS = [
     "thermostat",

--- a/custom_components/plugwise/const.py
+++ b/custom_components/plugwise/const.py
@@ -63,9 +63,9 @@ SERVICE_DELETE = "delete_notification"
 SEVERITIES = ["other", "info", "warning", "error"]
 CONF_HOMEKIT_EMULATION = "homekit_emulation"  # pw-beta
 
-ATTR_SCHEMA_NAME = "name"
+ATTR_SCHEMA_NAME = "schema"
 SERVICE_SELECT = "select_schema"
-SERVICE_SELECT_SCHEMA = ({vol.Schema({vol.Required(ATTR_SCHEMA_NAME): cv.string}))}
+SERVICE_SELECT_SCHEMA = vol.Schema({vol.Required(ATTR_SCHEMA_NAME): cv.string})
 
 # Climate const:
 MASTER_THERMOSTATS = [

--- a/custom_components/plugwise/manifest.json
+++ b/custom_components/plugwise/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "plugwise",
   "name": "Plugwise Beta",
-  "version": "0.21.5a4",
+  "version": "0.21.5",
   "documentation": "https://github.com/plugwise/plugwise-beta",
   "after_dependencies": ["usb", "zeroconf"],
   "requirements": ["plugwise==0.16.9"],

--- a/custom_components/plugwise/select.py
+++ b/custom_components/plugwise/select.py
@@ -10,7 +10,6 @@ from .const import (
     COORDINATOR,
     DOMAIN,
     MASTER_THERMOSTATS,
-    PW_TYPE,
     SCHEDULE_ON,
 )
 from .coordinator import PlugwiseDataUpdateCoordinator

--- a/custom_components/plugwise/select.py
+++ b/custom_components/plugwise/select.py
@@ -1,0 +1,81 @@
+"""Plugwise Select component for Home Assistant."""
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from homeassistant.components.binary_sensor import SelectEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_platform
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import (
+    COORDINATOR,
+    DOMAIN,
+    LOGGER,
+    PW_TYPE,
+    SCHEDULE_ON,
+    SERVICE_SELECT,
+    SERVICE_SELECT_SCHEMA,
+)
+from .coordinator import PlugwiseDataUpdateCoordinator
+from .entity import PlugwiseEntity
+
+PARALLEL_UPDATES = 0
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the Smile switches from a config entry."""
+    if hass.data[DOMAIN][config_entry.entry_id][PW_TYPE] == USB:
+        return 
+    # Considered default and for earlier setups without usb/network config_flow
+    return await async_setup_entry_gateway(hass, config_entry, async_add_entities)
+
+
+async def async_setup_entry_gateway(hass, config_entry, async_add_entities):
+    """Set up the Smile binary_sensors from a config entry."""
+    coordinator: PlugwiseDataUpdateCoordinator = hass.data[DOMAIN][
+        config_entry.entry_id
+    ][COORDINATOR]
+
+    async_add_entities(
+        PlugwiseSelectEntity(coordinator, device_id)
+        for device_id, device in coordinator.data.devices.items()
+        if device["class"] in MASTER_THERMOSTATS
+    )
+
+class PlugwiseSelectEntity(PlugwiseEntity, SelectEntity):
+    """Represent Smile Binary Sensors."""
+
+    def __init__(
+        self,
+        coordinator: PlugwiseDataUpdateCoordinator,
+        device_id: str,
+    ) -> None:
+        """Initialise the binary_sensor."""
+        super().__init__(coordinator, device_id)
+        self._attr_entity_registry_enabled_default = (
+            description.entity_registry_enabled_default
+        )
+        self._attr_unique_id = f"{device_id}-select_schema"
+        self._attr_name = (f"{self.device.get('name', '')} Select Schema").lstrip()
+
+    @property
+    def options(self) -> list[str]:
+        """Return a set of selectable options."""
+        return self.device.get("available_schedules")
+
+    async def async_select_option(self, option: str) -> None:
+        """Change the selected option."""
+        await self.coordinator.api.set_schedule_state(
+            self.device.get("location"),
+            option,
+            SCHEDULE_ON,
+        )
+        self.set_schedule_state

--- a/custom_components/plugwise/select.py
+++ b/custom_components/plugwise/select.py
@@ -1,26 +1,17 @@
 """Plugwise Select component for Home Assistant."""
 from __future__ import annotations
 
-from collections.abc import Mapping
-from typing import Any
-
 from homeassistant.components.select import SelectEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_platform
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import (
-    ATTR_SCHEMA_NAME,
     COORDINATOR,
     DOMAIN,
-    LOGGER,
     MASTER_THERMOSTATS,
     PW_TYPE,
     SCHEDULE_ON,
-    SERVICE_SELECT,
-    SERVICE_SELECT_SCHEMA,
     USB,
 )
 from .coordinator import PlugwiseDataUpdateCoordinator
@@ -36,7 +27,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up the Smile switches from a config entry."""
     if hass.data[DOMAIN][config_entry.entry_id][PW_TYPE] == USB:
-        return 
+        return
     # Considered default and for earlier setups without usb/network config_flow
     return await async_setup_entry_gateway(hass, config_entry, async_add_entities)
 
@@ -53,6 +44,7 @@ async def async_setup_entry_gateway(hass, config_entry, async_add_entities):
         if device["class"] in MASTER_THERMOSTATS
     )
 
+
 class PlugwiseSelectEntity(PlugwiseEntity, SelectEntity):
     """Represent Smile Binary Sensors."""
 
@@ -63,9 +55,10 @@ class PlugwiseSelectEntity(PlugwiseEntity, SelectEntity):
     ) -> None:
         """Initialise the binary_sensor."""
         super().__init__(coordinator, device_id)
-        #self._attr_entity_registry_enabled_default = (
+        #  TODO: add descriptions for select
+        #  self._attr_entity_registry_enabled_default = (
         #    description.entity_registry_enabled_default
-        #)
+        #  )
         self._attr_unique_id = f"{device_id}-select_schema"
         self._attr_name = (f"{self.device.get('name', '')} Select Schema").lstrip()
         self._attr_current_option = self.device.get("selected_schedule")

--- a/custom_components/plugwise/select.py
+++ b/custom_components/plugwise/select.py
@@ -68,7 +68,7 @@ class PlugwiseSelectEntity(PlugwiseEntity, SelectEntity):
         #)
         self._attr_unique_id = f"{device_id}-select_schema"
         self._attr_name = (f"{self.device.get('name', '')} Select Schema").lstrip()
-        self._attr_current_option = self.device.get("selected_schema")
+        self._attr_current_option = self.device.get("selected_schedule")
 
     @property
     def options(self) -> list[str]:
@@ -82,4 +82,3 @@ class PlugwiseSelectEntity(PlugwiseEntity, SelectEntity):
             option,
             SCHEDULE_ON,
         )
-        self.set_schedule_state

--- a/custom_components/plugwise/select.py
+++ b/custom_components/plugwise/select.py
@@ -45,8 +45,8 @@ class PlugwiseSelectEntity(PlugwiseEntity, SelectEntity):
     ) -> None:
         """Initialise the selector."""
         super().__init__(coordinator, device_id)
-        self._attr_unique_id = f"{device_id}-select_schema"
-        self._attr_name = (f"{self.device.get('name', '')} Select Schema").lstrip()
+        self._attr_unique_id = f"{device_id}-select_schedule"
+        self._attr_name = (f"{self.device.get('name', '')} Select Schedule").lstrip()
         self._attr_current_option = self.device.get("selected_schedule")
 
     @property

--- a/custom_components/plugwise/select.py
+++ b/custom_components/plugwise/select.py
@@ -12,6 +12,7 @@ from homeassistant.helpers import entity_platform
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import (
+    ATTR_SCHEMA_NAME,
     COORDINATOR,
     DOMAIN,
     LOGGER,

--- a/custom_components/plugwise/select.py
+++ b/custom_components/plugwise/select.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Any
 
-from homeassistant.components.binary_sensor import SelectEntity
+from homeassistant.components.select import SelectEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
@@ -16,10 +16,12 @@ from .const import (
     COORDINATOR,
     DOMAIN,
     LOGGER,
+    MASTER_THERMOSTATS,
     PW_TYPE,
     SCHEDULE_ON,
     SERVICE_SELECT,
     SERVICE_SELECT_SCHEMA,
+    USB,
 )
 from .coordinator import PlugwiseDataUpdateCoordinator
 from .entity import PlugwiseEntity
@@ -61,11 +63,12 @@ class PlugwiseSelectEntity(PlugwiseEntity, SelectEntity):
     ) -> None:
         """Initialise the binary_sensor."""
         super().__init__(coordinator, device_id)
-        self._attr_entity_registry_enabled_default = (
-            description.entity_registry_enabled_default
-        )
+        #self._attr_entity_registry_enabled_default = (
+        #    description.entity_registry_enabled_default
+        #)
         self._attr_unique_id = f"{device_id}-select_schema"
         self._attr_name = (f"{self.device.get('name', '')} Select Schema").lstrip()
+        self._attr_current_option = self.device.get("selected_schema")
 
     @property
     def options(self) -> list[str]:

--- a/custom_components/plugwise/select.py
+++ b/custom_components/plugwise/select.py
@@ -12,7 +12,6 @@ from .const import (
     MASTER_THERMOSTATS,
     PW_TYPE,
     SCHEDULE_ON,
-    USB,
 )
 from .coordinator import PlugwiseDataUpdateCoordinator
 from .entity import PlugwiseEntity
@@ -25,15 +24,7 @@ async def async_setup_entry(
     config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up the Smile switches from a config entry."""
-    if hass.data[DOMAIN][config_entry.entry_id][PW_TYPE] == USB:
-        return
-    # Considered default and for earlier setups without usb/network config_flow
-    return await async_setup_entry_gateway(hass, config_entry, async_add_entities)
-
-
-async def async_setup_entry_gateway(hass, config_entry, async_add_entities):
-    """Set up the Smile binary_sensors from a config entry."""
+    """Set up the Smile selector from a config entry."""
     coordinator: PlugwiseDataUpdateCoordinator = hass.data[DOMAIN][
         config_entry.entry_id
     ][COORDINATOR]
@@ -46,19 +37,15 @@ async def async_setup_entry_gateway(hass, config_entry, async_add_entities):
 
 
 class PlugwiseSelectEntity(PlugwiseEntity, SelectEntity):
-    """Represent Smile Binary Sensors."""
+    """Represent Smile selector."""
 
     def __init__(
         self,
         coordinator: PlugwiseDataUpdateCoordinator,
         device_id: str,
     ) -> None:
-        """Initialise the binary_sensor."""
+        """Initialise the selector."""
         super().__init__(coordinator, device_id)
-        #  TODO: add descriptions for select
-        #  self._attr_entity_registry_enabled_default = (
-        #    description.entity_registry_enabled_default
-        #  )
         self._attr_unique_id = f"{device_id}-select_schema"
         self._attr_name = (f"{self.device.get('name', '')} Select Schema").lstrip()
         self._attr_current_option = self.device.get("selected_schedule")

--- a/custom_components/plugwise/services.yaml
+++ b/custom_components/plugwise/services.yaml
@@ -1,5 +1,12 @@
 delete_notification:
   description: Delete the Plugwise Notification(s).
+select_schema:
+  description: Change the active schema
+  fields:
+    name:
+      description: The name of an existing schema
+      example: Normal
+device_remove:
 device_add:
   description: Manually add a new plugwise device.
   fields:

--- a/custom_components/plugwise/services.yaml
+++ b/custom_components/plugwise/services.yaml
@@ -1,12 +1,5 @@
 delete_notification:
   description: Delete the Plugwise Notification(s).
-select_schema:
-  description: Change the active schema
-  fields:
-    name:
-      description: The name of an existing schema
-      example: Normal
-device_remove:
 device_add:
   description: Manually add a new plugwise device.
   fields:

--- a/scripts/core-testing.sh
+++ b/scripts/core-testing.sh
@@ -118,6 +118,10 @@ echo ""
 cp -r ../custom_components/plugwise ./homeassistant/components/
 cp -r ../tests/components/plugwise ./tests/components/
 echo ""
+echo "Adding select to coveragerc as we don't mock this yet"
+echo ""
+sed -i".sedbck" 's#homeassistant/scripts/..py#homeassistant/components/plugwise/select.py#' .coveragerc
+echo ""
 echo "Activating venv and installing selected test modules (zeroconf,pyserial, etc)"
 echo ""
 # shellcheck source=/dev/null


### PR DESCRIPTION
Add active schema/schedule select functionality as requested

Testing this is rather hard, as we'd have to mock the Location id from one place to another. It's possible but will require xml into the conftest.

As long as this is not upstreamed: in core-testing added changing `.coveragerc` accordingly NOT to test the select option.

**BREAKING** in that we choose `schedule` over `schema` and as such renamed the thermostat visible attributes to `available_schedules` and `selected_schedule` accordingly