### PR TITLE
Core v Beta progress update

### DIFF
--- a/custom_components/plugwise/__init__.py
+++ b/custom_components/plugwise/__init__.py
@@ -1,4 +1,4 @@
-"""Plugwise beta for Home Assistant Core."""
+"""Plugwise platform for Home Assistant Core."""
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST

--- a/custom_components/plugwise/__init__.py
+++ b/custom_components/plugwise/__init__.py
@@ -4,17 +4,17 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 
-from .const import CONF_USB_PATH  # pw-beta
+from .const import CONF_USB_PATH  # pw-beta usb
 from .gateway import async_setup_entry_gw, async_unload_entry_gw
-from .usb import async_setup_entry_usb, async_unload_entry_usb  # pw-beta
+from .usb import async_setup_entry_usb, async_unload_entry_usb  # pw-beta usb
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Plugwise components from a config entry."""
     if entry.data.get(CONF_HOST):
         return await async_setup_entry_gw(hass, entry)
-    if entry.data.get(CONF_USB_PATH):  # pw-beta
-        return await async_setup_entry_usb(hass, entry)  # pw-beta
+    if entry.data.get(CONF_USB_PATH):  # pw-beta usb
+        return await async_setup_entry_usb(hass, entry)  # pw-beta usb
     return False  # pragma: no cover
 
 
@@ -22,6 +22,6 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload the Plugwise components."""
     if entry.data.get(CONF_HOST):
         return await async_unload_entry_gw(hass, entry)
-    if entry.data.get(CONF_USB_PATH):  # pw-beta
-        return await async_unload_entry_usb(hass, entry)  # pw-beta
+    if entry.data.get(CONF_USB_PATH):  # pw-beta usb
+        return await async_unload_entry_usb(hass, entry)  # pw-beta usb
     return False  # pragma: no cover

--- a/custom_components/plugwise/__init__.py
+++ b/custom_components/plugwise/__init__.py
@@ -4,17 +4,17 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 
-from .const import CONF_USB_PATH
+from .const import CONF_USB_PATH  # pw-beta
 from .gateway import async_setup_entry_gw, async_unload_entry_gw
-from .usb import async_setup_entry_usb, async_unload_entry_usb
+from .usb import async_setup_entry_usb, async_unload_entry_usb  # pw-beta
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Plugwise components from a config entry."""
     if entry.data.get(CONF_HOST):
         return await async_setup_entry_gw(hass, entry)
-    if entry.data.get(CONF_USB_PATH):
-        return await async_setup_entry_usb(hass, entry)
+    if entry.data.get(CONF_USB_PATH):  # pw-beta
+        return await async_setup_entry_usb(hass, entry)  # pw-beta
     return False  # pragma: no cover
 
 
@@ -22,6 +22,6 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload the Plugwise components."""
     if entry.data.get(CONF_HOST):
         return await async_unload_entry_gw(hass, entry)
-    if entry.data.get(CONF_USB_PATH):
-        return await async_unload_entry_usb(hass, entry)
+    if entry.data.get(CONF_USB_PATH):  # pw-beta
+        return await async_unload_entry_usb(hass, entry)  # pw-beta
     return False  # pragma: no cover

--- a/custom_components/plugwise/binary_sensor.py
+++ b/custom_components/plugwise/binary_sensor.py
@@ -12,33 +12,27 @@ from homeassistant.helpers import entity_platform
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from plugwise.nodes import PlugwiseNode
 
-from .const import (
-    ATTR_SCAN_DAYLIGHT_MODE,
-    ATTR_SCAN_RESET_TIMER,
-    ATTR_SCAN_SENSITIVITY_MODE,
-    ATTR_SED_CLOCK_INTERVAL,
-    ATTR_SED_CLOCK_SYNC,
-    ATTR_SED_MAINTENANCE_INTERVAL,
-    ATTR_SED_SLEEP_FOR,
-    ATTR_SED_STAY_ACTIVE,
-    CB_NEW_NODE,
-    COORDINATOR,
-    DOMAIN,
-    LOGGER,
-    PW_TYPE,
-    SERVICE_USB_SCAN_CONFIG,
-    SERVICE_USB_SCAN_CONFIG_SCHEMA,
-    SERVICE_USB_SED_BATTERY_CONFIG,
-    SERVICE_USB_SED_BATTERY_CONFIG_SCHEMA,
-    SEVERITIES,
-    STICK,
-    USB,
-    USB_MOTION_ID,
-)
+from .const import ATTR_SCAN_DAYLIGHT_MODE  # pw-beta
+from .const import ATTR_SCAN_RESET_TIMER  # pw-beta
+from .const import ATTR_SCAN_SENSITIVITY_MODE  # pw-beta
+from .const import ATTR_SED_CLOCK_INTERVAL  # pw-beta
+from .const import ATTR_SED_CLOCK_SYNC  # pw-beta
+from .const import ATTR_SED_MAINTENANCE_INTERVAL  # pw-beta
+from .const import ATTR_SED_SLEEP_FOR  # pw-beta
+from .const import ATTR_SED_STAY_ACTIVE  # pw-beta
+from .const import CB_NEW_NODE  # pw-beta
+from .const import COORDINATOR, DOMAIN, LOGGER, SEVERITIES, STICK
+from .const import PW_TYPE  # pw-beta
+from .const import SERVICE_USB_SCAN_CONFIG  # pw-beta
+from .const import SERVICE_USB_SCAN_CONFIG_SCHEMA  # pw-beta
+from .const import SERVICE_USB_SED_BATTERY_CONFIG  # pw-beta
+from .const import SERVICE_USB_SED_BATTERY_CONFIG_SCHEMA  # pw-beta
+from .const import USB  # pw-beta
+from .const import USB_MOTION_ID  # pw-beta
 from .coordinator import PlugwiseDataUpdateCoordinator
 from .entity import PlugwiseEntity
 from .models import PW_BINARY_SENSOR_TYPES, PlugwiseBinarySensorEntityDescription
