### PR TITLE
Improve testing and DRY between local and github actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,44 +27,29 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: ${{ env.DEFAULT_PYTHON }}
-      - name: Restore base HA-core Python ${{ env.DEFAULT_PYTHON }} virtual environment
+      - name: Restore base HA-core Python ${{ env.DEFAULT_PYTHON }} environment
         id: cache-hacore
         uses: actions/cache@v2
         env:
           cache-name: cache-hacore
         with:
-          path: ~/ha-core
           key: >-
             ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-hacore-${{
             steps.python.outputs.python-version }}-${{
-            hashFiles('custom_components/plugwise/manifest.json') }}-${{
-            hashFiles('~/ha-core/.git/plugwise-tracking') }}
+            hashFiles('./custom_components/plugwise/manifest.json') }}-${{
+            hashFiles('./ha-core/.git/plugwise-tracking') }}
           restore-keys: |
             ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-hacore-${{ steps.python.outputs.python-version }}-
             ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-hacore
             ${{ env.CACHE_VERSION}}-${{ runner.os }}
             ${{ env.CACHE_VERSION}}
-      # Workaround, even though cache restored on new(er) PR
-      # cache-hit isn't registered (although cache is restored
       - name: Create HA-core Python virtual environment
         run: |
-          if [ -f ~/ha-core/requirements_test_all.txt ]; then
-              cd ~/ha-core
-              git config pull.rebase true
-              git reset --hard
-              git pull
-          else
-              git clone https://github.com/home-assistant/core.git ~/ha-core
-              cd ~/ha-core
-              git config pull.rebase true
-              git checkout dev
-              script/setup
-              . venv/bin/activate
-              pip install -q -r requirements_test.txt
-          fi
-          git log -1 | head -1 > ~/ha-core/.git/plugwise-tracking
+          scripts/core-testing.sh core_prep
+      - name: Prepare HA-core Python virtual environment
+        run: |
+          scripts/core-testing.sh pip_prep
 
-  # Reset GIT, preload and execute tests
   ha-core-test:
     runs-on: ubuntu-latest
     name: Test against HA-core
@@ -77,18 +62,17 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: ${{ env.DEFAULT_PYTHON }}
-      - name: Restore base HA-core Python ${{ env.DEFAULT_PYTHON }} virtual environment
+      - name: Restore base HA-core Python ${{ env.DEFAULT_PYTHON }} environment
         id: cache-hacore
         uses: actions/cache@v2
         env:
           cache-name: cache-hacore
         with:
-          path: ~/ha-core
           key: >-
             ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-hacore-${{
             steps.python.outputs.python-version }}-${{
-            hashFiles('custom_components/plugwise/manifest.json') }}-${{
-            hashFiles('~/ha-core/.git/plugwise-tracking') }}
+            hashFiles('./custom_components/plugwise/manifest.json') }}-${{
+            hashFiles('./ha-core/.git/plugwise-tracking') }}
           restore-keys: |
             ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-hacore-${{ steps.python.outputs.python-version }}-
             ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-hacore
@@ -97,26 +81,53 @@ jobs:
       - name: Fail job if Python cache restore failed
         if: steps.cache-hacore.outputs.cache-hit != 'true'
         run: |
-          echo "Failed to restore Python ${{ env.DEFAULT_PYTHON }} virtual environment from cache"
+          echo "Failed to restore Python ${{ env.DEFAULT_PYTHON }} environment from cache"
           exit 1
-      - name: Debug
+      - name: Test
         run: |
-          echo "git top level"
-          git rev-parse --show-toplevel
-          echo "pwd"
-          pwd
-          echo "env"
-          env
-          echo "set"
-          set
-          echo "ls s"
-          ls -l
-          ls -l ~
-          ls -l ~/ha-core
+          scripts/core-testing.sh testing
+
+  ha-core-quality:
+    runs-on: ubuntu-latest
+    name: Run linting/quality
+    needs: ha-core-test
+    steps:
+      - name: Check out committed code
+        uses: actions/checkout@v3
+      - name: Set up Python ${{ env.DEFAULT_PYTHON }}
+        id: python
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON }}
+      - name: Restore base HA-core Python ${{ env.DEFAULT_PYTHON }} environment
+        id: cache-hacore
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-hacore
+        with:
+          key: >-
+            ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-hacore-${{
+            steps.python.outputs.python-version }}-${{
+            hashFiles('./custom_components/plugwise/manifest.json') }}-${{
+            hashFiles('./ha-core/.git/plugwise-tracking') }}
+          restore-keys: |
+            ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-hacore-${{ steps.python.outputs.python-version }}-
+            ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-hacore
+            ${{ env.CACHE_VERSION}}-${{ runner.os }}
+            ${{ env.CACHE_VERSION}}
+      - name: Fail job if Python cache restore failed
+        if: steps.cache-hacore.outputs.cache-hit != 'true'
+        run: |
+          echo "Failed to restore Python ${{ env.DEFAULT_PYTHON }} environment from cache"
+          exit 1
+      - name: Test
+        run: |
+          scripts/core-testing.sh quality
 
   shellcheck:
     name: Shellcheck
     runs-on: ubuntu-latest
+    needs: ha-core-quality
     steps:
       - uses: actions/checkout@v3
       - name: Run ShellCheck

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,80 +50,10 @@ jobs:
       - name: Prepare HA-core Python virtual environment
         run: |
           scripts/core-testing.sh pip_prep
