### PR TITLE
Improve config_flow: save user input

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,13 @@ Our [`python-plugwise`](https://github.com/plugwise/python-plugwise) python modu
 
 # Changelog
 
-# NEW JAN 2023 [0.34.0] Implement Core Climate and Select translations
-Implement Core PR's #83286 and #84617
+# NEW JAN 2023 [0.34.1] Smile: save user input when adding the integration
+
+# JAN 2023 [0.34.0] Implement Core Climate and Select translations
+- Implement Core PR's #83286 and #84617
 
 # JAN 2023 [0.33.1] Bump plugwise to v0.27.1
-https://github.com/plugwise/python-plugwise/releases/tag/v0.27.1
+- https://github.com/plugwise/python-plugwise/releases/tag/v0.27.1
 
 # DEC 2022 [0.33.0] Smile P1: add support for 3-phase DMSR
 - Add 3-phase support, this requires P1 firmware >= 4.4.2 - via plugwise v0.27.0 - https://github.com/plugwise/python-plugwise/releases/tag/v0.27.0

--- a/custom_components/plugwise/config_flow.py
+++ b/custom_components/plugwise/config_flow.py
@@ -55,6 +55,7 @@ from .const import (
     FLOW_STRETCH,
     FLOW_TYPE,
     FLOW_USB,
+    LOGGER,
     PW_TYPE,
     SMILE,
     STICK,
@@ -107,23 +108,41 @@ async def validate_usb_connection(self, device_path=None) -> tuple[dict[str, str
     return errors, api_stick
 
 
-def _base_gw_schema(discovery_info: ZeroconfServiceInfo | None) -> vol.Schema:
+def _base_gw_schema(
+    discovery_info: ZeroconfServiceInfo | None,
+    user_input: dict[str, Any] | None,
+    ) -> vol.Schema:
     """Generate base schema for gateways."""
-    base_gw_schema = vol.Schema({vol.Required(CONF_PASSWORD): str})
-
     if not discovery_info:
-        base_gw_schema = base_gw_schema.extend(
+        if not user_input:
+            return vol.Schema(
+                {
+                    vol.Required(CONF_PASSWORD): str,
+                    vol.Required(CONF_HOST): str,
+                    vol.Optional(CONF_PORT, default=DEFAULT_PORT): int,
+                    vol.Required(CONF_USERNAME, default=SMILE): vol.In(
+                        {SMILE: FLOW_SMILE, STRETCH: FLOW_STRETCH}
+                    ),
+                }
+            )
+        return vol.Schema(
             {
-                vol.Required(CONF_HOST): str,
-                vol.Optional(CONF_PORT, default=DEFAULT_PORT): int,
-                vol.Required(CONF_USERNAME, default=SMILE): vol.In(
-                    {SMILE: FLOW_SMILE, STRETCH: FLOW_STRETCH}
-                ),
+                vol.Required(
+                    CONF_PASSWORD, default=user_input[CONF_PASSWORD]
+                    ): str,
+                vol.Required(
+                    CONF_HOST, default=user_input[CONF_HOST]
+                    ): str,
+                vol.Optional(
+                    CONF_PORT, default=user_input[CONF_PORT]
+                    ): int,
+                vol.Required(
+                    CONF_USERNAME, default=user_input[CONF_USERNAME]
+                    ): vol.In({SMILE: FLOW_SMILE, STRETCH: FLOW_STRETCH}),
             }
         )
 
-    return base_gw_schema
-
+    return vol.Schema({vol.Required(CONF_PASSWORD): str})
 
 async def validate_gw_input(hass: HomeAssistant, data: dict[str, Any]) -> Smile:
     """
@@ -297,42 +316,57 @@ class PlugwiseConfigFlow(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Handle the initial step when using network/gateway setups."""
+        LOGGER.debug("Step_user: %s", user_input)
         errors: dict[str, str] = {}
 
-        if user_input is not None:
-            if self.discovery_info:
-                user_input[CONF_HOST] = self.discovery_info.host
-                user_input[CONF_PORT] = self.discovery_info.port
-                user_input[CONF_USERNAME] = self._username
+        if not user_input:
+            LOGGER.debug("Show_form...")
+            return self.async_show_form(
+                step_id="user_gateway",
+                data_schema=_base_gw_schema(self.discovery_info, None),
+                errors=errors,
+            )
 
-            try:
-                api = await validate_gw_input(self.hass, user_input)
-            except ConnectionFailedError:
-                errors[CONF_BASE] = "cannot_connect"
-            except InvalidAuthentication:
-                errors[CONF_BASE] = "invalid_auth"
-            except InvalidSetupError:
-                errors[CONF_BASE] = "invalid_setup"
-            except (InvalidXMLError, ResponseError):
-                errors[CONF_BASE] = "response_error"
-            except UnsupportedDeviceError:
-                errors[CONF_BASE] = "unsupported"
-            except Exception:  # pylint: disable=broad-except
-                errors[CONF_BASE] = "unknown"
-            else:
-                await self.async_set_unique_id(
-                    api.smile_hostname or api.gateway_id, raise_on_progress=False
-                )
-                self._abort_if_unique_id_configured()
+        if self.discovery_info:
+            LOGGER.debug("Discovery info: %s", self.discovery_info)
+            user_input[CONF_HOST] = self.discovery_info.host
+            user_input[CONF_PORT] = self.discovery_info.port
+            user_input[CONF_USERNAME] = self._username
+        LOGGER.debug("Starting...")
+        try:
+            LOGGER.debug("Validating...")
+            api = await validate_gw_input(self.hass, user_input)
+        except ConnectionFailedError:
+            errors[CONF_BASE] = "cannot_connect"
+        except InvalidAuthentication:
+            errors[CONF_BASE] = "invalid_auth"
+            LOGGER.debug("Auth error")
+        except InvalidSetupError:
+            errors[CONF_BASE] = "invalid_setup"
+        except (InvalidXMLError, ResponseError):
+            errors[CONF_BASE] = "response_error"
+        except UnsupportedDeviceError:
+            errors[CONF_BASE] = "unsupported"
+        except Exception:  # pylint: disable=broad-except
+            errors[CONF_BASE] = "unknown"
 
-                user_input[PW_TYPE] = API
-                return self.async_create_entry(title=api.smile_name, data=user_input)
+        if errors:
+            LOGGER.debug("Show form again...")
+            LOGGER.debug(user_input)
+            return self.async_show_form(
+                step_id="user_gateway",
+                data_schema=_base_gw_schema(None, user_input),
+                errors=errors,
+            )
 
-        return self.async_show_form(
-            step_id="user_gateway",
-            data_schema=_base_gw_schema(self.discovery_info),
-            errors=errors,
+        LOGGER.debug("No error")
+        await self.async_set_unique_id(
+            api.smile_hostname or api.gateway_id, raise_on_progress=False
         )
+        self._abort_if_unique_id_configured()
+
+        user_input[PW_TYPE] = API
+        return self.async_create_entry(title=api.smile_name, data=user_input)
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None

--- a/custom_components/plugwise/config_flow.py
+++ b/custom_components/plugwise/config_flow.py
@@ -55,7 +55,6 @@ from .const import (
     FLOW_STRETCH,
     FLOW_TYPE,
     FLOW_USB,
-    LOGGER,
     PW_TYPE,
     SMILE,
     STICK,
@@ -311,11 +310,9 @@ class PlugwiseConfigFlow(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Handle the initial step when using network/gateway setups."""
-        LOGGER.debug("Step_user: %s", user_input)
         errors: dict[str, str] = {}
 
         if not user_input:
-            LOGGER.debug("Show_form...")
             return self.async_show_form(
                 step_id="user_gateway",
                 data_schema=_base_gw_schema(self.discovery_info, None),
@@ -323,19 +320,15 @@ class PlugwiseConfigFlow(ConfigFlow, domain=DOMAIN):
             )
 
         if self.discovery_info:
-            LOGGER.debug("Discovery info: %s", self.discovery_info)
             user_input[CONF_HOST] = self.discovery_info.host
             user_input[CONF_PORT] = self.discovery_info.port
             user_input[CONF_USERNAME] = self._username
-        LOGGER.debug("Starting...")
         try:
-            LOGGER.debug("Validating...")
             api = await validate_gw_input(self.hass, user_input)
         except ConnectionFailedError:
             errors[CONF_BASE] = "cannot_connect"
         except InvalidAuthentication:
             errors[CONF_BASE] = "invalid_auth"
-            LOGGER.debug("Auth error")
         except InvalidSetupError:
             errors[CONF_BASE] = "invalid_setup"
         except (InvalidXMLError, ResponseError):
@@ -346,15 +339,12 @@ class PlugwiseConfigFlow(ConfigFlow, domain=DOMAIN):
             errors[CONF_BASE] = "unknown"
 
         if errors:
-            LOGGER.debug("Show form again...")
-            LOGGER.debug(user_input)
             return self.async_show_form(
                 step_id="user_gateway",
                 data_schema=_base_gw_schema(None, user_input),
                 errors=errors,
             )
 
-        LOGGER.debug("No error")
         await self.async_set_unique_id(
             api.smile_hostname or api.gateway_id, raise_on_progress=False
         )

--- a/custom_components/plugwise/config_flow.py
+++ b/custom_components/plugwise/config_flow.py
@@ -127,18 +127,12 @@ def _base_gw_schema(
             )
         return vol.Schema(
             {
-                vol.Required(
-                    CONF_PASSWORD, default=user_input[CONF_PASSWORD]
-                ): str,
-                vol.Required(
-                    CONF_HOST, default=user_input[CONF_HOST]
-                ): str,
-                vol.Optional(
-                    CONF_PORT, default=user_input[CONF_PORT]
-                ): int,
-                vol.Required(
-                    CONF_USERNAME, default=user_input[CONF_USERNAME]
-                ): vol.In({SMILE: FLOW_SMILE, STRETCH: FLOW_STRETCH}),
+                vol.Required(CONF_PASSWORD, default=user_input[CONF_PASSWORD]): str,
+                vol.Required(CONF_HOST, default=user_input[CONF_HOST]): str,
+                vol.Optional(CONF_PORT, default=user_input[CONF_PORT]): int,
+                vol.Required(CONF_USERNAME, default=user_input[CONF_USERNAME]): vol.In(
+                    {SMILE: FLOW_SMILE, STRETCH: FLOW_STRETCH}
+                ),
             }
         )
 

--- a/custom_components/plugwise/config_flow.py
+++ b/custom_components/plugwise/config_flow.py
@@ -111,7 +111,7 @@ async def validate_usb_connection(self, device_path=None) -> tuple[dict[str, str
 def _base_gw_schema(
     discovery_info: ZeroconfServiceInfo | None,
     user_input: dict[str, Any] | None,
-    ) -> vol.Schema:
+) -> vol.Schema:
     """Generate base schema for gateways."""
     if not discovery_info:
         if not user_input:
@@ -129,20 +129,21 @@ def _base_gw_schema(
             {
                 vol.Required(
                     CONF_PASSWORD, default=user_input[CONF_PASSWORD]
-                    ): str,
+                ): str,
                 vol.Required(
                     CONF_HOST, default=user_input[CONF_HOST]
-                    ): str,
+                ): str,
                 vol.Optional(
                     CONF_PORT, default=user_input[CONF_PORT]
-                    ): int,
+                ): int,
                 vol.Required(
                     CONF_USERNAME, default=user_input[CONF_USERNAME]
-                    ): vol.In({SMILE: FLOW_SMILE, STRETCH: FLOW_STRETCH}),
+                ): vol.In({SMILE: FLOW_SMILE, STRETCH: FLOW_STRETCH}),
             }
         )
 
     return vol.Schema({vol.Required(CONF_PASSWORD): str})
+
 
 async def validate_gw_input(hass: HomeAssistant, data: dict[str, Any]) -> Smile:
     """

--- a/custom_components/plugwise/manifest.json
+++ b/custom_components/plugwise/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "plugwise",
   "name": "Plugwise Beta",
-  "version": "0.34.1a0",
+  "version": "0.34.1",
   "documentation": "https://github.com/plugwise/plugwise-beta",
   "after_dependencies": ["usb", "zeroconf"],
   "requirements": ["plugwise==0.27.1"],

--- a/custom_components/plugwise/manifest.json
+++ b/custom_components/plugwise/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "plugwise",
   "name": "Plugwise Beta",
-  "version": "0.34.0",
+  "version": "0.34.1a0",
   "documentation": "https://github.com/plugwise/plugwise-beta",
   "after_dependencies": ["usb", "zeroconf"],
   "requirements": ["plugwise==0.27.1"],

--- a/custom_components/plugwise/strings.json
+++ b/custom_components/plugwise/strings.json
@@ -50,7 +50,7 @@
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "invalid_auth": "Invalid authentication, check the 8 characters of your ID",
+      "invalid_auth": "Authentication failed",
       "invalid_setup": "Add your Adam instead of your Anna, see the documentation",
       "network_down": "Plugwise Zigbee network is down",
       "network_timeout": "Network communication timeout",

--- a/custom_components/plugwise/translations/en.json
+++ b/custom_components/plugwise/translations/en.json
@@ -50,7 +50,7 @@
     },
     "error": {
       "cannot_connect": "Failed to connect",
-      "invalid_auth": "Invalid authentication, check the 8 characters of your ID",
+      "invalid_auth": "Authentication failed",
       "invalid_setup": "Add your Adam instead of your Anna, see the documentation",
       "network_down": "Plugwise Zigbee network is down",
       "network_timeout": "Network communication timeout",

--- a/custom_components/plugwise/translations/nl.json
+++ b/custom_components/plugwise/translations/nl.json
@@ -50,7 +50,7 @@
     },
     "error": {
       "cannot_connect": "Verbinden is mislukt",
-      "invalid_auth": "Authenticatie mislukt, voer de 8 karakters van je ID goed in",
+      "invalid_auth": "Authenticatie mislukt",
       "invalid_setup": "Voeg je Adam toe in plaats van je Anna, lees de documentatie",
       "network_down": "Plugwise Zigbee netwerk is onbereikbaar",
       "network_timeout": "Network communicatie timeout",


### PR DESCRIPTION
The updated code saves the provided input for a next attempt, when adding the Plugwise integration fails, due to e.g. a typing error.