-from .usb import PlugwiseUSBEntity
+from .usb import PlugwiseUSBEntity  # pw-beta
 
 PARALLEL_UPDATES = 0
 
@@ -55,7 +49,7 @@ async def async_setup_entry(
     return await async_setup_entry_gateway(hass, config_entry, async_add_entities)
 
 
-async def async_setup_entry_usb(hass, config_entry, async_add_entities):
+async def async_setup_entry_usb(hass, config_entry, async_add_entities):  # pw-beta
     """Set up Plugwise binary sensor based on config_entry."""
     api_stick = hass.data[DOMAIN][config_entry.entry_id][STICK]
     platform = entity_platform.current_platform.get()
@@ -150,8 +144,9 @@ class PlugwiseBinarySensorEntity(PlugwiseEntity, BinarySensorEntity):
     @property
     def is_on(self) -> bool | None:
         """Return true if the binary sensor is on."""
-        # pw-beta: show Plugwise notifications as HA persistent notifications
-        if self._notification:
+        if (
+            self._notification
+        ):  # pw-beta: show Plugwise notifications as HA persistent notifications
             for notify_id, message in self._notification.items():
                 self.hass.components.persistent_notification.async_create(
                     message, "Plugwise Notification:", f"{DOMAIN}.{notify_id}"
@@ -172,17 +167,15 @@ class PlugwiseBinarySensorEntity(PlugwiseEntity, BinarySensorEntity):
         if self.entity_description.key != "plugwise_notification":
             return None
 
-        attrs: dict[str, list[str]] = {}
+        attrs: dict[str, list[str]] = {f"{severity}_msg": [] for severity in SEVERITIES}
         self._notification = {}  # pw-beta
         if notify := self.coordinator.data.gateway["notifications"]:
-            for notify_id, details in notify.items():
+            for notify_id, details in notify.items():  # pw-beta uses notify_id
                 for msg_type, msg in details.items():
                     msg_type = msg_type.lower()
                     if msg_type not in SEVERITIES:
                         msg_type = "other"  # pragma: no cover
 
-                    if f"{msg_type}_msg" not in attrs:
-                        attrs[f"{msg_type}_msg"] = []
                     attrs[f"{msg_type}_msg"].append(msg)
 
                     self._notification[
@@ -192,6 +185,7 @@ class PlugwiseBinarySensorEntity(PlugwiseEntity, BinarySensorEntity):
         return attrs
 
 
+# pw-beta
 # Github issue #265
 class USBBinarySensor(PlugwiseUSBEntity, BinarySensorEntity):  # type: ignore[misc]
     """Representation of a Plugwise USB Binary Sensor."""

--- a/custom_components/plugwise/binary_sensor.py
+++ b/custom_components/plugwise/binary_sensor.py
@@ -12,10 +12,11 @@ from homeassistant.helpers import entity_platform
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from plugwise.nodes import PlugwiseNode  # pw-beta usb
 
-from .const import COORDINATOR, DOMAIN, LOGGER, SEVERITIES, STICK
-from .const import PW_TYPE  # pw-beta
+from .const import DOMAIN, LOGGER, SEVERITIES
 
 # isort: off
+from .const import COORDINATOR, PW_TYPE  # pw-beta
+
 from .const import (
     ATTR_SCAN_DAYLIGHT_MODE,
     ATTR_SCAN_RESET_TIMER,
@@ -30,6 +31,7 @@ from .const import (
     SERVICE_USB_SCAN_CONFIG_SCHEMA,
     SERVICE_USB_SED_BATTERY_CONFIG,
     SERVICE_USB_SED_BATTERY_CONFIG_SCHEMA,
+    STICK,
     USB,
     USB_MOTION_ID,
 )  # pw-beta usb

--- a/custom_components/plugwise/binary_sensor.py
+++ b/custom_components/plugwise/binary_sensor.py
@@ -167,6 +167,8 @@ class PlugwiseBinarySensorEntity(PlugwiseEntity, BinarySensorEntity):
         if self.entity_description.key != "plugwise_notification":
             return None
 
+        # pw-beta adjustment with attrs is to only represent severities *with* content
+        # not all severities including those without content as empty lists
         attrs: dict[str, list[str]] = {}  # pw-beta Re-evaluate against Core
         self._notification = {}  # pw-beta
         if notify := self.coordinator.data.gateway["notifications"]:

--- a/custom_components/plugwise/binary_sensor.py
+++ b/custom_components/plugwise/binary_sensor.py
@@ -167,7 +167,7 @@ class PlugwiseBinarySensorEntity(PlugwiseEntity, BinarySensorEntity):
         if self.entity_description.key != "plugwise_notification":
             return None
 
-        attrs: dict[str, list[str]] = {f"{severity}_msg": [] for severity in SEVERITIES}
+        attrs: dict[str, list[str]] = {}  # pw-beta Re-evaluate against Core
         self._notification = {}  # pw-beta
         if notify := self.coordinator.data.gateway["notifications"]:
             for notify_id, details in notify.items():  # pw-beta uses notify_id
@@ -176,6 +176,10 @@ class PlugwiseBinarySensorEntity(PlugwiseEntity, BinarySensorEntity):
                     if msg_type not in SEVERITIES:
                         msg_type = "other"  # pragma: no cover
 
+                    if (
+                        f"{msg_type}_msg" not in attrs
+                    ):  # pw-beta Re-evaluate against Core
+                        attrs[f"{msg_type}_msg"] = []
                     attrs[f"{msg_type}_msg"].append(msg)
 
                     self._notification[

--- a/custom_components/plugwise/binary_sensor.py
+++ b/custom_components/plugwise/binary_sensor.py
@@ -10,25 +10,25 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_platform
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from plugwise.nodes import PlugwiseNode
+from plugwise.nodes import PlugwiseNode  # pw-beta usb
 
-from .const import ATTR_SCAN_DAYLIGHT_MODE  # pw-beta
-from .const import ATTR_SCAN_RESET_TIMER  # pw-beta
-from .const import ATTR_SCAN_SENSITIVITY_MODE  # pw-beta
-from .const import ATTR_SED_CLOCK_INTERVAL  # pw-beta
-from .const import ATTR_SED_CLOCK_SYNC  # pw-beta
-from .const import ATTR_SED_MAINTENANCE_INTERVAL  # pw-beta
-from .const import ATTR_SED_SLEEP_FOR  # pw-beta
-from .const import ATTR_SED_STAY_ACTIVE  # pw-beta
-from .const import CB_NEW_NODE  # pw-beta
+from .const import ATTR_SCAN_DAYLIGHT_MODE  # pw-beta usb
+from .const import ATTR_SCAN_RESET_TIMER  # pw-beta usb
+from .const import ATTR_SCAN_SENSITIVITY_MODE  # pw-beta usb
+from .const import ATTR_SED_CLOCK_INTERVAL  # pw-beta usb
+from .const import ATTR_SED_CLOCK_SYNC  # pw-beta usb
+from .const import ATTR_SED_MAINTENANCE_INTERVAL  # pw-beta usb
+from .const import ATTR_SED_SLEEP_FOR  # pw-beta usb
+from .const import ATTR_SED_STAY_ACTIVE  # pw-beta usb
+from .const import CB_NEW_NODE  # pw-beta usb
 from .const import COORDINATOR, DOMAIN, LOGGER, SEVERITIES, STICK
 from .const import PW_TYPE  # pw-beta
-from .const import SERVICE_USB_SCAN_CONFIG  # pw-beta
-from .const import SERVICE_USB_SCAN_CONFIG_SCHEMA  # pw-beta
-from .const import SERVICE_USB_SED_BATTERY_CONFIG  # pw-beta
-from .const import SERVICE_USB_SED_BATTERY_CONFIG_SCHEMA  # pw-beta
-from .const import USB  # pw-beta
-from .const import USB_MOTION_ID  # pw-beta
+from .const import SERVICE_USB_SCAN_CONFIG  # pw-beta usb
+from .const import SERVICE_USB_SCAN_CONFIG_SCHEMA  # pw-beta usb
+from .const import SERVICE_USB_SED_BATTERY_CONFIG  # pw-beta usb
+from .const import SERVICE_USB_SED_BATTERY_CONFIG_SCHEMA  # pw-beta usb
+from .const import USB  # pw-beta usb
+from .const import USB_MOTION_ID  # pw-beta usb
 from .coordinator import PlugwiseDataUpdateCoordinator
 from .entity import PlugwiseEntity
 from .models import PW_BINARY_SENSOR_TYPES, PlugwiseBinarySensorEntityDescription

--- a/custom_components/plugwise/binary_sensor.py
+++ b/custom_components/plugwise/binary_sensor.py
@@ -12,23 +12,30 @@ from homeassistant.helpers import entity_platform
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from plugwise.nodes import PlugwiseNode  # pw-beta usb
 
-from .const import ATTR_SCAN_DAYLIGHT_MODE  # pw-beta usb
-from .const import ATTR_SCAN_RESET_TIMER  # pw-beta usb
-from .const import ATTR_SCAN_SENSITIVITY_MODE  # pw-beta usb
-from .const import ATTR_SED_CLOCK_INTERVAL  # pw-beta usb
-from .const import ATTR_SED_CLOCK_SYNC  # pw-beta usb
-from .const import ATTR_SED_MAINTENANCE_INTERVAL  # pw-beta usb
-from .const import ATTR_SED_SLEEP_FOR  # pw-beta usb
-from .const import ATTR_SED_STAY_ACTIVE  # pw-beta usb
-from .const import CB_NEW_NODE  # pw-beta usb
 from .const import COORDINATOR, DOMAIN, LOGGER, SEVERITIES, STICK
 from .const import PW_TYPE  # pw-beta
-from .const import SERVICE_USB_SCAN_CONFIG  # pw-beta usb
-from .const import SERVICE_USB_SCAN_CONFIG_SCHEMA  # pw-beta usb
-from .const import SERVICE_USB_SED_BATTERY_CONFIG  # pw-beta usb
-from .const import SERVICE_USB_SED_BATTERY_CONFIG_SCHEMA  # pw-beta usb
-from .const import USB  # pw-beta usb
-from .const import USB_MOTION_ID  # pw-beta usb
+
+# isort: off
+from .const import (
+    ATTR_SCAN_DAYLIGHT_MODE,
+    ATTR_SCAN_RESET_TIMER,
+    ATTR_SCAN_SENSITIVITY_MODE,
+    ATTR_SED_CLOCK_INTERVAL,
+    ATTR_SED_CLOCK_SYNC,
+    ATTR_SED_MAINTENANCE_INTERVAL,
+    ATTR_SED_SLEEP_FOR,
+    ATTR_SED_STAY_ACTIVE,
+    CB_NEW_NODE,
+    SERVICE_USB_SCAN_CONFIG,
+    SERVICE_USB_SCAN_CONFIG_SCHEMA,
+    SERVICE_USB_SED_BATTERY_CONFIG,
+    SERVICE_USB_SED_BATTERY_CONFIG_SCHEMA,
+    USB,
+    USB_MOTION_ID,
+)  # pw-beta usb
+
+# isort: on
+
 from .coordinator import PlugwiseDataUpdateCoordinator
 from .entity import PlugwiseEntity
 from .models import PW_BINARY_SENSOR_TYPES, PlugwiseBinarySensorEntityDescription

--- a/custom_components/plugwise/climate.py
+++ b/custom_components/plugwise/climate.py
@@ -134,7 +134,9 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity):
     @property
     def hvac_mode(self) -> HVACMode:
         """Return HVAC operation ie. auto, heat, heat_cool, or off mode."""
-        if (mode := self.device.get("mode")) is None or mode not in self.hvac_modes:
+        if (
+            mode := self.device["mode"]
+        ) is None or mode not in self.hvac_modes:  # pw-beta add to Core
             return HVACMode.HEAT  # pragma: no cover
         # pw-beta homekit emulation
         if self._homekit_enabled and self._homekit_mode == HVACMode.OFF:

--- a/custom_components/plugwise/climate.py
+++ b/custom_components/plugwise/climate.py
@@ -1,7 +1,6 @@
 """Plugwise Climate component for Home Assistant."""
 from __future__ import annotations
 
-from collections.abc import Mapping
 from typing import Any
 
 from homeassistant.components.climate import (
@@ -144,7 +143,7 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity):
         return HVACMode(mode)
 
     @property
-    def hvac_action(self) -> HVACAction | None:
+    def hvac_action(self) -> HVACAction:  # pw-beta add to Core
         """Return the current running hvac operation if supported."""
         # When control_state is present, prefer this data
         if (control_state := self.device.get("control_state")) == "cooling":
@@ -167,14 +166,6 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity):
         return HVACAction.IDLE
 
     @property
-    def extra_state_attributes(self) -> Mapping[str, Any] | None:
-        """Return entity specific state attributes."""
-        return {
-            "available_schemas": self.device["available_schedules"],
-            "selected_schema": self.device["selected_schedule"],
-        }
-
-    @property
     def preset_mode(self) -> str | None:
         """Return the current preset mode."""
         return self.device["active_preset"]
@@ -182,8 +173,10 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity):
     @plugwise_command
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
-        if ATTR_HVAC_MODE in kwargs:  # pw-beta
-            await self.async_set_hvac_mode(kwargs[ATTR_HVAC_MODE])  # pw-beta
+        if ATTR_HVAC_MODE in kwargs:  # pw-beta add to Core
+            await self.async_set_hvac_mode(
+                kwargs[ATTR_HVAC_MODE]
+            )  # pw-beta add to Core
 
         data: dict[str, Any] = {}
         if ATTR_TEMPERATURE in kwargs:

--- a/custom_components/plugwise/climate.py
+++ b/custom_components/plugwise/climate.py
@@ -70,7 +70,6 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity):
     ) -> None:
         """Set up the Plugwise API."""
         super().__init__(coordinator, device_id)
