### PR TITLE
Climate: add extra filtering, improve cooling hvac-modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,14 @@ Our [`python-plugwise`](https://github.com/plugwise/python-plugwise) python modu
 
 # Changelog
 
-## NEW APR 2022 [0.22.1]
+## NEW APR 2022 [0.22.2]
+- Smile climate:
+  - Add input filtering in the set-functions
+  - Improve generation of the hvac_modes list:
+    - Improve support for the cooling implementations of the Adam (manual) and the Anna (automatic)
+    - Make hvac_modes a property as the contents of the hvac_modes isn't fixed
+
+## APR 2022 [0.22.1]
 - Smile:
   - link to plugwise v0.17.6 - https://github.com/plugwise/python-plugwise/releases/tag/v0.17.6
   - link to plugwise v0.17.5 - https://github.com/plugwise/python-plugwise/releases/tag/v0.17.5

--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ Our [`python-plugwise`](https://github.com/plugwise/python-plugwise) python modu
 
 ## NEW APR 2022 [0.22.2]
 - Smile:
-  - Climate: add input filtering in the set-functions
+  - Climate: filter/report invalid options when using the HA climate service functions
   - Climate: improve generation of the hvac_modes list:
     - Improve support for the cooling implementations of the Adam (manual) and the Anna (automatic)
-    - Make hvac_modes a property as the contents of the hvac_modes isn't fixed
-  - Integration: fix CONFIGURE options
+    - Make hvac_modes a property as the contents of the hvac_modes list isn't fixed
+  - Integration: fix CONFIGURE options not working
 
 ## APR 2022 [0.22.1]
 - Smile:

--- a/README.md
+++ b/README.md
@@ -29,11 +29,12 @@ Our [`python-plugwise`](https://github.com/plugwise/python-plugwise) python modu
 # Changelog
 
 ## NEW APR 2022 [0.22.2]
-- Smile climate:
-  - Add input filtering in the set-functions
-  - Improve generation of the hvac_modes list:
+- Smile:
+  - Climate: add input filtering in the set-functions
+  - Climate: improve generation of the hvac_modes list:
     - Improve support for the cooling implementations of the Adam (manual) and the Anna (automatic)
     - Make hvac_modes a property as the contents of the hvac_modes isn't fixed
+  - Integration: fix CONFIGURE options
 
 ## APR 2022 [0.22.1]
 - Smile:

--- a/custom_components/plugwise/climate.py
+++ b/custom_components/plugwise/climate.py
@@ -84,6 +84,7 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity):
         self._attr_hvac_modes = [HVAC_MODE_HEAT]
         if self.coordinator.data.gateway.get("cooling_present"):
             if self._attr_name == "Anna":
+                self._attr_hvac_modes.pop(HVAC_MODE_HEAT)
                 self._attr_hvac_modes.append(HVAC_MODE_HEAT_COOL)
             else:
                 self._attr_hvac_modes.append(HVAC_MODE_COOL)

--- a/custom_components/plugwise/climate.py
+++ b/custom_components/plugwise/climate.py
@@ -79,26 +79,6 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity):
             self._attr_supported_features |= SUPPORT_PRESET_MODE
             self._attr_preset_modes = list(presets)
 
-        # Determine hvac modes and current hvac mode
-        self._attr_hvac_modes = [HVAC_MODE_HEAT]
-        if self.gateway["cooling_present"]:
-            if self.gateway["smile_name"] == "Anna":
-                self._attr_hvac_modes.append(HVAC_MODE_HEAT_COOL)
-                self._attr_hvac_modes.remove(HVAC_MODE_HEAT)
-            if (
-                self.gateway["smile_name"] == "Adam"
-                and self.coordinator.data.devices[self.gateway["gateway_id"]][
-                    "regulation_mode"
-                ]
-                == "cooling"
-            ):
-                self._attr_hvac_modes.append(HVAC_MODE_COOL)
-                self._attr_hvac_modes.remove(HVAC_MODE_HEAT)
-        if self.device["available_schedules"] != ["None"]:
-            self._attr_hvac_modes.append(HVAC_MODE_AUTO)
-        if self._homekit_enabled:  # pw-beta homekit emulation
-            self._attr_hvac_modes.append(HVAC_MODE_OFF)
-
         self._attr_min_temp = self.device.get("lower_bound", DEFAULT_MIN_TEMP)
         self._attr_max_temp = self.device.get("upper_bound", DEFAULT_MAX_TEMP)
         if resolution := self.device.get("resolution"):
@@ -144,6 +124,30 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity):
             if heater_central_data["binary_sensors"]["cooling_state"]:
                 return CURRENT_HVAC_COOL
         return CURRENT_HVAC_IDLE
