### PR TITLE
Select schedule fix

### DIFF
--- a/custom_components/plugwise/manifest.json
+++ b/custom_components/plugwise/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "plugwise",
   "name": "Plugwise Beta",
-  "version": "0.21.5",
+  "version": "0.21.6",
   "documentation": "https://github.com/plugwise/plugwise-beta",
   "after_dependencies": ["usb", "zeroconf"],
   "requirements": ["plugwise==0.16.9"],

--- a/custom_components/plugwise/select.py
+++ b/custom_components/plugwise/select.py
@@ -31,7 +31,7 @@ async def async_setup_entry(
     async_add_entities(
         PlugwiseSelectEntity(coordinator, device_id)
         for device_id, device in coordinator.data.devices.items()
-        if device["class"] in MASTER_THERMOSTATS
+        if device["class"] in MASTER_THERMOSTATS and device.get("available_schedules")
     )
 
 
@@ -48,11 +48,7 @@ class PlugwiseSelectEntity(PlugwiseEntity, SelectEntity):
         self._attr_unique_id = f"{device_id}-select_schedule"
         self._attr_name = (f"{self.device.get('name', '')} Select Schedule").lstrip()
         self._attr_current_option = self.device.get("selected_schedule")
-
-    @property
-    def options(self) -> list[str]:
-        """Return a set of selectable options."""
-        return self.device.get("available_schedules")
+        self._attr_options = self.device.get("available_schedules",list[str])
 
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""

--- a/custom_components/plugwise/select.py
+++ b/custom_components/plugwise/select.py
@@ -48,7 +48,7 @@ class PlugwiseSelectEntity(PlugwiseEntity, SelectEntity):
         self._attr_unique_id = f"{device_id}-select_schedule"
         self._attr_name = (f"{self.device.get('name', '')} Select Schedule").lstrip()
         self._attr_current_option = self.device.get("selected_schedule")
-        self._attr_options = self.device.get("available_schedules",list[str])
+        self._attr_options = self.device.get("available_schedules", list[str])
 
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""


### PR DESCRIPTION
While prepping Core PR (enforcing typing) realisation set in that non-schedule environments might break. Not initialising when no schema's are available should solve this.

Also the options call was redundant seeing that `self._attr_options` exists