-        self._attr_extra_state_attributes = {}
         self._homekit_enabled = homekit_enabled  # pw-beta homekit emulation
         self._homekit_mode: str | None = None  # pw-beta homekit emulation
         self._attr_unique_id = f"{device_id}-climate"

--- a/custom_components/plugwise/config_flow.py
+++ b/custom_components/plugwise/config_flow.py
@@ -1,10 +1,10 @@
 """Config flow for Plugwise integration."""
 from __future__ import annotations
 
-import datetime as dt  # pw-beta
+import datetime as dt  # pw-beta options
 from typing import Any
 
-import serial.tools.list_ports
+import serial.tools.list_ports  # pw-beta usb
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -29,47 +29,51 @@ from plugwise.exceptions import (
     InvalidAuthentication,
     InvalidSetupError,
     InvalidXMLError,
-    NetworkDown,
-    PortError,
     ResponseError,
-    StickInitError,
-    TimeoutException,
     UnsupportedDeviceError,
 )
+
+# pw-beta Note; the below are explicit through isort
+from plugwise.exceptions import NetworkDown  # pw-beta usb
+from plugwise.exceptions import PortError  # pw-beta usb
+from plugwise.exceptions import StickInitError  # pw-beta usb
+from plugwise.exceptions import TimeoutException  # pw-beta usb
 from plugwise.smile import Smile