+
+    @property
+    def hvac_modes(self) -> list[str]:
+        """Return the current hvac modes."""
+        hvac_modes = [HVAC_MODE_HEAT]
+        if self.gateway["cooling_present"]:
+            if self.gateway["smile_name"] == "Anna":
+                hvac_modes.append(HVAC_MODE_HEAT_COOL)
+                hvac_modes.remove(HVAC_MODE_HEAT)
+            if (
+                self.gateway["smile_name"] == "Adam"
+                and self.coordinator.data.devices[self.gateway["gateway_id"]][
+                    "regulation_mode"
+                ]
+                == "cooling"
+            ):
+                hvac_modes.append(HVAC_MODE_COOL)
+                hvac_modes.remove(HVAC_MODE_HEAT)
+        if self.device["available_schedules"] != ["None"]:
+            hvac_modes.append(HVAC_MODE_AUTO)
+        if self._homekit_enabled:  # pw-beta homekit emulation
+            hvac_modes.append(HVAC_MODE_OFF)
+
+        return hvac_modes
 
     @property
     def preset_mode(self) -> str:

--- a/custom_components/plugwise/climate.py
+++ b/custom_components/plugwise/climate.py
@@ -70,13 +70,12 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity):
         super().__init__(coordinator, device_id)
         self._homekit_enabled = enabled  # pw-beta homekit emulation
         self._homekit_mode: str | None = None  # pw-beta homekit emulation
-        self._attr_extra_state_attributes = {}
         self._attr_unique_id = f"{device_id}-climate"
-        self._attr_name = self.device.get("name")
+        self._attr_name = self.device["name"]
 
         # Determine preset modes
         self._attr_supported_features = SUPPORT_TARGET_TEMPERATURE
-        if presets := self.device.get("presets"):
+        if presets := self.device["presets"]:
             self._attr_supported_features |= SUPPORT_PRESET_MODE
             self._attr_preset_modes = list(presets)
 
@@ -86,10 +85,12 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity):
             if self.gateway["smile_name"] == "Anna":
                 self._attr_hvac_modes.append(HVAC_MODE_HEAT_COOL)
                 self._attr_hvac_modes.remove(HVAC_MODE_HEAT)
-            if self.gateway["smile_name"] == "Adam" and self.coordinator.data.devices[self.gateway["gateway_id"]]["regulation_mode"] == "cooling":
+            if self.gateway["smile_name"] == "Adam" and self.coordinator.data.devices[
+                self.gateway["gateway_id"]
+            ]["regulation_mode"] == "cooling":
                 self._attr_hvac_modes.append(HVAC_MODE_COOL)
                 self._attr_hvac_modes.remove(HVAC_MODE_HEAT)
-        if self.device.get("available_schedules") != ["None"]:
+        if self.device["available_schedules"] != ["None"]:
             self._attr_hvac_modes.append(HVAC_MODE_AUTO)
         if self._homekit_enabled:  # pw-beta homekit emulation
             self._attr_hvac_modes.append(HVAC_MODE_OFF)
@@ -101,19 +102,19 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity):
             self._attr_target_temperature_step = max(resolution, 0.1)
 
     @property
-    def current_temperature(self) -> float | None:
+    def current_temperature(self) -> float:
         """Return the current temperature."""
-        return self.device["sensors"].get("temperature")
+        return self.device["sensors"]["temperature"]
 
     @property
-    def target_temperature(self) -> float | None:
+    def target_temperature(self) -> float:
         """Return the temperature we try to reach."""
-        return self.device["sensors"].get("setpoint")
+        return self.device["sensors"]["setpoint"]
 
     @property
     def hvac_mode(self) -> str:
         """Return HVAC operation ie. auto, heat, cool, or off mode."""
-        if (mode := self.device.get("mode")) is None or mode not in self.hvac_modes:
+        if (mode := self.device["mode"]) is None or mode not in self.hvac_modes:
             return HVAC_MODE_HEAT
         # pw-beta homekit emulation
         if self._homekit_enabled and self._homekit_mode == HVAC_MODE_OFF:
@@ -125,10 +126,10 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity):
         """Return the current running hvac operation if supported."""
         # When control_state is present, prefer this data
         if "control_state" in self.device:
-            if self.device.get("control_state") == "cooling":
+            if self.device["control_state"] == "cooling":
                 return CURRENT_HVAC_COOL
             # Support preheating state as heating, until preheating is added as a separate state
-            if self.device.get("control_state") in ["heating", "preheating"]:
+            if self.device["control_state"] in ["heating", "preheating"]:
                 return CURRENT_HVAC_HEAT
         else:
             heater_central_data = self.coordinator.data.devices[self.gateway["heater_id"]]
@@ -139,9 +140,9 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity):
         return CURRENT_HVAC_IDLE
 
     @property
-    def preset_mode(self) -> str | None:
+    def preset_mode(self) -> str:
         """Return the current preset mode."""
-        return self.device.get("active_preset")
+        return self.device["active_preset"]
 
     @plugwise_command
     async def async_set_temperature(self, **kwargs: Any) -> None:

--- a/custom_components/plugwise/climate.py
+++ b/custom_components/plugwise/climate.py
@@ -12,6 +12,7 @@ from homeassistant.components.climate.const import (
     DEFAULT_MIN_TEMP,
     HVAC_MODE_AUTO,
     HVAC_MODE_HEAT,
+    HVAC_MODE_HEAT_COOL,
     HVAC_MODE_COOL,
     HVAC_MODE_OFF,
     PRESET_AWAY,  # pw-beta homekit emulation
@@ -82,7 +83,10 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity):
         # Determine hvac modes and current hvac mode
         self._attr_hvac_modes = [HVAC_MODE_HEAT]
         if self.coordinator.data.gateway.get("cooling_present"):
-            self._attr_hvac_modes.append(HVAC_MODE_COOL)
+            if self._attr_name == "Anna":
+                self._attr_hvac_modes.append(HVAC_MODE_HEAT_COOL)
+            else:
+                self._attr_hvac_modes.append(HVAC_MODE_COOL)
         if self.device.get("available_schedules") != ["None"]:
             self._attr_hvac_modes.append(HVAC_MODE_AUTO)
         if self._homekit_enabled:  # pw-beta homekit emulation

--- a/custom_components/plugwise/climate.py
+++ b/custom_components/plugwise/climate.py
@@ -164,13 +164,11 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity):
         """Set the hvac mode."""
         if hvac_mode not in self._attr_hvac_modes:
             raise HomeAssistantError("Unsupported hvac_mode")
-            return
 
         if hvac_mode == HVAC_MODE_AUTO and not self.device.get("schedule_temperature"):
             raise HomeAssistantError(
                 "Cannot set HVAC mode to Auto: No schedule available"
             )
-            return
 
         await self.coordinator.api.set_schedule_state(
             self.device["location"],
@@ -197,6 +195,5 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity):
             and preset_mode not in self._attr_preset_modes
         ):
             raise HomeAssistantError("Unsupported preset mode")
-            return
 
         await self.coordinator.api.set_preset(self.device["location"], preset_mode)

--- a/custom_components/plugwise/climate.py
+++ b/custom_components/plugwise/climate.py
@@ -166,7 +166,7 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity):
     @plugwise_command
     async def async_set_hvac_mode(self, hvac_mode: str) -> None:
         """Set the hvac mode."""
-        if hvac_mode not in self._attr_hvac_modes:
+        if hvac_mode not in self.hvac_modes:
             raise HomeAssistantError("Unsupported hvac_mode")
 
         if hvac_mode == HVAC_MODE_AUTO and not self.device.get("schedule_temperature"):