-
-  ha-core-test:
-    runs-on: ubuntu-latest
-    name: Test against HA-core
-    needs: ha-core-prepare
-    steps:
-      - name: Check out committed code
-        uses: actions/checkout@v3
-      - name: Set up Python ${{ env.DEFAULT_PYTHON }}
-        id: python
-        uses: actions/setup-python@v3
-        with:
-          python-version: ${{ env.DEFAULT_PYTHON }}
-      - name: Restore base HA-core Python ${{ env.DEFAULT_PYTHON }} environment
-        id: cache-hacore
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-hacore
-        with:
-          path: ./
-          key: >-
-            ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-hacore-${{
-            steps.python.outputs.python-version }}-${{
-            hashFiles('./custom_components/plugwise/manifest.json') }}-${{
-            hashFiles('./ha-core/.git/plugwise-tracking') }}
-          restore-keys: |
-            ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-hacore-${{ steps.python.outputs.python-version }}-
-            ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-hacore
-            ${{ env.CACHE_VERSION}}-${{ runner.os }}
-            ${{ env.CACHE_VERSION}}
-      - name: Fail job if Python cache restore failed
-        if: steps.cache-hacore.outputs.cache-hit != 'true'
-        run: |
-          echo "Failed to restore Python ${{ env.DEFAULT_PYTHON }} environment from cache"
-          exit 1
       - name: Test
         run: |
           scripts/core-testing.sh testing
-
-  ha-core-quality:
-    runs-on: ubuntu-latest
-    name: Run linting/quality
-    needs: ha-core-test
-    steps:
-      - name: Check out committed code
-        uses: actions/checkout@v3
-      - name: Set up Python ${{ env.DEFAULT_PYTHON }}
-        id: python
-        uses: actions/setup-python@v3
-        with:
-          python-version: ${{ env.DEFAULT_PYTHON }}
-      - name: Restore base HA-core Python ${{ env.DEFAULT_PYTHON }} environment
-        id: cache-hacore
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-hacore
-        with:
-          path: ./
-          key: >-
-            ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-hacore-${{
-            steps.python.outputs.python-version }}-${{
-            hashFiles('./custom_components/plugwise/manifest.json') }}-${{
-            hashFiles('./ha-core/.git/plugwise-tracking') }}
-          restore-keys: |
-            ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-hacore-${{ steps.python.outputs.python-version }}-
-            ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-hacore
-            ${{ env.CACHE_VERSION}}-${{ runner.os }}
-            ${{ env.CACHE_VERSION}}
-      - name: Fail job if Python cache restore failed
-        if: steps.cache-hacore.outputs.cache-hit != 'true'
-        run: |
-          echo "Failed to restore Python ${{ env.DEFAULT_PYTHON }} environment from cache"
-          exit 1
-      - name: Test
+      - name: Quality
         run: |
           scripts/core-testing.sh quality
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ name: Test with HA-core
 
 env:
   CACHE_VERSION: 4
-  DEFAULT_PYTHON: 3.10
+  DEFAULT_PYTHON: "3.10"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,6 +102,8 @@ jobs:
       - name: Debug
         run: |
           pwd
+          env
+          set
           ls -l
           ls -l ~
           ls -l ~/ha-core

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,6 @@ jobs:
   shellcheck:
     name: Shellcheck
     runs-on: ubuntu-latest
-    needs: ha-core-quality
     steps:
       - uses: actions/checkout@v3
       - name: Run ShellCheck

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,7 @@ jobs:
         env:
           cache-name: cache-hacore
         with:
+          path: ./
           key: >-
             ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-hacore-${{
             steps.python.outputs.python-version }}-${{
@@ -68,6 +69,7 @@ jobs:
         env:
           cache-name: cache-hacore
         with:
+          path: ./
           key: >-
             ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-hacore-${{
             steps.python.outputs.python-version }}-${{
@@ -105,6 +107,7 @@ jobs:
         env:
           cache-name: cache-hacore
         with:
+          path: ./
           key: >-
             ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-hacore-${{
             steps.python.outputs.python-version }}-${{

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,8 +4,8 @@
 name: Test with HA-core
 
 env:
-  CACHE_VERSION: 3
-  DEFAULT_PYTHON: 3.9
+  CACHE_VERSION: 4
+  DEFAULT_PYTHON: 3.10
 
 on:
   workflow_dispatch:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,9 +101,15 @@ jobs:
           exit 1
       - name: Debug
         run: |
+          echo "git top level"
+          git rev-parse --show-toplevel
+          echo "pwd"
           pwd
+          echo "env"
           env
+          echo "set"
           set
+          echo "ls s"
           ls -l
           ls -l ~
           ls -l ~/ha-core

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@
 name: Test with HA-core
 
 env:
-  CACHE_VERSION: 2
+  CACHE_VERSION: 3
   DEFAULT_PYTHON: 3.9
 
 on:
@@ -20,50 +20,49 @@ jobs:
     runs-on: ubuntu-latest
     name: Setup for HA-core
     steps:
-    - name: Check out committed code
-      uses: actions/checkout@v3
-    - name: Set up Python ${{ env.DEFAULT_PYTHON }}
-      id: python
-      uses: actions/setup-python@v3
-      with:
-        python-version: ${{ env.DEFAULT_PYTHON }}
-    - name: Restore base HA-core Python ${{ env.DEFAULT_PYTHON }} virtual environment
-      id: cache-hacore
-      uses: actions/cache@v2
-      env:
-        cache-name: cache-hacore
-      with:
-        path: ~/ha-core
-        key: >-
-          ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-hacore-${{
-          steps.python.outputs.python-version }}-${{
-          hashFiles('custom_components/plugwise/manifest.json') }}-${{
-          hashFiles('~/ha-core/.git/plugwise-tracking') }}
-        restore-keys: |
-          ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-hacore-${{ steps.python.outputs.python-version }}-
-          ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-hacore
-          ${{ env.CACHE_VERSION}}-${{ runner.os }}
-          ${{ env.CACHE_VERSION}}
-    # Workaround, even though cache restored on new(er) PR
-    # cache-hit isn't registered (although cache is restored
-    - name: Create HA-core Python virtual environment
-      run: |
-        if [ -f ~/ha-core/requirements_test_all.txt ]; then
-            cd ~/ha-core
-            git config pull.rebase true
-            git reset --hard
-            git pull
-        else
-            git clone https://github.com/home-assistant/core.git ~/ha-core
-            cd ~/ha-core
-            git config pull.rebase true
-            git checkout dev
-            script/setup
-            . venv/bin/activate
-            pip install -q -r requirements_test.txt
-        fi
-        git log -1 | head -1 > ~/ha-core/.git/plugwise-tracking
-
+      - name: Check out committed code
+        uses: actions/checkout@v3
+      - name: Set up Python ${{ env.DEFAULT_PYTHON }}
+        id: python
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON }}
+      - name: Restore base HA-core Python ${{ env.DEFAULT_PYTHON }} virtual environment
+        id: cache-hacore
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-hacore
+        with:
+          path: ~/ha-core
+          key: >-
+            ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-hacore-${{
+            steps.python.outputs.python-version }}-${{
+            hashFiles('custom_components/plugwise/manifest.json') }}-${{
+            hashFiles('~/ha-core/.git/plugwise-tracking') }}
+          restore-keys: |
+            ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-hacore-${{ steps.python.outputs.python-version }}-
+            ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-hacore
+            ${{ env.CACHE_VERSION}}-${{ runner.os }}
+            ${{ env.CACHE_VERSION}}
+      # Workaround, even though cache restored on new(er) PR
+      # cache-hit isn't registered (although cache is restored
+      - name: Create HA-core Python virtual environment
+        run: |
+          if [ -f ~/ha-core/requirements_test_all.txt ]; then
+              cd ~/ha-core
+              git config pull.rebase true
+              git reset --hard
+              git pull
+          else
+              git clone https://github.com/home-assistant/core.git ~/ha-core
+              cd ~/ha-core
+              git config pull.rebase true
+              git checkout dev
+              script/setup
+              . venv/bin/activate
+              pip install -q -r requirements_test.txt
+          fi
+          git log -1 | head -1 > ~/ha-core/.git/plugwise-tracking
 
   # Reset GIT, preload and execute tests
   ha-core-test:
@@ -71,160 +70,46 @@ jobs:
     name: Test against HA-core
     needs: ha-core-prepare
     steps:
-    - name: Check out committed code
-      uses: actions/checkout@v3
-    - name: Set up Python ${{ env.DEFAULT_PYTHON }}
-      id: python
-      uses: actions/setup-python@v3
-      with:
-        python-version: ${{ env.DEFAULT_PYTHON }}
-    - name: Restore base HA-core Python ${{ env.DEFAULT_PYTHON }} virtual environment
-      id: cache-hacore
-      uses: actions/cache@v2
-      env:
-        cache-name: cache-hacore
-      with:
-        path: ~/ha-core
-        key: >-
-          ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-hacore-${{
-          steps.python.outputs.python-version }}-${{
-          hashFiles('custom_components/plugwise/manifest.json') }}-${{
-          hashFiles('~/ha-core/.git/plugwise-tracking') }}
-        restore-keys: |
-          ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-hacore-${{ steps.python.outputs.python-version }}-
-          ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-hacore
-          ${{ env.CACHE_VERSION}}-${{ runner.os }}
-          ${{ env.CACHE_VERSION}}
-    - name: Fail job if Python cache restore failed
-      if: steps.cache-hacore.outputs.cache-hit != 'true'
-      run: |
-        echo "Failed to restore Python ${{ env.DEFAULT_PYTHON }} virtual environment from cache"
-        exit 1
-    - name: Show last commit message
-      run: |
-        echo "Last commit message:"
-        git log -1 --pretty=%B
-    - name: Remove current code and tests
-      run: |
-        cd ~/ha-core
-        rm -r homeassistant/components/plugwise tests/components/plugwise
-    - name: Copy code and tests
-      run: |
-        cp -r custom_components/plugwise ~/ha-core/homeassistant/components/
-        cp -r tests/components/plugwise ~/ha-core/tests/components/
-    - name: Prepare requirements (be)for(e) plugwise
-      run: |
-        cd ~/ha-core
-        . venv/bin/activate
-        mkdir ~/tmp
-        pip install -q -r requirements_test.txt -r requirements.txt
-        egrep -i "voluptuous|aiohttp_cors|pyroute2|sqlalchemy|zeroconf|pyserial|pytest-socket" requirements_test_all.txt > ~/tmp/requirements_test_extra.txt
-        pip install -q -r ~/tmp/requirements_test_extra.txt
-        pip install -q $(grep require ~/work/plugwise-beta/plugwise-beta/custom_components/plugwise/manifest.json | cut -f 4 -d '"')
-        pip list | grep plugwise
-    - name: Run tests
-      run: |
-        cd ~/ha-core
-        . venv/bin/activate
-        pytest -- tests/components/plugwise/
-    - name: Show coverage
-      run: |
-        cd ~/ha-core
-        . venv/bin/activate
-        pytest --cov=homeassistant/components/plugwise/ --cov-report term-missing -- tests/components/plugwise/
-
-  # Reset GIT, preload and validate code
-  ha-core-quality:
-    runs-on: ubuntu-latest
-    name: Verify code quality
-    needs: ha-core-test
-    steps:
-    - name: Check out committed code
-      uses: actions/checkout@v3
-    - name: Set up Python ${{ env.DEFAULT_PYTHON }}
-      id: python
-      uses: actions/setup-python@v3
-      with:
-        python-version: ${{ env.DEFAULT_PYTHON }}
-    - name: Restore base HA-core Python ${{ env.DEFAULT_PYTHON }} virtual environment
-      id: cache-hacore
-      uses: actions/cache@v2
-      env:
-        cache-name: cache-hacore
-      with:
-        path: ~/ha-core
-        key: >-
-          ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-hacore-${{
-          steps.python.outputs.python-version }}-${{
-          hashFiles('custom_components/plugwise/manifest.json') }}-${{
-          hashFiles('~/ha-core/.git/plugwise-tracking') }}
-        restore-keys: |
-          ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-hacore-${{ steps.python.outputs.python-version }}-
-          ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-hacore
-          ${{ env.CACHE_VERSION}}-${{ runner.os }}
-          ${{ env.CACHE_VERSION}}
-    - name: Fail job if Python cache restore failed
-      if: steps.cache-hacore.outputs.cache-hit != 'true'
-      run: |
-        echo "Failed to restore Python ${{ env.DEFAULT_PYTHON }} virtual environment from cache"
-        exit 1
-    - name: Show last commit message
-      run: |
-        echo "Last commit message:"
-        git log -1 --pretty=%B
-    - name: Remove current code and tests
-      run: |
-        cd ~/ha-core
-        rm -r homeassistant/components/plugwise tests/components/plugwise
-    - name: Copy code and tests
-      run: |
-        cp -r custom_components/plugwise ~/ha-core/homeassistant/components/
-        cp -r tests/components/plugwise ~/ha-core/tests/components/
-    - name: Prepare requirements (be)for(e) plugwise
-      run: |
-        cd ~/ha-core
-        . venv/bin/activate
-        mkdir ~/tmp
-        egrep -i "sqlalchemy|zeroconf|pyserial" requirements_test_all.txt > ~/tmp/requirements_test_extra.txt
-        pip install -r ~/tmp/requirements_test_extra.txt
-        pip install $(grep require ~/work/plugwise-beta/plugwise-beta/custom_components/plugwise/manifest.json | cut -f 4 -d '"')
-    - name: flake8
-      run: |
-        cd ~/ha-core
-        . venv/bin/activate
-        pip install flake8
-        flake8 homeassistant/components/plugwise/*py
-        flake8 tests/components/plugwise/*py
-    - name: pylint
-      run: |
-        cd ~/ha-core
-        . venv/bin/activate
-        pip install pylint
-        pylint homeassistant/components/plugwise/*py
-        # disable for further figuring out, apparently HA doesn't pylint against test
-        #pylint tests/components/plugwise/*py
-    - name: hassfest-lite
-      run: |
-        echo ""
-        echo "Hassfest-lite (i.e. core-compatible and ignoring test-pypi and github URIs)"
-        echo ""
-        cd ~/ha-core
-        . venv/bin/activate
-        echo "Removing version from manifest for hassfest-ing (no version in core components)"
-        echo ""
-        sed -i "/version.:/d" ./homeassistant/components/plugwise/manifest.json
-        grep -q -E "require.*http.*test-files.pythonhosted.*#" ./homeassistant/components/plugwise/manifest.json && (
-          echo "Changing requirement for hassfest pass .... :("
-          sed -i "s/http.*test-files.pythonhosted.*#//g" ./homeassistant/components/plugwise/manifest.json
-        )
-        echo "Running hassfest (plugwise-only)"
-        echo ""
-        python3 -m script.hassfest --integration-path homeassistant/components/plugwise
+      - name: Check out committed code
+        uses: actions/checkout@v3
+      - name: Set up Python ${{ env.DEFAULT_PYTHON }}
+        id: python
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON }}
+      - name: Restore base HA-core Python ${{ env.DEFAULT_PYTHON }} virtual environment
+        id: cache-hacore
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-hacore
+        with:
+          path: ~/ha-core
+          key: >-
+            ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-hacore-${{
+            steps.python.outputs.python-version }}-${{
+            hashFiles('custom_components/plugwise/manifest.json') }}-${{
+            hashFiles('~/ha-core/.git/plugwise-tracking') }}
+          restore-keys: |
+            ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-hacore-${{ steps.python.outputs.python-version }}-
+            ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-hacore
+            ${{ env.CACHE_VERSION}}-${{ runner.os }}
+            ${{ env.CACHE_VERSION}}
+      - name: Fail job if Python cache restore failed
+        if: steps.cache-hacore.outputs.cache-hit != 'true'
+        run: |
+          echo "Failed to restore Python ${{ env.DEFAULT_PYTHON }} virtual environment from cache"
+          exit 1
+      - name: Debug
+        run: |
+          pwd
+          ls -l
+          ls -l ~
+          ls -l ~/ha-core
 
   shellcheck:
     name: Shellcheck
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - name: Run ShellCheck
-      uses: ludeeus/action-shellcheck@master
+      - uses: actions/checkout@v3
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@master

--- a/scripts/core-testing.sh
+++ b/scripts/core-testing.sh
@@ -203,8 +203,6 @@ if [ -z "${GITHUB_ACTIONS}" ] || [ "$1" == "quality" ] ; then
 	flake8 homeassistant/components/plugwise/*py || exit
 	echo "... flake8-ing tests..."
 	flake8 tests/components/plugwise/*py || exit
-	#echo "... pylint-ing component ..."
-	#pylint homeassistant/components/plugwise/*py tests/components/plugwise/*py|| exit
 	echo "... black-ing ..."
 	black homeassistant/components/plugwise/*py tests/components/plugwise/*py || exit
 fi # quality
@@ -231,7 +229,10 @@ if [ -z "${GITHUB_ACTIONS}" ]; then
 	python3 -m script.hassfest --integration-path homeassistant/components/plugwise
 fi
 
-if [ -z "${GITHUB_ACTIONS}" ] && [ ! -z "${COMMIT_CHECK}" ] ; then 
+# pylint was removed from 'quality' some time ago
+# this is a much better replacement for actually checking everything
+# including isort and mypy
+if [ -z "${GITHUB_ACTIONS}" ] && [ -n "${COMMIT_CHECK}" ] ; then 
 	cd "${coredir}" || exit
 	echo ""
 	echo "Core PR pre-commit check ..."
@@ -242,8 +243,4 @@ fi
 if [ -z "${GITHUB_ACTIONS}" ] ; then 
 	deactivate
 fi
-
-	#        # disable for further figuring out, apparently HA doesn't pylint against test
-	#        #pylint tests/components/plugwise/*py
-
 

--- a/scripts/core-testing.sh
+++ b/scripts/core-testing.sh
@@ -121,7 +121,7 @@ if [ -z "${GITHUB_ACTIONS}" ] || [ "$1" == "core_prep" ] ; then
 		git pull
 	fi
 	# Add tracker
-	git log -1 | head -1 > ${coredir}/.git/plugwise-tracking
+	git log -1 | head -1 > "${coredir}/.git/plugwise-tracking"
 
 	echo ""
 	echo "Cleaning existing plugwise from HA core"

--- a/scripts/core-testing.sh
+++ b/scripts/core-testing.sh
@@ -24,7 +24,7 @@ which git || ( echo "You should have git installed, exiting"; exit 1)
 # - quality
 
 
-pyversions=(3.9 dummy) # HA-Core is pinned to 3.9
+pyversions=("3.10" 3.9 dummy) # HA-Core is pinned to 3.9
 my_path=$(git rev-parse --show-toplevel)
 my_venv=${my_path}/venv
 
@@ -57,14 +57,18 @@ if [ -z "${GITHUB_ACTIONS}" ] ; then
 	# /Cloned code
 fi
 
-# Handle variables
-subject=""
-basedir=""
-if [ $# -eq 2 ]; then
-	subject=$2
-fi
-if [ $# -gt 0 ]; then
-	basedir=$1
+# Skip targetting for github
+# i.e. args used for functions, not directions 
+if [ -z "${GITHUB_ACTIONS}" ] ; then
+	# Handle variables
+	subject=""
+	basedir=""
+	if [ $# -eq 2 ]; then
+		subject=$2
+	fi
+	if [ $# -gt 0 ]; then
+		basedir=$1
+	fi
 fi
 
 # Ensure ha-core exists

--- a/scripts/core-testing.sh
+++ b/scripts/core-testing.sh
@@ -28,7 +28,7 @@ pyversions=(3.9 dummy) # HA-Core is pinned to 3.9
 my_path=$(git rev-parse --show-toplevel)
 my_venv=${my_path}/venv
 
-if [ -z "${GITHUB_ACTIONS}"] ; then 
+if [ -z "${GITHUB_ACTIONS}" ] ; then 
 	# Ensures a python virtualenv is available at the highest available python3 version
 	for pv in "${pyversions[@]};"; do
 	    if [ "$(which "python$pv")" ]; then
@@ -95,7 +95,7 @@ if [ -z "${GITHUB_ACTIONS}" ] || [ "$1" == "core_prep" ] ; then
 		echo ""
 		echo " ** Running setup script from HA core **"
 		echo ""
-		if [ -z "${GITHUB_ACTIONS}"] ; then 
+		if [ -z "${GITHUB_ACTIONS}" ] ; then 
 			# shellcheck source=/dev/null
 			. "${my_path}/venv/bin/activate"
 			python3 -m venv venv
@@ -103,7 +103,7 @@ if [ -z "${GITHUB_ACTIONS}" ] || [ "$1" == "core_prep" ] ; then
 		python3 -m pip install --upgrade pip 
 		# Not a typo, core setup script resets back to pip 20.3
 		script/setup || python3 -m pip install --upgrade pip 
-		if [ -z "${GITHUB_ACTIONS}"] ; then 
+		if [ -z "${GITHUB_ACTIONS}" ] ; then 
 			# shellcheck source=/dev/null
 			. venv/bin/activate
 		fi
@@ -141,7 +141,7 @@ fi # core_prep
 
 if [ -z "${GITHUB_ACTIONS}" ] || [ "$1" == "pip_prep" ] ; then 
 	cd "${coredir}" || exit
-	if [ -z "${GITHUB_ACTIONS}"] ; then 
+	if [ -z "${GITHUB_ACTIONS}" ] ; then 
 		echo "Activating venv and installing selected test modules (zeroconf,pyserial, etc)"
 		echo ""
 		# shellcheck source=/dev/null
@@ -209,7 +209,7 @@ if [ -z "${GITHUB_ACTIONS}" ]; then
 	)
 	echo "Running hassfest for plugwise"
 	python3 -m script.hassfest --integration-path homeassistant/components/plugwise
-	if [ -z "${GITHUB_ACTIONS}"] ; then 
+	if [ -z "${GITHUB_ACTIONS}" ] ; then 
 		deactivate
 	fi
 fi

--- a/scripts/core-testing.sh
+++ b/scripts/core-testing.sh
@@ -42,20 +42,20 @@ if [ -z "${GITHUB_ACTIONS}" ] ; then
 		break
 	    fi
 	done
-fi
 
-# shellcheck source=/dev/null
-. "${my_venv}/bin/activate"
-# shellcheck disable=2145
-which python3 || ( echo "You should have python3 (${pyversions[@]}) installed, or change the script yourself, exiting"; exit 1)
-python3 --version
+	# shellcheck source=/dev/null
+	. "${my_venv}/bin/activate"
+	# shellcheck disable=2145
+	which python3 || ( echo "You should have python3 (${pyversions[@]}) installed, or change the script yourself, exiting"; exit 1)
+	python3 --version
 
-# Failsafe
-if [ ! -d "${my_venv}" ]; then
-    echo "Unable to instantiate venv, check your base python3 version and if you have python3-venv installed"
-    exit 1
+	# Failsafe
+	if [ ! -d "${my_venv}" ]; then
+	    echo "Unable to instantiate venv, check your base python3 version and if you have python3-venv installed"
+	    exit 1
+	fi
+	# /Cloned code
 fi
-# /Cloned code
 
 # Handle variables
 subject=""

--- a/scripts/core-testing.sh
+++ b/scripts/core-testing.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -eu
+set -e
 
 # If you want to test a single file
 # run as "scripts/core_testing.sh test_config_flow.py" or
@@ -17,24 +17,32 @@ which git || ( echo "You should have git installed, exiting"; exit 1)
 # use the 'venv', but instantiate it to ensure it works in the
 # ha-core testing later on
 
+# GITHUB ACTIONS $1
+# - core_prep
+# - pip_prep
+# - testing
+# - quality
+
 
 pyversions=(3.9 dummy) # HA-Core is pinned to 3.9
 my_path=$(git rev-parse --show-toplevel)
 my_venv=${my_path}/venv
 
-# Ensures a python virtualenv is available at the highest available python3 version
-for pv in "${pyversions[@]};"; do
-    if [ "$(which "python$pv")" ]; then
-        # If not (yet) available instantiate python virtualenv
-        if [ ! -d "${my_venv}" ]; then
-            "python${pv}" -m venv "${my_venv}"
-            # Ensure wheel is installed (preventing local issues)
-            # shellcheck disable=SC1091
-            . "${my_venv}/bin/activate"
-        fi
-        break
-    fi
-done
+if [ -z "${GITHUB_ACTIONS}"] ; then 
+	# Ensures a python virtualenv is available at the highest available python3 version
+	for pv in "${pyversions[@]};"; do
+	    if [ "$(which "python$pv")" ]; then
+		# If not (yet) available instantiate python virtualenv
+		if [ ! -d "${my_venv}" ]; then
+		    "python${pv}" -m venv "${my_venv}"
+		    # Ensure wheel is installed (preventing local issues)
+		    # shellcheck disable=SC1091
+		    . "${my_venv}/bin/activate"
+		fi
+		break
+	    fi
+	done
+fi
 
 # shellcheck source=/dev/null
 . "${my_venv}/bin/activate"
@@ -63,118 +71,150 @@ fi
 coredir="${my_path}/ha-core/"
 mkdir -p "${coredir}"
 
-# If only dir exists, but not cloned yet
-if [ ! -f "${coredir}/requirements_test_all.txt" ]; then
+if [ -z "${GITHUB_ACTIONS}" ] || [ "$1" == "core_prep" ] ; then 
+	# If only dir exists, but not cloned yet
+	if [ ! -f "${coredir}/requirements_test_all.txt" ]; then
+		echo ""
+		echo " ** Cloning HA core **"
+		echo ""
+		git clone https://github.com/home-assistant/core.git "${coredir}"
+		if [ ! -f "${coredir}/requirements_test_all.txt" ]; then
+			echo ""
+			echo "Cloning failed .. make sure ${coredir} exists and is an empty directory"
+			echo ""
+			echo "Stopping"
+			echo ""
+			exit 1
+		fi
+		cd "${coredir}" || exit
+		echo ""
+		echo " ** Resetting to dev **"
+		echo ""
+		git config pull.rebase true
+		git checkout dev
+		echo ""
+		echo " ** Running setup script from HA core **"
+		echo ""
+		if [ -z "${GITHUB_ACTIONS}"] ; then 
+			# shellcheck source=/dev/null
+			. "${my_path}/venv/bin/activate"
+			python3 -m venv venv
+		fi
+		python3 -m pip install --upgrade pip 
+		# Not a typo, core setup script resets back to pip 20.3
+		script/setup || python3 -m pip install --upgrade pip 
+		if [ -z "${GITHUB_ACTIONS}"] ; then 
+			# shellcheck source=/dev/null
+			. venv/bin/activate
+		fi
+		echo ""
+		echo " ** Installing test requirements **"
+		echo ""
+		pip install -r requirements_test.txt
+	else
+		cd "${coredir}" || exit
+		echo ""
+		echo " ** Resetting/rebasing core **"
+		echo ""
+		git config pull.rebase true
+		git reset --hard
+		git pull
+	fi
+	# Add tracker
+	git log -1 | head -1 > ${coredir}/.git/plugwise-tracking
+
 	echo ""
-	echo " ** Cloning HA core **"
+	echo "Cleaning existing plugwise from HA core"
 	echo ""
-	git clone https://github.com/home-assistant/core.git "${coredir}"
-        if [ ! -f "${coredir}/requirements_test_all.txt" ]; then
+	rm -r homeassistant/components/plugwise tests/components/plugwise
+	echo ""
+	echo "Overwriting with plugwise-beta"
+	echo ""
+	cp -r ../custom_components/plugwise ./homeassistant/components/
+	cp -r ../tests/components/plugwise ./tests/components/
+	echo ""
+	echo "Adding select to coveragerc as we don't mock this yet"
+	echo ""
+	sed -i".sedbck" 's#homeassistant/scripts/..py#homeassistant/components/plugwise/select.py#' .coveragerc
+	echo ""
+fi # core_prep
+
+if [ -z "${GITHUB_ACTIONS}" ] || [ "$1" == "pip_prep" ] ; then 
+	cd "${coredir}" || exit
+	if [ -z "${GITHUB_ACTIONS}"] ; then 
+		echo "Activating venv and installing selected test modules (zeroconf,pyserial, etc)"
 		echo ""
-		echo "Cloning failed .. make sure ${coredir} exists and is an empty directory"
+		# shellcheck source=/dev/null
+		. venv/bin/activate
 		echo ""
-		echo "Stopping"
-		echo ""
-		exit 1
-        fi
+	fi
+	python3 -m pip install -q --upgrade pip
+	mkdir -p ./tmp
+	echo ""
+	echo "Installing pip modules"
+	echo ""
+	echo " - HA requirements (core and test)"
+	pip install -q --disable-pip-version-check -r requirements.txt -r requirements_test.txt
+	grep -hEi "fnvhash|lru-dict|voluptuous|aiohttp_cors|pyroute2|sqlalchemy|zeroconf|pyserial|pytest-socket" requirements_test_all.txt > ./tmp/requirements_test_extra.txt
+	echo " - extra's required for plugwise"
+	pip install -q --disable-pip-version-check -r ./tmp/requirements_test_extra.txt
+	echo " - flake8"
+	pip install -q flake8
+	echo ""
+	module=$(grep require ../custom_components/plugwise/manifest.json | cut -f 4 -d '"')
+	echo "Checking manifest for current python-plugwise to install: ${module}"
+	echo ""
+	pip install -q --disable-pip-version-check "${module}"
+fi # pip_prep
+
+if [ -z "${GITHUB_ACTIONS}" ] || [ "$1" == "testing" ] ; then 
 	cd "${coredir}" || exit
 	echo ""
-	echo " ** Resetting to dev **"
+	echo "Test commencing ..."
 	echo ""
-	git config pull.rebase true
-	git checkout dev
+	# shellcheck disable=SC2086
+	pytest ${subject} --cov=homeassistant/components/plugwise/ --cov-report term-missing -- "tests/components/plugwise/${basedir}" || exit
+fi # testing
+
+if [ -z "${GITHUB_ACTIONS}" ] || [ "$1" == "quality" ] ; then 
+	cd "${coredir}" || exit
 	echo ""
-	echo " ** Running setup script from HA core **"
+	echo "... flake8-ing component..."
+	flake8 homeassistant/components/plugwise/*py || exit
+	echo "... flak8-ing tests..."
+	flake8 tests/components/plugwise/*py || exit
+	#echo "... pylint-ing component ..."
+	#pylint homeassistant/components/plugwise/*py tests/components/plugwise/*py|| exit
+	echo "... black-ing ..."
+	black homeassistant/components/plugwise/*py tests/components/plugwise/*py || exit
+fi # quality
+
+# Copying back not neccesary in actions
+# hassfest is another action
+if [ -z "${GITHUB_ACTIONS}" ]; then
+	cd "${coredir}" || exit
 	echo ""
-	# shellcheck source=/dev/null
-        . "${my_path}/venv/bin/activate"
-        python3 -m venv venv
-	python3 -m pip install --upgrade pip 
-        # Not a typo, core setup script resets back to pip 20.3
-	script/setup || python3 -m pip install --upgrade pip 
-	# shellcheck source=/dev/null
-        . venv/bin/activate
+	echo "Copy back modified files ..."
 	echo ""
-	echo " ** Installing test requirements **"
+	cp -r ./homeassistant/components/plugwise ../custom_components/
+	cp -r ./tests/components/plugwise ../tests/components/
+	echo "Removing 'version' from manifest for hassfest-ing, version not allowed in core components"
 	echo ""
-        pip install -r requirements_test.txt
-else
-        cd "${coredir}" || exit
-	echo ""
-	echo " ** Resetting/rebasing core **"
-	echo ""
-        git config pull.rebase true
-        git reset --hard
-        git pull
+	# shellcheck disable=SC2090
+	sed -i".sedbck" '/version.:/d' ./homeassistant/components/plugwise/manifest.json
+	grep -q -E 'require.*http.*test-files.pythonhosted.*#' ./homeassistant/components/plugwise/manifest.json && (
+	  echo "Changing requirement for hassfest pass ...."
+	  # shellcheck disable=SC2090
+	  sed -i".sedbck" 's/http.*test-files.pythonhosted.*#//g' ./homeassistant/components/plugwise/manifest.json
+	)
+	echo "Running hassfest for plugwise"
+	python3 -m script.hassfest --integration-path homeassistant/components/plugwise
+	if [ -z "${GITHUB_ACTIONS}"] ; then 
+		deactivate
+	fi
 fi
 
-echo ""
-echo "Cleaning existing plugwise from HA core"
-echo ""
-rm -r homeassistant/components/plugwise tests/components/plugwise
-echo ""
-echo "Overwriting with plugwise-beta"
-echo ""
-cp -r ../custom_components/plugwise ./homeassistant/components/
-cp -r ../tests/components/plugwise ./tests/components/
-echo ""
-echo "Adding select to coveragerc as we don't mock this yet"
-echo ""
-sed -i".sedbck" 's#homeassistant/scripts/..py#homeassistant/components/plugwise/select.py#' .coveragerc
-echo ""
-echo "Activating venv and installing selected test modules (zeroconf,pyserial, etc)"
-echo ""
-# shellcheck source=/dev/null
-. venv/bin/activate
-echo ""
-python3 -m pip install -q --upgrade pip
-mkdir -p ./tmp
-echo ""
-echo "Installing pip modules"
-echo ""
-echo " - HA requirements (core and test)"
-pip install -q --disable-pip-version-check -r requirements.txt -r requirements_test.txt
-grep -hEi "fnvhash|lru-dict|voluptuous|aiohttp_cors|pyroute2|sqlalchemy|zeroconf|pyserial|pytest-socket" requirements_test_all.txt > ./tmp/requirements_test_extra.txt
-echo " - extra's required for plugwise"
-pip install -q --disable-pip-version-check -r ./tmp/requirements_test_extra.txt
-echo " - flake8"
-pip install -q flake8
-echo ""
-module=$(grep require ../custom_components/plugwise/manifest.json | cut -f 4 -d '"')
-echo "Checking manifest for current python-plugwise to install: ${module}"
-echo ""
-pip install -q --disable-pip-version-check "${module}"
-echo ""
-echo "Test commencing ..."
-echo ""
-# shellcheck disable=SC2086
-pytest ${subject} --cov=homeassistant/components/plugwise/ --cov-report term-missing -- "tests/components/plugwise/${basedir}" || exit
-echo ""
-echo "... flake8-ing component..."
-flake8 homeassistant/components/plugwise/*py || exit
-echo "... flak8-ing tests..."
-flake8 tests/components/plugwise/*py || exit
-#echo "... pylint-ing component ..."
-#pylint homeassistant/components/plugwise/*py tests/components/plugwise/*py|| exit
-echo "... black-ing ..."
-black homeassistant/components/plugwise/*py tests/components/plugwise/*py || exit
-echo ""
-echo "Copy back modified files ..."
-echo ""
-cp -r ./homeassistant/components/plugwise ../custom_components/
-cp -r ./tests/components/plugwise ../tests/components/
-echo "Removing 'version' from manifest for hassfest-ing, version not allowed in core components"
-echo ""
-# shellcheck disable=SC2090
-sed -i".sedbck" '/version.:/d' ./homeassistant/components/plugwise/manifest.json
-grep -q -E 'require.*http.*test-files.pythonhosted.*#' ./homeassistant/components/plugwise/manifest.json && (
-  echo "Changing requirement for hassfest pass ...."
-  # shellcheck disable=SC2090
-  sed -i".sedbck" 's/http.*test-files.pythonhosted.*#//g' ./homeassistant/components/plugwise/manifest.json
-)
-echo "Running hassfest for plugwise"
-python3 -m script.hassfest --integration-path homeassistant/components/plugwise
-deactivate
+	#        # disable for further figuring out, apparently HA doesn't pylint against test
+	#        #pylint tests/components/plugwise/*py
 
-#        # disable for further figuring out, apparently HA doesn't pylint against test
-#        #pylint tests/components/plugwise/*py
+


### PR DESCRIPTION
Bumped to python 3.10
Ensure we only use 1 method (i.e. DRY) to test locally and in actions
Removed pylint, use `COMMIT_CHECK=true scripts/core-testing.sh` locally (eventually we should include this in the action to test all requirements for upstreaming

Side-action (not for this PR): we should really isort again :)