-from plugwise.stick import Stick
+from plugwise.stick import Stick  # pw-beta usb
 
 from .const import (
     API,
-    CONF_MANUAL_PATH,
-    CONF_USB_PATH,
     COORDINATOR,
     DEFAULT_PORT,
     DEFAULT_USERNAME,
     DOMAIN,
-    FLOW_NET,
     FLOW_SMILE,
     FLOW_STRETCH,
-    FLOW_TYPE,
-    FLOW_USB,
     PW_TYPE,
     SMILE,
-    STICK,
     STRETCH,
     STRETCH_USERNAME,
     ZEROCONF_MAP,
 )
+
+# pw-beta Note; the below are explicit through isort
 from .const import CONF_HOMEKIT_EMULATION  # pw-beta option
+from .const import CONF_MANUAL_PATH  # pw-beta usb
 from .const import CONF_REFRESH_INTERVAL  # pw-beta option
+from .const import CONF_USB_PATH  # pw-beta usb
 from .const import DEFAULT_SCAN_INTERVAL  # pw-beta option
+from .const import FLOW_NET  # pw-beta usb
+from .const import FLOW_TYPE  # pw-beta usb
+from .const import FLOW_USB  # pw-beta usb
+from .const import STICK  # pw-beta usb
 
 CONNECTION_SCHEMA = vol.Schema(
     {vol.Required(FLOW_TYPE, default=FLOW_NET): vol.In([FLOW_NET, FLOW_USB])}
-)
+)  # pw-beta usb
 
 
 @callback