--- a/custom_components/plugwise/climate.py
+++ b/custom_components/plugwise/climate.py
@@ -192,7 +192,7 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity):
     @plugwise_command
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set the preset mode."""
-        if preset_mode not in self._attr_preset_modes:
+        if self._attr_preset_modes is not None and preset_mode not in self._attr_preset_modes:
             raise HomeAssistantError("Unsupported preset mode")
             return
 

--- a/custom_components/plugwise/climate.py
+++ b/custom_components/plugwise/climate.py
@@ -162,13 +162,15 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity):
     @plugwise_command
     async def async_set_hvac_mode(self, hvac_mode: str) -> None:
         """Set the hvac mode."""
-        if hvac_mode not in self._attr_hvac_modes:
+        if not hvac_mode in self._attr_hvac_modes:
             raise HomeAssistantError("Unsupported hvac_mode")
+            return
 
         if hvac_mode == HVAC_MODE_AUTO and not self.device.get("schedule_temperature"):
             raise HomeAssistantError(
                 "Cannot set HVAC mode to Auto: No schedule available"
             )
+            return
 
         await self.coordinator.api.set_schedule_state(
             self.device["location"],
@@ -190,7 +192,8 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity):
     @plugwise_command
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set the preset mode."""
-        if preset_mode not in self._attr_preset_modes:
+        if not preset_mode in self._attr_preset_modes:
             raise HomeAssistantError("Unsupported preset mode")
+            return
 
         await self.coordinator.api.set_preset(self.device["location"], preset_mode)

--- a/custom_components/plugwise/climate.py
+++ b/custom_components/plugwise/climate.py
@@ -192,7 +192,10 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity):
     @plugwise_command
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set the preset mode."""
-        if self._attr_preset_modes is not None and preset_mode not in self._attr_preset_modes:
+        if (
+            self._attr_preset_modes is not None
+            and preset_mode not in self._attr_preset_modes
+        ):
             raise HomeAssistantError("Unsupported preset mode")
             return
 

--- a/custom_components/plugwise/climate.py
+++ b/custom_components/plugwise/climate.py
@@ -11,9 +11,9 @@ from homeassistant.components.climate.const import (
     DEFAULT_MAX_TEMP,
     DEFAULT_MIN_TEMP,
     HVAC_MODE_AUTO,
+    HVAC_MODE_COOL,
     HVAC_MODE_HEAT,
     HVAC_MODE_HEAT_COOL,
-    HVAC_MODE_COOL,
     HVAC_MODE_OFF,
     PRESET_AWAY,  # pw-beta homekit emulation
     PRESET_HOME,  # pw-beta homekit emulation

--- a/custom_components/plugwise/climate.py
+++ b/custom_components/plugwise/climate.py
@@ -22,6 +22,8 @@ from homeassistant.components.climate.const import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .const import (
     CONF_HOMEKIT_EMULATION,  # pw-beta homekit emulation
@@ -149,9 +151,11 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity):
     @plugwise_command
     async def async_set_hvac_mode(self, hvac_mode: str) -> None:
         """Set the hvac mode."""
-        self._homekit_mode = hvac_mode  # pw-beta homekit emulation
+        if hvac_mode not in self._attr_hvac_modes:
+            raise HomeAssistantError("Unsupported hvac_mode")
+
         if hvac_mode == HVAC_MODE_AUTO and not self.device.get("schedule_temperature"):
-            raise ValueError("Cannot set HVAC mode to Auto: No schedule available")
+            raise HomeAssistantError("Cannot set HVAC mode to Auto: No schedule available")
 
         await self.coordinator.api.set_schedule_state(
             self.device["location"],
@@ -160,6 +164,7 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity):
         )
 
         # pw-beta: feature request - mimic HomeKit behavior
+        self._homekit_mode = hvac_mode
         if self._homekit_enabled:
             if self._homekit_mode == HVAC_MODE_OFF:
                 await self.async_set_preset_mode(PRESET_AWAY)
@@ -172,4 +177,7 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity):
     @plugwise_command
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set the preset mode."""
+        if preset_mode not in self._attr_preset_modes:
+            raise HomeAssistantError("Unsupported preset mode")
+
         await self.coordinator.api.set_preset(self.device["location"], preset_mode)

--- a/custom_components/plugwise/climate.py
+++ b/custom_components/plugwise/climate.py
@@ -82,12 +82,13 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity):
 
         # Determine hvac modes and current hvac mode
         self._attr_hvac_modes = [HVAC_MODE_HEAT]
-        if self.coordinator.data.gateway.get("cooling_present"):
-            if self._attr_name == "Anna":
+        if self.gateway["cooling_present"]:
+            if self.gateway["name"] == "Anna":
                 self._attr_hvac_modes.append(HVAC_MODE_HEAT_COOL)
                 self._attr_hvac_modes.remove(HVAC_MODE_HEAT)
