### PR TITLE
isort 2 ruff

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@
 name: Test with HA-core
 
 env:
-  CACHE_VERSION: 3
+  CACHE_VERSION: 4
   DEFAULT_PYTHON: "3.11"
 
 on:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,11 +11,6 @@ default_language_version:
 
 repos:
   # Run manually in CI skipping the branch checks
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.12.0
-    hooks:
-      - id: isort
-        name: "Verifying/updating code using isort"
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,13 @@ default_language_version:
 
 repos:
   # Run manually in CI skipping the branch checks
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.0.272
+    hooks:
+      - id: ruff
+        name: "Ruff-ing code"
+        args:
+          - --fix
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:

--- a/custom_components/plugwise/__init__.py
+++ b/custom_components/plugwise/__init__.py
@@ -13,6 +13,7 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 from plugwise.exceptions import PlugwiseError
 
 from .const import (
+    CONF_REFRESH_INTERVAL,  # pw-beta options
     COORDINATOR,
     DOMAIN,
     LOGGER,
@@ -20,7 +21,6 @@ from .const import (
     SERVICE_DELETE,
     UNDO_UPDATE_LISTENER,
 )
-from .const import CONF_REFRESH_INTERVAL  # pw-beta options
 from .coordinator import PlugwiseDataUpdateCoordinator
 
 

--- a/custom_components/plugwise/binary_sensor.py
+++ b/custom_components/plugwise/binary_sensor.py
@@ -9,8 +9,12 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import COORDINATOR  # pw-beta
-from .const import DOMAIN, LOGGER, SEVERITIES
+from .const import (
+    COORDINATOR,  # pw-beta
+    DOMAIN,
+    LOGGER,
+    SEVERITIES,
+)
 from .coordinator import PlugwiseDataUpdateCoordinator
 from .entity import PlugwiseEntity
 from .models import PW_BINARY_SENSOR_TYPES, PlugwiseBinarySensorEntityDescription

--- a/custom_components/plugwise/climate.py
+++ b/custom_components/plugwise/climate.py
@@ -14,8 +14,6 @@ from homeassistant.components.climate import (
 )
 from homeassistant.components.climate.const import (
     PRESET_AWAY,  # pw-beta homekit emulation
-)
-from homeassistant.components.climate.const import (
     PRESET_HOME,  # pw-beta homekit emulation
 )
 from homeassistant.config_entries import ConfigEntry
@@ -24,9 +22,12 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import CONF_HOMEKIT_EMULATION  # pw-beta homekit emulation
-from .const import COORDINATOR  # pw-beta
-from .const import DOMAIN, MASTER_THERMOSTATS
+from .const import (
+    CONF_HOMEKIT_EMULATION,  # pw-beta homekit emulation
+    COORDINATOR,  # pw-beta
+    DOMAIN,
+    MASTER_THERMOSTATS,
+)
 from .coordinator import PlugwiseDataUpdateCoordinator
 from .entity import PlugwiseEntity
 from .util import plugwise_command

--- a/custom_components/plugwise/config_flow.py
+++ b/custom_components/plugwise/config_flow.py
@@ -33,8 +33,11 @@ from plugwise.exceptions import (
 )
 
 from .const import (
+    CONF_HOMEKIT_EMULATION,  # pw-beta option
+    CONF_REFRESH_INTERVAL,  # pw-beta option
     COORDINATOR,
     DEFAULT_PORT,
+    DEFAULT_SCAN_INTERVAL,  # pw-beta option
     DEFAULT_USERNAME,
     DOMAIN,
     FLOW_SMILE,
@@ -44,9 +47,6 @@ from .const import (
     STRETCH_USERNAME,
     ZEROCONF_MAP,
 )
-from .const import CONF_HOMEKIT_EMULATION  # pw-beta option
-from .const import CONF_REFRESH_INTERVAL  # pw-beta option
-from .const import DEFAULT_SCAN_INTERVAL  # pw-beta option
 
 
 def _base_gw_schema(

--- a/custom_components/plugwise/coordinator.py
+++ b/custom_components/plugwise/coordinator.py
@@ -2,8 +2,13 @@
 from datetime import timedelta
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNAME
-from homeassistant.const import CONF_SCAN_INTERVAL  # pw-beta options
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_PASSWORD,
+    CONF_PORT,
+    CONF_SCAN_INTERVAL,  # pw-beta options
+    CONF_USERNAME,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryError
 from homeassistant.helpers.aiohttp_client import async_get_clientsession

--- a/custom_components/plugwise/diagnostics.py
+++ b/custom_components/plugwise/diagnostics.py
@@ -6,8 +6,10 @@ from typing import Any
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from .const import COORDINATOR  # pw-beta
-from .const import DOMAIN
+from .const import (
+    COORDINATOR,  # pw-beta
+    DOMAIN,
+)
 from .coordinator import PlugwiseDataUpdateCoordinator
 
 

--- a/custom_components/plugwise/number.py
+++ b/custom_components/plugwise/number.py
@@ -16,8 +16,11 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from plugwise import DeviceData, Smile
 
-from .const import COORDINATOR  # pw-beta
-from .const import DOMAIN, LOGGER
+from .const import (
+    COORDINATOR,  # pw-beta
+    DOMAIN,
+    LOGGER,
+)
 from .coordinator import PlugwiseDataUpdateCoordinator
 from .entity import PlugwiseEntity
 

--- a/custom_components/plugwise/select.py
+++ b/custom_components/plugwise/select.py
@@ -12,8 +12,11 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from plugwise import DeviceData, Smile
 
-from .const import COORDINATOR  # pw-beta
-from .const import DOMAIN, LOGGER
+from .const import (
+    COORDINATOR,  # pw-beta
+    DOMAIN,
+    LOGGER,
+)
 from .coordinator import PlugwiseDataUpdateCoordinator
 from .entity import PlugwiseEntity
 

--- a/custom_components/plugwise/sensor.py
+++ b/custom_components/plugwise/sensor.py
@@ -6,8 +6,11 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import COORDINATOR  # pw-beta
-from .const import DOMAIN, LOGGER
+from .const import (
+    COORDINATOR,  # pw-beta
+    DOMAIN,
+    LOGGER,
+)
 from .coordinator import PlugwiseDataUpdateCoordinator
 from .entity import PlugwiseEntity
 from .models import PW_SENSOR_TYPES, PlugwiseSensorEntityDescription

--- a/custom_components/plugwise/switch.py
+++ b/custom_components/plugwise/switch.py
@@ -8,8 +8,11 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import COORDINATOR  # pw-beta
-from .const import DOMAIN, LOGGER
+from .const import (
+    COORDINATOR,  # pw-beta
+    DOMAIN,
+    LOGGER,
+)
 from .coordinator import PlugwiseDataUpdateCoordinator
 from .entity import PlugwiseEntity
 from .models import PW_SWITCH_TYPES, PlugwiseSwitchEntityDescription

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,23 +6,8 @@
 target-version = ["py39", "py310", "py311"]
 exclude = 'generated'
 
-[tool.isort]
-# https://github.com/PyCQA/isort/wiki/isort-Settings
-profile = "black"
-# will group `import x` and `from x import` of the same module.
-force_sort_within_sections = true
-known_first_party = [
-    "plugwise",
-    "homeassistant",
-    "tests",
-]
-forced_separate = [
-    "tests",
-]
-combine_as_imports = true
-
 [tool.ruff]
-target-version = "py310"
+target-version = "py311"
 
 select = [
     "B007", # Loop control variable {name} not used within loop body
@@ -31,6 +16,7 @@ select = [
     "D",  # docstrings
     "E",  # pycodestyle
     "F",  # pyflakes/autoflake
+    "I",  # isort
     "ICN001", # import concentions; {name} should be imported as {asname}
     "PGH004",  # Use specific rule codes when using noqa
     "PLC0414", # Useless import alias. Import alias does not rename original package.
@@ -71,8 +57,12 @@ voluptuous = "vol"
 [tool.ruff.flake8-pytest-style]
 fixture-parentheses = false
 
-[tool.ruff.pyupgrade]
-keep-runtime-typing = true
+[tool.ruff.isort]
+force-sort-within-sections = true
+known-first-party = [
+    "homeassistant",
+]
+combine-as-imports = true
 
 [tool.ruff.per-file-ignores]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,23 @@ select = [
     "ICN001", # import concentions; {name} should be imported as {asname}
     "PGH004",  # Use specific rule codes when using noqa
     "PLC0414", # Useless import alias. Import alias does not rename original package.
+    "S103",  # bad-file-permissions
+    "S108",  # hardcoded-temp-file
+    "S306",  # suspicious-mktemp-usage
+    "S307",  # suspicious-eval-usage
+    "S313",  # suspicious-xmlc-element-tree-usage
+    "S314",  # suspicious-xml-element-tree-usage
+    "S315",  # suspicious-xml-expat-reader-usage
+    "S316",  # suspicious-xml-expat-builder-usage
+    "S317",  # suspicious-xml-sax-usage
+    "S318",  # suspicious-xml-mini-dom-usage
+    "S319",  # suspicious-xml-pull-dom-usage
+    "S320",  # suspicious-xmle-tree-usage
+    "S601",  # paramiko-call
+    "S602",  # subprocess-popen-with-shell-equals-true
+    "S604",  # call-with-shell-equals-true
+    "S608",  # hardcoded-sql-expression
+    "S609",  # unix-command-wildcard-injection
     "SIM105", # Use contextlib.suppress({exception}) instead of try-except-pass
     "SIM117", # Merge with-statements that use the same scope
     "SIM118", # Use {key} in {dict} instead of {key} in {dict}.keys()
@@ -42,6 +59,8 @@ ignore = [
     "D407",  # Section name underlining
     "E501",  # line too long
     "E731",  # do not assign a lambda expression, use a def
+    "UP006", # keep type annotation style as is
+    "UP007", # keep type annotation style as is
     # Ignored due to performance: https://github.com/charliermarsh/ruff/issues/2923
     "UP038", # Use `X | Y` in `isinstance` call instead of `(X, Y)`
 ]
@@ -53,6 +72,7 @@ voluptuous = "vol"
 "homeassistant.helpers.device_registry" = "dr"
 "homeassistant.helpers.entity_registry" = "er"
 "homeassistant.helpers.issue_registry" = "ir"
+"homeassistant.util.dt" = "dt_util"
 
 [tool.ruff.flake8-pytest-style]
 fixture-parentheses = false
@@ -61,15 +81,9 @@ fixture-parentheses = false
 force-sort-within-sections = true
 known-first-party = [
     "homeassistant",
+    "plugwise",
 ]
 combine-as-imports = true
-
-[tool.ruff.per-file-ignores]
-
-# Allow for main entry & scripts to write to stdout
-"homeassistant/__main__.py" = ["T201"]
-"homeassistant/scripts/*" = ["T201"]
-"script/*" = ["T20"]
 
 [tool.ruff.mccabe]
 max-complexity = 25

--- a/scripts/core-testing.sh
+++ b/scripts/core-testing.sh
@@ -17,7 +17,7 @@ set -e
 # Which packages to install (to prevent installing all test requirements)
 # actual package version ARE verified (i.e. grepped) from requirements_test_all
 # separate packages with |
-pip_packages="fnvhash|lru-dict|voluptuous|aiohttp_cors|pyroute2|sqlalchemy|zeroconf|pytest-socket|pre-commit|paho-mqtt|numpy|pydantic|ruff"
+pip_packages="fnvhash|lru-dict|voluptuous|aiohttp-cors|pyroute2|sqlalchemy|zeroconf|pytest-socket|pre-commit|paho-mqtt|numpy|pydantic|ruff"
 
 echo ""
 echo "Checking for necessary tools and preparing setup:"

--- a/scripts/core-testing.sh
+++ b/scripts/core-testing.sh
@@ -205,9 +205,9 @@ if [ -z "${GITHUB_ACTIONS}" ] || [ "$1" == "quality" ] ; then
 	cd "${coredir}" || exit
 	echo ""
 	echo "... ruff-ing component..."
-	ruff homeassistant/components/plugwise/*py || exit
+	ruff --fix homeassistant/components/plugwise/*py || exit
 	echo "... ruff-ing tests..."
-	ruff tests/components/plugwise/*py || exit
+	ruff --fix tests/components/plugwise/*py || exit
 	echo "... black-ing ..."
 	black homeassistant/components/plugwise/*py tests/components/plugwise/*py || exit
 	echo "... Prepping strict without hassfest ... (for mypy)"

--- a/scripts/core-testing.sh
+++ b/scripts/core-testing.sh
@@ -204,10 +204,12 @@ fi # testing
 if [ -z "${GITHUB_ACTIONS}" ] || [ "$1" == "quality" ] ; then 
 	cd "${coredir}" || exit
 	echo ""
+	set +e
 	echo "... ruff-ing component..."
 	ruff --fix homeassistant/components/plugwise/*py || echo "Ruff applied autofixes"
 	echo "... ruff-ing tests..."
 	ruff --fix tests/components/plugwise/*py || echo "Ruff applied autofixes"
+	set -e
 	echo "... black-ing ..."
 	black homeassistant/components/plugwise/*py tests/components/plugwise/*py || exit
 	echo "... Prepping strict without hassfest ... (for mypy)"

--- a/scripts/core-testing.sh
+++ b/scripts/core-testing.sh
@@ -205,9 +205,9 @@ if [ -z "${GITHUB_ACTIONS}" ] || [ "$1" == "quality" ] ; then
 	cd "${coredir}" || exit
 	echo ""
 	echo "... ruff-ing component..."
-	ruff --fix homeassistant/components/plugwise/*py || exit
+	ruff --fix homeassistant/components/plugwise/*py 
 	echo "... ruff-ing tests..."
-	ruff --fix tests/components/plugwise/*py || exit
+	ruff --fix tests/components/plugwise/*py 
 	echo "... black-ing ..."
 	black homeassistant/components/plugwise/*py tests/components/plugwise/*py || exit
 	echo "... Prepping strict without hassfest ... (for mypy)"

--- a/scripts/core-testing.sh
+++ b/scripts/core-testing.sh
@@ -269,7 +269,7 @@ fi
 
 # pylint was removed from 'quality' some time ago
 # this is a much better replacement for actually checking everything
-# including isort and mypy
+# including mypy
 if [ -z "${GITHUB_ACTIONS}" ] && [ -n "${COMMIT_CHECK}" ] ; then 
 	cd "${coredir}" || exit
 	echo ""

--- a/scripts/core-testing.sh
+++ b/scripts/core-testing.sh
@@ -205,9 +205,9 @@ if [ -z "${GITHUB_ACTIONS}" ] || [ "$1" == "quality" ] ; then
 	cd "${coredir}" || exit
 	echo ""
 	echo "... ruff-ing component..."
-	ruff --fix homeassistant/components/plugwise/*py 
+	ruff --fix homeassistant/components/plugwise/*py || echo "Ruff applied autofixes"
 	echo "... ruff-ing tests..."
-	ruff --fix tests/components/plugwise/*py 
+	ruff --fix tests/components/plugwise/*py || echo "Ruff applied autofixes"
 	echo "... black-ing ..."
 	black homeassistant/components/plugwise/*py tests/components/plugwise/*py || exit
 	echo "... Prepping strict without hassfest ... (for mypy)"

--- a/tests/components/plugwise/conftest.py
+++ b/tests/components/plugwise/conftest.py
@@ -18,7 +18,6 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from plugwise import PlugwiseData
-
 from tests.common import MockConfigEntry, load_fixture
 
 

--- a/tests/components/plugwise/test_binary_sensor.py
+++ b/tests/components/plugwise/test_binary_sensor.py
@@ -4,7 +4,6 @@ from unittest.mock import MagicMock
 
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
-
 from tests.common import MockConfigEntry
 
 

--- a/tests/components/plugwise/test_climate.py
+++ b/tests/components/plugwise/test_climate.py
@@ -8,7 +8,6 @@ from homeassistant.components.climate.const import HVACMode
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from plugwise.exceptions import PlugwiseError
-
 from tests.common import MockConfigEntry
 
 TEST_HOST = "1.1.1.1"

--- a/tests/components/plugwise/test_config_flow.py
+++ b/tests/components/plugwise/test_config_flow.py
@@ -30,7 +30,6 @@ from plugwise.exceptions import (
     InvalidXMLError,
     UnsupportedDeviceError,
 )
-
 from tests.common import MockConfigEntry
 
 TEST_HOST = "1.1.1.1"

--- a/tests/components/plugwise/test_diagnostics.py
+++ b/tests/components/plugwise/test_diagnostics.py
@@ -4,7 +4,6 @@ from unittest.mock import MagicMock
 from aiohttp import ClientSession
 
 from homeassistant.core import HomeAssistant
-
 from tests.common import MockConfigEntry
 from tests.components.diagnostics import get_diagnostics_for_config_entry
 

--- a/tests/components/plugwise/test_init.py
+++ b/tests/components/plugwise/test_init.py
@@ -16,7 +16,6 @@ from plugwise.exceptions import (
     ResponseError,
     UnsupportedDeviceError,
 )
-
 from tests.common import MockConfigEntry
 
 HEATER_ID = "1cbf783bb11e4a7c8a6843dee3a86927"  # Opentherm device_id for migration

--- a/tests/components/plugwise/test_number.py
+++ b/tests/components/plugwise/test_number.py
@@ -9,7 +9,6 @@ from homeassistant.components.number import (
 )
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
-
 from tests.common import MockConfigEntry
 
 

--- a/tests/components/plugwise/test_select.py
+++ b/tests/components/plugwise/test_select.py
@@ -9,7 +9,6 @@ from homeassistant.components.select import (
 )
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
-
 from tests.common import MockConfigEntry
 
 

--- a/tests/components/plugwise/test_sensor.py
+++ b/tests/components/plugwise/test_sensor.py
@@ -4,7 +4,6 @@ from unittest.mock import MagicMock
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_registry import async_get
-
 from tests.common import MockConfigEntry
 
 

--- a/tests/components/plugwise/test_switch.py
+++ b/tests/components/plugwise/test_switch.py
@@ -9,7 +9,6 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_registry import async_get
 from plugwise.exceptions import PlugwiseException
-
 from tests.common import MockConfigEntry
 
 


### PR DESCRIPTION
Follow upstream, caveat;
- [ ] ruff is unable to determine where to locate the import within the `custom_component`; i.e.
```
+from plugwise.exceptions import PlugwiseError
 import voluptuous as vol

 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
@@ -10,7 +11,6 @@
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.helpers import device_registry as dr, entity_registry as er
-from plugwise.exceptions import PlugwiseError
```
- [x] Made ruff part of pre-commit check (none-auto-fixing)
- [x] In `scripts/core-testing.sh` for ha-core `--fix` is applied always