-def plugwise_stick_entries(hass):
+def plugwise_stick_entries(hass):  # pw-beta usb
     """Return existing connections for Plugwise USB-stick domain."""
     sticks = []
     for entry in hass.config_entries.async_entries(DOMAIN):
@@ -81,7 +85,9 @@ def plugwise_stick_entries(hass):
 # Github issue: #265
 # Might be a `tuple[dict[str, str], Stick | None]` for typing, but that throws
 # Item None of Optional[Any] not having attribute mac [union-attr]
-async def validate_usb_connection(self, device_path=None) -> tuple[dict[str, str], Any]:
+async def validate_usb_connection(
+    self, device_path=None
+) -> tuple[dict[str, str], Any]:  # pw-beta usb
     """Test if device_path is a real Plugwise USB-Stick."""
     errors = {}
 
@@ -240,7 +246,7 @@ class PlugwiseConfigFlow(ConfigFlow, domain=DOMAIN):
 
     async def async_step_user_usb(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    ) -> FlowResult:  # pw-beta usb
         """Step when user initializes a integration."""
         errors: dict[str, str] = {}
         ports = await self.hass.async_add_executor_job(serial.tools.list_ports.comports)
@@ -278,7 +284,7 @@ class PlugwiseConfigFlow(ConfigFlow, domain=DOMAIN):
 
     async def async_step_manual_path(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    ) -> FlowResult:  # pw-beta usb
         """Step when manual path to device."""
         errors: dict[str, str] = {}
         if user_input is not None:
@@ -369,10 +375,11 @@ class PlugwiseConfigFlow(ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
-    # pw-beta
     @staticmethod
     @callback
-    def async_get_options_flow(config_entry: ConfigEntry) -> config_entries.OptionsFlow:
+    def async_get_options_flow(
+        config_entry: ConfigEntry,
+    ) -> config_entries.OptionsFlow:  # pw-beta options
         """Get the options flow for this handler."""
         return PlugwiseOptionsFlowHandler(config_entry)
 
@@ -380,7 +387,7 @@ class PlugwiseConfigFlow(ConfigFlow, domain=DOMAIN):
 # pw-beta - change the scan-interval via CONFIGURE
 # pw-beta - add homekit emulation via CONFIGURE
 # pw-beta - change the frontend refresh interval via CONFIGURE
-class PlugwiseOptionsFlowHandler(config_entries.OptionsFlow):
+class PlugwiseOptionsFlowHandler(config_entries.OptionsFlow):  # pw-beta options
     """Plugwise option flow."""
 
     def __init__(self, config_entry: ConfigEntry) -> None:  # pragma: no cover
@@ -410,7 +417,7 @@ class PlugwiseOptionsFlowHandler(config_entries.OptionsFlow):
         coordinator = self.hass.data[DOMAIN][self.config_entry.entry_id][COORDINATOR]
         interval: dt.timedelta = DEFAULT_SCAN_INTERVAL[
             coordinator.api.smile_type
-        ]  # pw-beta
+        ]  # pw-beta options
 
         data = {
             vol.Optional(

--- a/custom_components/plugwise/config_flow.py
+++ b/custom_components/plugwise/config_flow.py
@@ -8,7 +8,7 @@ import serial.tools.list_ports  # pw-beta usb
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.components import usb
+from homeassistant.components import usb  # pw-beta usb
 from homeassistant.components.zeroconf import ZeroconfServiceInfo
 from homeassistant.config_entries import ConfigEntry, ConfigFlow
 from homeassistant.const import (

--- a/custom_components/plugwise/const.py
+++ b/custom_components/plugwise/const.py
@@ -1,9 +1,9 @@
-"""Constants for Plugwise beta component."""
+"""Constants for Plugwise component."""
 from datetime import timedelta
 import logging
 from typing import Final
 
-import voluptuous as vol
+import voluptuous as vol  # pw-beta usb
 
 from homeassistant.const import Platform
 from homeassistant.helpers import config_validation as cv
@@ -14,8 +14,8 @@ LOGGER = logging.getLogger(__package__)
 
 API: Final = "api"
 COORDINATOR: Final = "coordinator"
-CONF_HOMEKIT_EMULATION: Final = "homekit_emulation"  # pw-beta
-CONF_REFRESH_INTERVAL: Final = "refresh_interval"  # pw-beta
+CONF_HOMEKIT_EMULATION: Final = "homekit_emulation"  # pw-beta options
+CONF_REFRESH_INTERVAL: Final = "refresh_interval"  # pw-beta options
 CONF_MANUAL_PATH: Final = "Enter Manually"
 GATEWAY: Final = "gateway"
 PW_TYPE: Final = "plugwise_type"
@@ -160,7 +160,7 @@ SERVICE_USB_DEVICE_ADD: Final = "device_add"
 SERVICE_USB_DEVICE_REMOVE: Final = "device_remove"
 SERVICE_USB_DEVICE_SCHEMA: Final = vol.Schema(
     {vol.Required(ATTR_MAC_ADDRESS): cv.string}
-)
+)  # pw-beta usb
 
 
 # USB Relay device constants

--- a/custom_components/plugwise/coordinator.py
+++ b/custom_components/plugwise/coordinator.py
@@ -37,7 +37,7 @@ class PlugwiseDataUpdateCoordinator(DataUpdateCoordinator[PlugwiseData]):
 
     def __init__(
         self, hass: HomeAssistant, entry: ConfigEntry, cooldown: float
-    ) -> None:  # pw-beta add to Core
+    ) -> None:  # pw-beta cooldown
         """Initialize the coordinator."""
         super().__init__(
             hass,

--- a/custom_components/plugwise/coordinator.py
+++ b/custom_components/plugwise/coordinator.py
@@ -3,13 +3,8 @@ from datetime import timedelta
 from typing import NamedTuple, cast
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (
-    CONF_HOST,
-    CONF_PASSWORD,
-    CONF_PORT,
-    CONF_SCAN_INTERVAL,
-    CONF_USERNAME,
-)
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNAME
+from homeassistant.const import CONF_SCAN_INTERVAL  # pw-beta options
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryError
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -25,7 +20,6 @@ from plugwise.exceptions import (
     UnsupportedDeviceError,
 )
 
-# pw-beta - for core compat should import DEFAULT_SCAN_INTERVAL
 from .const import DEFAULT_PORT, DEFAULT_SCAN_INTERVAL, DEFAULT_USERNAME, DOMAIN, LOGGER
 
 
@@ -43,7 +37,7 @@ class PlugwiseDataUpdateCoordinator(DataUpdateCoordinator[PlugwiseData]):
 
     def __init__(
         self, hass: HomeAssistant, entry: ConfigEntry, cooldown: float
-    ) -> None:
+    ) -> None:  # pw-beta add to Core
         """Initialize the coordinator."""
         super().__init__(
             hass,
@@ -78,16 +72,15 @@ class PlugwiseDataUpdateCoordinator(DataUpdateCoordinator[PlugwiseData]):
         self.api.get_all_devices()
         self.name = self.api.smile_name
 
-        # pw-beta scan-interval
         self.update_interval = DEFAULT_SCAN_INTERVAL.get(
             self.api.smile_type, timedelta(seconds=60)
-        )
+        )  # pw-beta options scan-interval
         if (custom_time := self._entry.options.get(CONF_SCAN_INTERVAL)) is not None:
             self.update_interval = timedelta(
                 seconds=int(custom_time)
-            )  # pragma: no cover
+            )  # pragma: no cover  # pw-beta options
 
-        LOGGER.debug("DUC update interval: %s", self.update_interval)
+        LOGGER.debug("DUC update interval: %s", self.update_interval)  # pw-beta options
 
     async def _async_update_data(self) -> PlugwiseData:
         """Fetch data from Plugwise."""
@@ -101,21 +94,21 @@ class PlugwiseDataUpdateCoordinator(DataUpdateCoordinator[PlugwiseData]):
             if self._unavailable_logged:
                 self._unavailable_logged = False
         except InvalidAuthentication as err:
-            if not self._unavailable_logged:
+            if not self._unavailable_logged:  # pw-beta add to Core
                 self._unavailable_logged = True
                 raise ConfigEntryError("Authentication failed") from err
         except (InvalidXMLError, ResponseError) as err:
-            if not self._unavailable_logged:
+            if not self._unavailable_logged:  # pw-beta add to Core
                 self._unavailable_logged = True
                 raise UpdateFailed(
                     "Invalid XML data, or error indication received from the Plugwise Adam/Smile/Stretch"
                 ) from err
         except UnsupportedDeviceError as err:
-            if not self._unavailable_logged:
+            if not self._unavailable_logged:  # pw-beta add to Core
                 self._unavailable_logged = True
                 raise ConfigEntryError("Device with unsupported firmware") from err
         except ConnectionFailedError as err:
-            if not self._unavailable_logged:
+            if not self._unavailable_logged:  # pw-beta add to Core
                 self._unavailable_logged = True
                 raise UpdateFailed("Failed to connect") from err
 

--- a/custom_components/plugwise/diagnostics.py
+++ b/custom_components/plugwise/diagnostics.py
@@ -6,7 +6,8 @@ from typing import Any
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from .const import COORDINATOR, DOMAIN
+from .const import COORDINATOR  # pw-beta
+from .const import DOMAIN
 from .coordinator import PlugwiseDataUpdateCoordinator
 
 

--- a/custom_components/plugwise/number.py
+++ b/custom_components/plugwise/number.py
@@ -16,7 +16,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from plugwise import Smile
 
-from .const import COORDINATOR, DOMAIN, LOGGER
+from .const import COORDINATOR  # pw-beta
+from .const import DOMAIN, LOGGER
 from .coordinator import PlugwiseDataUpdateCoordinator
 from .entity import PlugwiseEntity
 