-            else:
+            if self.gateway["name"] == "Adam" and self.coordinator.data.devices[self.gateway["gateway_id"]]["regulation_mode"] == "cooling":
                 self._attr_hvac_modes.append(HVAC_MODE_COOL)
+                self._attr_hvac_modes.remove(HVAC_MODE_HEAT)
         if self.device.get("available_schedules") != ["None"]:
             self._attr_hvac_modes.append(HVAC_MODE_AUTO)
         if self._homekit_enabled:  # pw-beta homekit emulation
@@ -130,12 +131,10 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity):
             if self.device.get("control_state") in ["heating", "preheating"]:
                 return CURRENT_HVAC_HEAT
         else:
-            heater_central_data = self.coordinator.data.devices[
-                self.coordinator.data.gateway["heater_id"]
-            ]
-            if heater_central_data["binary_sensors"].get("heating_state"):
+            heater_central_data = self.coordinator.data.devices[self.gateway["heater_id"]]
+            if heater_central_data["binary_sensors"]["heating_state"]:
                 return CURRENT_HVAC_HEAT
-            if heater_central_data["binary_sensors"].get("cooling_state"):
+            if heater_central_data["binary_sensors"]["cooling_state"]:
                 return CURRENT_HVAC_COOL
         return CURRENT_HVAC_IDLE
 

--- a/custom_components/plugwise/climate.py
+++ b/custom_components/plugwise/climate.py
@@ -162,7 +162,7 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity):
     @plugwise_command
     async def async_set_hvac_mode(self, hvac_mode: str) -> None:
         """Set the hvac mode."""
-        if not hvac_mode in self._attr_hvac_modes:
+        if hvac_mode not in self._attr_hvac_modes:
             raise HomeAssistantError("Unsupported hvac_mode")
             return
 
@@ -192,7 +192,7 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity):
     @plugwise_command
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set the preset mode."""
-        if not preset_mode in self._attr_preset_modes:
+        if preset_mode not in self._attr_preset_modes:
             raise HomeAssistantError("Unsupported preset mode")
             return
 

--- a/custom_components/plugwise/climate.py
+++ b/custom_components/plugwise/climate.py
@@ -84,8 +84,8 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity):
         self._attr_hvac_modes = [HVAC_MODE_HEAT]
         if self.coordinator.data.gateway.get("cooling_present"):
             if self._attr_name == "Anna":
-                self._attr_hvac_modes.pop(HVAC_MODE_HEAT)
                 self._attr_hvac_modes.append(HVAC_MODE_HEAT_COOL)
+                self._attr_hvac_modes.remove(HVAC_MODE_HEAT)
             else:
                 self._attr_hvac_modes.append(HVAC_MODE_COOL)
         if self.device.get("available_schedules") != ["None"]:

--- a/custom_components/plugwise/climate.py
+++ b/custom_components/plugwise/climate.py
@@ -85,9 +85,13 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity):
             if self.gateway["smile_name"] == "Anna":
                 self._attr_hvac_modes.append(HVAC_MODE_HEAT_COOL)
                 self._attr_hvac_modes.remove(HVAC_MODE_HEAT)
-            if self.gateway["smile_name"] == "Adam" and self.coordinator.data.devices[
-                self.gateway["gateway_id"]
-            ]["regulation_mode"] == "cooling":
+            if (
+                self.gateway["smile_name"] == "Adam"
+                and self.coordinator.data.devices[self.gateway["gateway_id"]][
+                    "regulation_mode"
+                ]
+                == "cooling"
+            ):
                 self._attr_hvac_modes.append(HVAC_MODE_COOL)
                 self._attr_hvac_modes.remove(HVAC_MODE_HEAT)
         if self.device["available_schedules"] != ["None"]:
@@ -132,7 +136,9 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity):
             if self.device["control_state"] in ["heating", "preheating"]:
                 return CURRENT_HVAC_HEAT
         else:
-            heater_central_data = self.coordinator.data.devices[self.gateway["heater_id"]]
+            heater_central_data = self.coordinator.data.devices[
+                self.gateway["heater_id"]
+            ]
             if heater_central_data["binary_sensors"]["heating_state"]:
                 return CURRENT_HVAC_HEAT
             if heater_central_data["binary_sensors"]["cooling_state"]:
@@ -160,7 +166,9 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity):
             raise HomeAssistantError("Unsupported hvac_mode")
 
         if hvac_mode == HVAC_MODE_AUTO and not self.device.get("schedule_temperature"):
-            raise HomeAssistantError("Cannot set HVAC mode to Auto: No schedule available")
+            raise HomeAssistantError(
+                "Cannot set HVAC mode to Auto: No schedule available"
+            )
 
         await self.coordinator.api.set_schedule_state(
             self.device["location"],

--- a/custom_components/plugwise/climate.py
+++ b/custom_components/plugwise/climate.py
@@ -83,10 +83,10 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity):
         # Determine hvac modes and current hvac mode
         self._attr_hvac_modes = [HVAC_MODE_HEAT]
         if self.gateway["cooling_present"]:
-            if self.gateway["name"] == "Anna":
+            if self.gateway["smile_name"] == "Anna":
                 self._attr_hvac_modes.append(HVAC_MODE_HEAT_COOL)
                 self._attr_hvac_modes.remove(HVAC_MODE_HEAT)
-            if self.gateway["name"] == "Adam" and self.coordinator.data.devices[self.gateway["gateway_id"]]["regulation_mode"] == "cooling":
+            if self.gateway["smile_name"] == "Adam" and self.coordinator.data.devices[self.gateway["gateway_id"]]["regulation_mode"] == "cooling":
                 self._attr_hvac_modes.append(HVAC_MODE_COOL)
                 self._attr_hvac_modes.remove(HVAC_MODE_HEAT)
         if self.device.get("available_schedules") != ["None"]:

--- a/custom_components/plugwise/config_flow.py
+++ b/custom_components/plugwise/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for Plugwise integration."""
 from __future__ import annotations
 
-from datetime import timedelta  # pw-beta
+import datetime as dt  # pw-beta
 from typing import Any
 
 from plugwise.exceptions import (
@@ -338,13 +338,15 @@ class PlugwiseOptionsFlowHandler(config_entries.OptionsFlow):
             return self.async_create_entry(title="", data=user_input)
 
         coordinator = self.hass.data[DOMAIN][self.config_entry.entry_id][COORDINATOR]
-        interval = DEFAULT_SCAN_INTERVAL[coordinator.api.smile_type]  # pw-beta
+        interval: dt.timedelta = DEFAULT_SCAN_INTERVAL[coordinator.api.smile_type]  # pw-beta
 
         data = {
             vol.Optional(
-                timedelta(seconds=int(CONF_SCAN_INTERVAL)),
-                default=interval,
-            ): timedelta,
+                CONF_SCAN_INTERVAL,
+                default=self.config_entry.options.get(
+                    CONF_SCAN_INTERVAL,interval.seconds
+                )
+            ): int,
         }  # pw-beta
 
         if coordinator.api.smile_type != "thermostat":

--- a/custom_components/plugwise/config_flow.py
+++ b/custom_components/plugwise/config_flow.py
@@ -338,14 +338,16 @@ class PlugwiseOptionsFlowHandler(config_entries.OptionsFlow):
             return self.async_create_entry(title="", data=user_input)
 
         coordinator = self.hass.data[DOMAIN][self.config_entry.entry_id][COORDINATOR]
-        interval: dt.timedelta = DEFAULT_SCAN_INTERVAL[coordinator.api.smile_type]  # pw-beta
+        interval: dt.timedelta = DEFAULT_SCAN_INTERVAL[
+            coordinator.api.smile_type
+        ]  # pw-beta
 
         data = {
             vol.Optional(
                 CONF_SCAN_INTERVAL,
                 default=self.config_entry.options.get(
                     CONF_SCAN_INTERVAL, interval.seconds
-                )
+                ),
             ): int,
         }  # pw-beta
 

--- a/custom_components/plugwise/config_flow.py
+++ b/custom_components/plugwise/config_flow.py
@@ -344,7 +344,7 @@ class PlugwiseOptionsFlowHandler(config_entries.OptionsFlow):
             vol.Optional(
                 CONF_SCAN_INTERVAL,
                 default=self.config_entry.options.get(
-                    CONF_SCAN_INTERVAL,interval.seconds
+                    CONF_SCAN_INTERVAL, interval.seconds
                 )
             ): int,
         }  # pw-beta