--- a/custom_components/plugwise/select.py
+++ b/custom_components/plugwise/select.py
@@ -12,7 +12,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from plugwise import Smile
 
-from .const import COORDINATOR, DOMAIN, LOGGER
+from .const import COORDINATOR  # pw-beta
+from .const import DOMAIN, LOGGER
 from .coordinator import PlugwiseDataUpdateCoordinator
 from .entity import PlugwiseEntity
 

--- a/custom_components/plugwise/sensor.py
+++ b/custom_components/plugwise/sensor.py
@@ -8,9 +8,10 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from plugwise.nodes import PlugwiseNode
 
-from .const import COORDINATOR, DOMAIN, LOGGER, PW_TYPE  # pw-beta
+from .const import DOMAIN, LOGGER
 
 # isort: off
+from .const import COORDINATOR, PW_TYPE  # pw-beta
 from .const import (
     CB_NEW_NODE,
     STICK,

--- a/custom_components/plugwise/sensor.py
+++ b/custom_components/plugwise/sensor.py
@@ -8,8 +8,11 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from plugwise.nodes import PlugwiseNode
 
-from .const import CB_NEW_NODE, COORDINATOR, DOMAIN, LOGGER, STICK, USB  # pw-beta usb
+from .const import CB_NEW_NODE  # pw-beta usb
+from .const import COORDINATOR, DOMAIN, LOGGER
 from .const import PW_TYPE  # pw-beta
+from .const import STICK  # pw-beta usb,
+from .const import USB  # pw-beta usb
 from .coordinator import PlugwiseDataUpdateCoordinator
 from .entity import PlugwiseEntity
 from .models import PW_SENSOR_TYPES, PlugwiseSensorEntityDescription

--- a/custom_components/plugwise/sensor.py
+++ b/custom_components/plugwise/sensor.py
@@ -8,11 +8,12 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from plugwise.nodes import PlugwiseNode
 
-from .const import CB_NEW_NODE, COORDINATOR, DOMAIN, LOGGER, PW_TYPE, STICK, USB
+from .const import CB_NEW_NODE, COORDINATOR, DOMAIN, LOGGER, STICK, USB  # pw-beta usb
+from .const import PW_TYPE  # pw-beta
 from .coordinator import PlugwiseDataUpdateCoordinator
 from .entity import PlugwiseEntity
 from .models import PW_SENSOR_TYPES, PlugwiseSensorEntityDescription
-from .usb import PlugwiseUSBEntity
+from .usb import PlugwiseUSBEntity  # pw-beta usb
 
 PARALLEL_UPDATES = 0
 
@@ -23,13 +24,13 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the Smile switches from a config entry."""
-    if hass.data[DOMAIN][config_entry.entry_id][PW_TYPE] == USB:
+    if hass.data[DOMAIN][config_entry.entry_id][PW_TYPE] == USB:  # pw-beta usb
         return await async_setup_entry_usb(hass, config_entry, async_add_entities)
     # Considered default and for earlier setups without usb/network config_flow
     return await async_setup_entry_gateway(hass, config_entry, async_add_entities)
 
 
-async def async_setup_entry_usb(hass, config_entry, async_add_entities):
+async def async_setup_entry_usb(hass, config_entry, async_add_entities):  # pw-beta usb
     """Set up Plugwise sensor based on config_entry."""
     api_stick = hass.data[DOMAIN][config_entry.entry_id][STICK]
 
@@ -108,7 +109,7 @@ class PlugwiseSensorEntity(PlugwiseEntity, SensorEntity):
 
 
 # Github issue #265
-class USBSensor(PlugwiseUSBEntity, SensorEntity):  # type: ignore[misc]
+class USBSensor(PlugwiseUSBEntity, SensorEntity):  # type: ignore[misc]  # pw-beta usb
     """Representation of a Plugwise USB sensor."""
 
     def __init__(

--- a/custom_components/plugwise/sensor.py
+++ b/custom_components/plugwise/sensor.py
@@ -8,11 +8,16 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from plugwise.nodes import PlugwiseNode
 
-from .const import CB_NEW_NODE  # pw-beta usb
-from .const import COORDINATOR, DOMAIN, LOGGER
-from .const import PW_TYPE  # pw-beta
-from .const import STICK  # pw-beta usb,
-from .const import USB  # pw-beta usb
+from .const import COORDINATOR, DOMAIN, LOGGER, PW_TYPE  # pw-beta
+
+# isort: off
+from .const import (
+    CB_NEW_NODE,
+    STICK,
+    USB,
+)  # pw-beta usb
+
+# isort: on
 from .coordinator import PlugwiseDataUpdateCoordinator
 from .entity import PlugwiseEntity
 from .models import PW_SENSOR_TYPES, PlugwiseSensorEntityDescription

--- a/custom_components/plugwise/switch.py
+++ b/custom_components/plugwise/switch.py
@@ -10,11 +10,20 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from plugwise.nodes import PlugwiseNode
 
-from .const import CB_NEW_NODE, COORDINATOR, DOMAIN, LOGGER, PW_TYPE, SMILE, STICK, USB
+from .const import (  # pw-beta usb
+    CB_NEW_NODE,
+    COORDINATOR,
+    DOMAIN,
+    LOGGER,
+    SMILE,
+    STICK,
+    USB,
+)
+from .const import PW_TYPE  # pw-beta
 from .coordinator import PlugwiseDataUpdateCoordinator
 from .entity import PlugwiseEntity
 from .models import PW_SWITCH_TYPES, PlugwiseSwitchEntityDescription
-from .usb import PlugwiseUSBEntity
+from .usb import PlugwiseUSBEntity  # pw-beta usb
 from .util import plugwise_command
 
 
@@ -24,13 +33,13 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the Smile switches from a config entry."""
-    if hass.data[DOMAIN][config_entry.entry_id][PW_TYPE] == USB:
+    if hass.data[DOMAIN][config_entry.entry_id][PW_TYPE] == USB:  # pw-beta usb
         return await async_setup_entry_usb(hass, config_entry, async_add_entities)
     # Considered default and for earlier setups without usb/network config_flow
     return await async_setup_entry_gateway(hass, config_entry, async_add_entities)
 
 
-async def async_setup_entry_usb(hass, config_entry, async_add_entities):
+async def async_setup_entry_usb(hass, config_entry, async_add_entities):  # pw-beta usb
     """Set up the USB switches from a config entry."""
     api_stick = hass.data[DOMAIN][config_entry.entry_id][STICK]
 
@@ -121,7 +130,7 @@ class PlugwiseSwitchEntity(PlugwiseEntity, SwitchEntity):
 
 
 # Github issue #265
-class USBSwitch(PlugwiseUSBEntity, SwitchEntity):  # type: ignore[misc]
+class USBSwitch(PlugwiseUSBEntity, SwitchEntity):  # type: ignore[misc]  # pw-beta usb
     """Representation of a Stick Node switch."""
 
     def __init__(

--- a/custom_components/plugwise/switch.py
+++ b/custom_components/plugwise/switch.py
@@ -10,16 +10,12 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from plugwise.nodes import PlugwiseNode
 
-from .const import (  # pw-beta usb
-    CB_NEW_NODE,
-    COORDINATOR,
-    DOMAIN,
-    LOGGER,
-    SMILE,
-    STICK,
-    USB,
-)
+from .const import CB_NEW_NODE  # pw-beta usb
+from .const import COORDINATOR, DOMAIN, LOGGER
 from .const import PW_TYPE  # pw-beta
+from .const import SMILE  # pw-beta usb
+from .const import STICK  # pw-beta usb
+from .const import USB  # pw-beta usb
 from .coordinator import PlugwiseDataUpdateCoordinator
 from .entity import PlugwiseEntity
 from .models import PW_SWITCH_TYPES, PlugwiseSwitchEntityDescription

--- a/custom_components/plugwise/switch.py
+++ b/custom_components/plugwise/switch.py
@@ -10,12 +10,18 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from plugwise.nodes import PlugwiseNode
 
-from .const import CB_NEW_NODE  # pw-beta usb
-from .const import COORDINATOR, DOMAIN, LOGGER
-from .const import PW_TYPE  # pw-beta
-from .const import SMILE  # pw-beta usb
-from .const import STICK  # pw-beta usb
-from .const import USB  # pw-beta usb
+from .const import DOMAIN, LOGGER
+
+# isort: off
+from .const import COORDINATOR, PW_TYPE  # pw-beta
+from .const import (
+    CB_NEW_NODE,
+    SMILE,
+    STICK,
+    USB,
+)
+
+# isort: on
 from .coordinator import PlugwiseDataUpdateCoordinator
 from .entity import PlugwiseEntity
 from .models import PW_SWITCH_TYPES, PlugwiseSwitchEntityDescription


### PR DESCRIPTION
Following https://plugwise.github.io/progress/diff.html

Adding `# pw-beta` tags where appropriate to ease up differences

PR is also meant as a step-up to see if we can carve out a way for the Core Team to decide on embedding USB into the Core Plugwise environment. E.g. making sure the 'mammoth' that is now https://plugwise.github.io/progress/diff.html can be used as an oversight and from that we can chunk PRs in a relative quick pace to ensure we embed USB within a month between releases. As such re-breathing live into Core PR 35713 

Checklist as per [Progress diff core/beta](https://plugwise.github.io/progress/diff.html) beginning of March 2023: (note that all `COORDINATOR` relations are under `coordinator.py` to not re-iterate across all domains)

- [x] **USB** `plugwise/__init__.py` replaces placeholders when upstreaming
- [ ] __Generic__/**USB** `plugwise/binary_sensor.py``dataclass` structure needs conformance/decision between beta and core
- [x] __Generic__ `plugwise/climate.py` though mainly 'options' which won't upstream
- [x] **USB** `plugwise/config_flow.py` foremost USB flow handling + some exceptions
- [ ] __Generic__/**USB** `plugwise/const.py` const & dataclass
- [ ] __Generic__ `plugwise/coordinator.py` untouched, needs alignment between beta and core
- [x] __Generic__ `plugwise/diagnostics.py` *) except coordinator
- [x] __Generic__ `plugwise/entity.py` only isorted
- [x] __Generic__ `plugwise/gateway.py` mostly beta-only related things
- [x] __Generic__ `plugwise/manifest.json` no actions needed specifically
- [ ] __Generic__ `plugwise/number.py` needs alignment
- [x] __Generic__ `plugwise/select.py` *) except coordinator
- [ ] __Generic__/**USB** `plugwise/sensor.py` `dataclass` structure needs conformance/decision between beta and core
- [x] **USB** `plugwise/strings.json` 
- [x] **USB** `plugwise/switch.py` 
- [ ] __Generic__ `plugwise/util.py`