--- a/custom_components/plugwise/config_flow.py
+++ b/custom_components/plugwise/config_flow.py
@@ -348,7 +348,7 @@ class PlugwiseOptionsFlowHandler(config_entries.OptionsFlow):
                 default=self.config_entry.options.get(
                     CONF_SCAN_INTERVAL, interval.seconds
                 ),
-            ): int,
+            ): vol.All(cv.positive_int, vol.Clamp(min=10)),
         }  # pw-beta
 
         if coordinator.api.smile_type != "thermostat":

--- a/custom_components/plugwise/entity.py
+++ b/custom_components/plugwise/entity.py
@@ -77,6 +77,11 @@ class PlugwiseEntity(CoordinatorEntity[PlugwiseDataUpdateCoordinator]):
         """Return data for this device."""
         return self.coordinator.data.devices[self._dev_id]
 
+    @property
+    def gateway(self) -> dict[str, Any]:
+        """Return data for this device."""
+        return self.coordinator.data.gateway
+
     async def async_added_to_hass(self) -> None:
         """Subscribe to updates."""
         self._handle_coordinator_update()

--- a/custom_components/plugwise/gateway.py
+++ b/custom_components/plugwise/gateway.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import asyncio
 import aiohttp
-from datetime import timedelta
+import datetime as dt
 from typing import Any
 import voluptuous as vol
 
@@ -78,10 +78,10 @@ async def async_setup_entry_gw(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass.config_entries.async_update_entry(entry, unique_id=api.smile_hostname)
 
     # pw-beta refresh-interval
-    update_interval = DEFAULT_SCAN_INTERVAL[api.smile_type]
+    update_interval: dt.timedelta = DEFAULT_SCAN_INTERVAL[api.smile_type]
     if custom_time := entry.options.get(CONF_SCAN_INTERVAL):
         update_interval = timedelta(seconds=int(custom_time))
-    LOGGER.debug("DUC update interval: %s", update_interval)
+    LOGGER.debug("DUC update interval: %s", update_interval.seconds)
 
     # pw-beta - update_interval as extra
     coordinator = PlugwiseDataUpdateCoordinator(hass, api, update_interval)

--- a/custom_components/plugwise/gateway.py
+++ b/custom_components/plugwise/gateway.py
@@ -80,7 +80,7 @@ async def async_setup_entry_gw(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # pw-beta refresh-interval
     update_interval: dt.timedelta = DEFAULT_SCAN_INTERVAL[api.smile_type]
     if custom_time := entry.options.get(CONF_SCAN_INTERVAL):
-        update_interval = timedelta(seconds=int(custom_time))
+        update_interval = dt.timedelta(seconds=int(custom_time))
     LOGGER.debug("DUC update interval: %s", update_interval.seconds)
 
     # pw-beta - update_interval as extra

--- a/custom_components/plugwise/manifest.json
+++ b/custom_components/plugwise/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "plugwise",
   "name": "Plugwise Beta",
-  "version": "0.22.2a0",
+  "version": "0.22.2",
   "documentation": "https://github.com/plugwise/plugwise-beta",
   "after_dependencies": ["usb", "zeroconf"],
   "requirements": ["plugwise==0.17.6"],

--- a/custom_components/plugwise/manifest.json
+++ b/custom_components/plugwise/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "plugwise",
   "name": "Plugwise Beta",
-  "version": "0.22.1",
+  "version": "0.22.2a0",
   "documentation": "https://github.com/plugwise/plugwise-beta",
   "after_dependencies": ["usb", "zeroconf"],
   "requirements": ["plugwise==0.17.6"],

--- a/scripts/core-testing.sh
+++ b/scripts/core-testing.sh
@@ -205,8 +205,8 @@ if [ -z "${GITHUB_ACTIONS}" ] || [ "$1" == "quality" ] ; then
 	flake8 tests/components/plugwise/*py || exit
 	echo "... black-ing ..."
 	black homeassistant/components/plugwise/*py tests/components/plugwise/*py || exit
-	# echo "... mypy ..."
-	# script/run-in-env.sh mypy homeassistant/components/plugwise/*.py || exit
+	echo "... mypy ..."
+	script/run-in-env.sh mypy homeassistant/components/plugwise/*.py || exit
 fi # quality
 
 # Copying back not neccesary in actions

--- a/scripts/core-testing.sh
+++ b/scripts/core-testing.sh
@@ -205,8 +205,8 @@ if [ -z "${GITHUB_ACTIONS}" ] || [ "$1" == "quality" ] ; then
 	flake8 tests/components/plugwise/*py || exit
 	echo "... black-ing ..."
 	black homeassistant/components/plugwise/*py tests/components/plugwise/*py || exit
-	echo "... mypy ..."
-	script/run-in-env.sh mypy homeassistant/components/plugwise/*.py || exit
+	# echo "... mypy ..."
+	# script/run-in-env.sh mypy homeassistant/components/plugwise/*.py || exit
 fi # quality
 
 # Copying back not neccesary in actions

--- a/tests/components/plugwise/test_climate.py
+++ b/tests/components/plugwise/test_climate.py
@@ -162,7 +162,6 @@ async def test_anna_climate_entity_attributes(
     assert state.attributes["preset_mode"] == "home"
     assert state.attributes["supported_features"] == 17
     assert state.attributes["temperature"] == 21.0
-    assert state.attributes["selected_schedule"] == "None"
 
 async def test_anna_climate_entity_climate_changes(
     hass: HomeAssistant, mock_smile_anna: MagicMock, init_integration: MockConfigEntry

--- a/tests/components/plugwise/test_climate.py
+++ b/tests/components/plugwise/test_climate.py
@@ -7,7 +7,6 @@ import pytest
 
 from homeassistant.components.climate.const import (
     HVAC_MODE_AUTO,
-    HVAC_MODE_COOL,
     HVAC_MODE_HEAT,
     HVAC_MODE_HEAT_COOL,
 )
@@ -162,6 +161,7 @@ async def test_anna_climate_entity_attributes(
     assert state.attributes["preset_mode"] == "home"
     assert state.attributes["supported_features"] == 17
     assert state.attributes["temperature"] == 21.0
+
 
 async def test_anna_climate_entity_climate_changes(
     hass: HomeAssistant, mock_smile_anna: MagicMock, init_integration: MockConfigEntry

--- a/tests/components/plugwise/test_climate.py
+++ b/tests/components/plugwise/test_climate.py
@@ -9,6 +9,7 @@ from homeassistant.components.climate.const import (
     HVAC_MODE_AUTO,
     HVAC_MODE_COOL,
     HVAC_MODE_HEAT,
+    HVAC_MODE_HEAT_COOL,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
@@ -151,8 +152,7 @@ async def test_anna_climate_entity_attributes(
     assert state
     assert state.state == HVAC_MODE_HEAT
     assert state.attributes["hvac_modes"] == [
-        HVAC_MODE_HEAT,
-        HVAC_MODE_COOL,
+        HVAC_MODE_HEAT_COOL,
     ]
     assert "no_frost" in state.attributes["preset_modes"]
     assert "home" in state.attributes["preset_modes"]

--- a/tests/components/plugwise/test_climate.py
+++ b/tests/components/plugwise/test_climate.py
@@ -162,7 +162,7 @@ async def test_anna_climate_entity_attributes(
     assert state.attributes["preset_mode"] == "home"
     assert state.attributes["supported_features"] == 17
     assert state.attributes["temperature"] == 21.0
-
+    assert state.attributes["selected_schedule"] == "None"
 
 async def test_anna_climate_entity_climate_changes(
     hass: HomeAssistant, mock_smile_anna: MagicMock, init_integration: MockConfigEntry
@@ -206,7 +206,7 @@ async def test_anna_climate_entity_climate_changes(
     )
 
     # Auto mode is not available, no schedules
-    with pytest.raises(ValueError):
+    with pytest.raises(HomeAssistantError):
         await hass.services.async_call(
             "climate",
             "set_hvac_mode",


### PR DESCRIPTION
Changes:
- Add filtering for input: via the `climate.set_xyz` functions invalid inputs can be provided. Until now these were accepted without providing any feedback for Plugwise
-  Improve generation of the `hvac_modes` list: for Anna: `auto` and `heat` / `heat_cool` (`heat_cool` because heating or cooling is executed automatically), and for Adam: `auto` and `heat` or `auto` and `cool` (because switching between heating and cooling is done manually).
- Replace `.get()`s because they are not a great solution in combination with typing hints.
- Proposal for fixing the not working scan_interval option.