### PR TITLE
Link to plugwise v0.32.1, remove py39 compatibility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@
 name: Test with HA-core
 
 env:
-  CACHE_VERSION: 10
+  CACHE_VERSION: 11
   DEFAULT_PYTHON: "3.11"
 
 on:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@
 name: Test with HA-core
 
 env:
-  CACHE_VERSION: 14
+  CACHE_VERSION: 15
   DEFAULT_PYTHON: "3.11"
 
 on:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@
 name: Test with HA-core
 
 env:
-  CACHE_VERSION: 11
+  CACHE_VERSION: 12
   DEFAULT_PYTHON: "3.11"
 
 on:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@
 name: Test with HA-core
 
 env:
-  CACHE_VERSION: 17
+  CACHE_VERSION: 18
   DEFAULT_PYTHON: "3.11"
 
 on:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@
 name: Test with HA-core
 
 env:
-  CACHE_VERSION: 16
+  CACHE_VERSION: 17
   DEFAULT_PYTHON: "3.11"
 
 on:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@
 name: Test with HA-core
 
 env:
-  CACHE_VERSION: 15
+  CACHE_VERSION: 16
   DEFAULT_PYTHON: "3.11"
 
 on:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@
 name: Test with HA-core
 
 env:
-  CACHE_VERSION: 12
+  CACHE_VERSION: 14
   DEFAULT_PYTHON: "3.11"
 
 on:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@
 name: Test with HA-core
 
 env:
-  CACHE_VERSION: 9
+  CACHE_VERSION: 10
   DEFAULT_PYTHON: "3.11"
 
 on:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
     hooks:
       - id: pyupgrade
         name: "Checking pyupgrade"
-        args: [--py39-plus]
+        args: [--py311-plus]
   - repo: https://github.com/psf/black
     rev: 23.7.0
     hooks:
@@ -82,7 +82,7 @@ repos:
         name: "Verifying code for typing-update"
         stages: [manual]
         args:
-          - --py39-plus
+          - --py311-plus
           - --force
           - --keep-updates
         files: ^(custom_components|tests)/.+\.py$

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,42 +8,42 @@
 - Remove python3.9 compatibility: remove/replace all python3.9 references.
 - Implement Ruff sorting fixes - tnx @CoMPaTech for achieving the line-up with the Core Plugwise code.
 - Update p1v4_442_triple testfixture, adding a Plugwise notification for the Smile P1. Add a related testcase.
-- Fix logging, line up for all platforms
-- More lining up with Core Plugwise, quality improvements
-- Test both versus core#dev- and core#master-branches
+- Fix logging, line up for all platforms.
+- More lining up with Core Plugwise, quality improvements.
+- Test both versus core#dev- and core#master-branches.
 
 ### v0.41.1
 
-- Line up with the latest Core Plugwise code
+- Line up with the latest Core Plugwise code.
 
 ### v0.41.0
 
 - New Feature: add a temperature_offset Number for devices that support this function, via [plugwise v0.32.0](https://github.com/plugwise/python-plugwise/releases/tag/v0.32.0)
-- Correct the unit_of_measurement for the temperature_difference sensor
+- Correct the unit_of_measurement for the temperature_difference sensor.
 
 ### v0.40.6
 
 - Typing improvements via [plugwise v0.31.9](https://github.com/plugwise/python-plugwise/releases/tag/v0.31.9)
-- Update fixtures and testfiles related to the updated plugwise backend version
+- Update fixtures and testfiles related to the updated plugwise backend version.
 - Update and simplify number.py and select.py
-- Add services entry to strings.json and translation files
+- Add services entry to strings.json and translation files.
 
 ### v0.40.5
 
 - Backend improvements via [plugwise v0.31.8](https://github.com/plugwise/python-plugwise/releases/tag/v0.31.8),
   adapt to relevant changes as suggested in Core PR #[96915](https://github.com/home-assistant/core/pull/96915#discussion_r1269292691)
-- Backend improvements via [plugwise v0.31.7](https://github.com/plugwise/python-plugwise/releases/tag/v0.31.7), adapt to relevant changes
+- Backend improvements via [plugwise v0.31.7](https://github.com/plugwise/python-plugwise/releases/tag/v0.31.7), adapt to relevant changes.
 - Implement improvements from PR's #93416, #96915
-- Update anna_heatpump_heating test-fixture, update related test-function
+- Update anna_heatpump_heating test-fixture, update related test-function.
 
 ### v0.40.4
 
 - Fix for [#417](https://github.com/plugwise/plugwise-beta/pull/424)
-- Rename Jip sensor `relative_humidity` to `humidity` and migrate the unique_id
+- Rename Jip sensor `relative_humidity` to `humidity` and migrate the unique_id.
 
 ### v0.40.3
 
-- CI improvements, ruff over pylint, adhere to upstream ruff version
+- CI improvements, ruff over pylint, adhere to upstream ruff version.
 - Fix Anna+Elga domestic_hot_water_setpoint-related bug via [plugwise v0.31.6](https://github.com/plugwise/python-plugwise/releases/tag/v0.31.6)
 - Cooling-related fix/improvements via [plugwise v0.31.5](https://github.com/plugwise/python-plugwise/releases/tag/v0.31.5)
 - Improvements via [plugwise v0.31.4](https://github.com/plugwise/python-plugwise/releases/tag/v0.31.4)
@@ -53,7 +53,7 @@
 
 - CI improvements
 - Implement strict typing, also via [plugwise v0.31.3](https://github.com/plugwise/python-plugwise/releases/tag/v0.31.3)
-- Dynamic generated fixtures re-introduced
+- Dynamic generated fixtures re-introduced.
 
 ### 0.40.1
 
@@ -61,8 +61,8 @@
 
 ### 0.40.0
 
-- More formal Split between Networked and USB code
-- Refactoring where necessary
+- More formal Split between Networked and USB code.
+- Refactoring where necessary.
 
 ## Versions from 0.30 and up
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,10 +81,10 @@
 
 - Attempt to fix for reported Plugwise-Beta issue #347 - via plugwise [v0.27.8](https://github.com/plugwise/python-plugwise/releases/tag/v0.27.8)
 - Fix for #368 - via plugwise [v0.27.9](https://github.com/plugwise/python-plugwise/releases/tag/v0.27.0)
-- Fix for #369
-- Added pre-commit and additional linting (no or marginal code changes)
-- Added tagging in #361 to enable a path forward for upstreaming (mostly isort and tagging, no or marginal code changes)
-- Replaceing flake8 linting with ruff as per upstream
+- Fix for #369.
+- Added pre-commit and additional linting (no or marginal code changes).
+- Added tagging in #361 to enable a path forward for upstreaming (mostly isort and tagging, no or marginal code changes).
+- Replaceing flake8 linting with ruff as per upstream.
 
 ### FEB 2023 [0.34.7.1] Stick-bugfix, rename P1 gas-interval sensor, line up with Core Plugwise
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,12 @@
 
 ## Versions from 0.40 and up
 
-### Ongoing
+### v0.41.2
 
+- Link to [plugwise v0.32.1](https://github.com/plugwise/python-plugwise/releases/tag/v0.32.1)
+- Remove python3.9 compatibility: remove/replace all python3.9 references.
+- Implement Ruff sorting fixes - tnx @CoMPaTech for achieving the line-up with the Core Plugwise code.
+- Update p1v4_442_triple testfixture, adding a Plugwise notification for the Smile P1. Add a related testcase.
 - Fix logging, line up for all platforms
 - More lining up with Core Plugwise, quality improvements
 - Test both versus core#dev- and core#master-branches

--- a/custom_components/plugwise/__init__.py
+++ b/custom_components/plugwise/__init__.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 
 from typing import Any
 
+from plugwise.exceptions import PlugwiseError
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.helpers import device_registry as dr, entity_registry as er
-from plugwise.exceptions import PlugwiseError
 
 from .const import (
     CONF_REFRESH_INTERVAL,  # pw-beta options

--- a/custom_components/plugwise/binary_sensor.py
+++ b/custom_components/plugwise/binary_sensor.py
@@ -5,6 +5,8 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any
 
+from plugwise.constants import BinarySensorType
+
 from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
     BinarySensorEntityDescription,
@@ -13,7 +15,6 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from plugwise.constants import BinarySensorType
 
 from .const import (
     COORDINATOR,  # pw-beta

--- a/custom_components/plugwise/config_flow.py
+++ b/custom_components/plugwise/config_flow.py
@@ -4,6 +4,15 @@ from __future__ import annotations
 import datetime as dt  # pw-beta options
 from typing import Any
 
+from plugwise import Smile
+from plugwise.exceptions import (
+    ConnectionFailedError,
+    InvalidAuthentication,
+    InvalidSetupError,
+    InvalidXMLError,
+    ResponseError,
+    UnsupportedDeviceError,
+)
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -22,15 +31,6 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from plugwise import Smile
-from plugwise.exceptions import (
-    ConnectionFailedError,
-    InvalidAuthentication,
-    InvalidSetupError,
-    InvalidXMLError,
-    ResponseError,
-    UnsupportedDeviceError,
-)
 
 from .const import (
     CONF_HOMEKIT_EMULATION,  # pw-beta option

--- a/custom_components/plugwise/coordinator.py
+++ b/custom_components/plugwise/coordinator.py
@@ -1,6 +1,15 @@
 """DataUpdateCoordinator for Plugwise."""
 from datetime import timedelta
 
+from plugwise import PlugwiseData, Smile
+from plugwise.exceptions import (
+    ConnectionFailedError,
+    InvalidAuthentication,
+    InvalidXMLError,
+    ResponseError,
+    UnsupportedDeviceError,
+)
+
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_HOST,
@@ -14,14 +23,6 @@ from homeassistant.exceptions import ConfigEntryError
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
-from plugwise import PlugwiseData, Smile
-from plugwise.exceptions import (
-    ConnectionFailedError,
-    InvalidAuthentication,
-    InvalidXMLError,
-    ResponseError,
-    UnsupportedDeviceError,
-)
 
 from .const import DEFAULT_PORT, DEFAULT_SCAN_INTERVAL, DEFAULT_USERNAME, DOMAIN, LOGGER
 

--- a/custom_components/plugwise/entity.py
+++ b/custom_components/plugwise/entity.py
@@ -1,6 +1,8 @@
 """Generic Plugwise Entity Class."""
 from __future__ import annotations
 
+from plugwise.constants import DeviceData
+
 from homeassistant.const import ATTR_NAME, ATTR_VIA_DEVICE, CONF_HOST
 from homeassistant.helpers.device_registry import (
     CONNECTION_NETWORK_MAC,
@@ -8,7 +10,6 @@ from homeassistant.helpers.device_registry import (
 )
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from plugwise.constants import DeviceData
 
 from .const import DOMAIN
 from .coordinator import PlugwiseDataUpdateCoordinator

--- a/custom_components/plugwise/manifest.json
+++ b/custom_components/plugwise/manifest.json
@@ -8,6 +8,6 @@
   "integration_type": "hub",
   "iot_class": "local_polling",
   "loggers": ["plugwise"],
-  "requirements": ["plugwise==0.32.0"],
-  "version": "0.41.1"
+  "requirements": ["plugwise==0.32.1"],
+  "version": "0.41.2"
 }

--- a/custom_components/plugwise/number.py
+++ b/custom_components/plugwise/number.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 
+from plugwise import Smile
+from plugwise.constants import NumberType
+
 from homeassistant.components.number import (
     NumberDeviceClass,
     NumberEntity,
@@ -14,8 +17,6 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from plugwise import Smile
-from plugwise.constants import NumberType
 
 from .const import (
     COORDINATOR,  # pw-beta

--- a/custom_components/plugwise/select.py
+++ b/custom_components/plugwise/select.py
@@ -4,13 +4,14 @@ from __future__ import annotations
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 
+from plugwise import Smile
+from plugwise.constants import SelectOptionsType, SelectType
+
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_ON, EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from plugwise import Smile
-from plugwise.constants import SelectOptionsType, SelectType
 
 from .const import (
     COORDINATOR,  # pw-beta

--- a/custom_components/plugwise/sensor.py
+++ b/custom_components/plugwise/sensor.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from plugwise.constants import SensorType
+
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
@@ -24,7 +26,6 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from plugwise.constants import SensorType
 
 from .const import (
     COORDINATOR,  # pw-beta

--- a/custom_components/plugwise/switch.py
+++ b/custom_components/plugwise/switch.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
+from plugwise.constants import SwitchType
+
 from homeassistant.components.switch import (
     SwitchDeviceClass,
     SwitchEntity,
@@ -13,7 +15,6 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from plugwise.constants import SwitchType
 
 from .const import (
     COORDINATOR,  # pw-beta

--- a/custom_components/plugwise/util.py
+++ b/custom_components/plugwise/util.py
@@ -2,8 +2,9 @@
 from collections.abc import Awaitable, Callable, Coroutine
 from typing import Any, Concatenate, ParamSpec, TypeVar
 
-from homeassistant.exceptions import HomeAssistantError
 from plugwise.exceptions import PlugwiseException
+
+from homeassistant.exceptions import HomeAssistantError
 
 from .entity import PlugwiseEntity
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,9 +117,15 @@ force-sort-within-sections = true
 section-order = ["future", "standard-library", "first-party", "third-party", "local-folder"]
 known-third-party = [
     "homeassistant",
+    "tests",
 ]
 known-first-party = [
     "plugwise",
+    "voluptuous",
+    "pytest",
+]
+forced-separate = [
+    "tests",
 ]
 combine-as-imports = true
 split-on-trailing-comma = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,16 +10,35 @@ exclude = 'generated'
 target-version = "py311"
 
 select = [
+    "B002", # Python does not support the unary prefix increment
     "B007", # Loop control variable {name} not used within loop body
     "B014", # Exception handler with duplicate exception
+    "B023", # Function definition does not bind loop variable {name}
+    "B026", # Star-arg unpacking after a keyword argument is strongly discouraged
     "C",  # complexity
+    "COM818", # Trailing comma on bare tuple prohibited
     "D",  # docstrings
+    "DTZ003",  # Use datetime.now(tz=) instead of datetime.utcnow()
+    "DTZ004",  # Use datetime.fromtimestamp(ts, tz=) instead of datetime.utcfromtimestamp(ts)
     "E",  # pycodestyle
     "F",  # pyflakes/autoflake
+    "G", # flake8-logging-format
     "I",  # isort
     "ICN001", # import concentions; {name} should be imported as {asname}
+    "ISC001", # Implicitly concatenated string literals on one line
+    "N804", # First argument of a class method should be named cls
+    "N805", # First argument of a method should be named self
+    "N815", # Variable {name} in class scope should not be mixedCase
+    "PGH001", # No builtin eval() allowed
     "PGH004",  # Use specific rule codes when using noqa
     "PLC0414", # Useless import alias. Import alias does not rename original package.
+    "PLC", # pylint
+    "PLE", # pylint
+    "PLR", # pylint
+    "PLW", # pylint
+    "Q000", # Double quotes found but single quotes preferred
+    "RUF006", # Store a reference to the return value of asyncio.create_task
+    "S102", # Use of exec detected
     "S103",  # bad-file-permissions
     "S108",  # hardcoded-temp-file
     "S306",  # suspicious-mktemp-usage
@@ -41,12 +60,16 @@ select = [
     "SIM117", # Merge with-statements that use the same scope
     "SIM118", # Use {key} in {dict} instead of {key} in {dict}.keys()
     "SIM201", # Use {left} != {right} instead of not {left} == {right}
+    "SIM208", # Use {expr} instead of not (not {expr})
     "SIM212", # Use {a} if {a} else {b} instead of {b} if not {a} else {a}
     "SIM300", # Yoda conditions. Use 'age == 42' instead of '42 == age'.
     "SIM401", # Use get from dict with default instead of an if block
+    "T100", # Trace found: {name} used
     "T20",  # flake8-print
+    "TID251", # Banned imports
     "TRY004", # Prefer TypeError exception for invalid type
-    "RUF006", # Store a reference to the return value of asyncio.create_task
+    "TRY200", # Use raise from to specify exception cause
+    "TRY302", # Remove exception handler; error is immediately re-raised
     "UP",  # pyupgrade
     "W",  # pycodestyle
 ]
@@ -59,6 +82,15 @@ ignore = [
     "D407",  # Section name underlining
     "E501",  # line too long
     "E731",  # do not assign a lambda expression, use a def
+    "PLC1901", # Lots of false positives
+    # False positives https://github.com/astral-sh/ruff/issues/5386
+    "PLC0208", # Use a sequence type instead of a `set` when iterating over values
+    "PLR0911", # Too many return statements ({returns} > {max_returns})
+    "PLR0912", # Too many branches ({branches} > {max_branches})
+    "PLR0913", # Too many arguments to function call ({c_args} > {max_args})
+    "PLR0915", # Too many statements ({statements} > {max_statements})
+    "PLR2004",  # Magic value used in comparison, consider replacing {value} with a constant variable
+    "PLW2901", # Outer {outer_kind} variable {name} overwritten by inner {inner_kind} target
     "UP006", # keep type annotation style as is
     "UP007", # keep type annotation style as is
     # Ignored due to performance: https://github.com/charliermarsh/ruff/issues/2923
@@ -77,6 +109,9 @@ voluptuous = "vol"
 [tool.ruff.flake8-pytest-style]
 fixture-parentheses = false
 
+[tool.ruff.flake8-tidy-imports.banned-api]
+"pytz".msg = "use zoneinfo instead"
+
 [tool.ruff.isort]
 force-sort-within-sections = true
 known-first-party = [
@@ -84,6 +119,7 @@ known-first-party = [
     "plugwise",
 ]
 combine-as-imports = true
+split-on-trailing-comma = false
 
 [tool.ruff.mccabe]
 max-complexity = 25

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 "Bug Reports" = "https://github.com/plugwise/plugwise-beta/issues"
 
 [tool.black]
-target-version = ["py39", "py310", "py311"]
+target-version = ["py310", "py311"]
 exclude = 'generated'
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,8 +114,12 @@ fixture-parentheses = false
 
 [tool.ruff.isort]
 force-sort-within-sections = true
-known-first-party = [
+section-order = ["future", "standard-library", "first-party", "third-party", "local-folder"]
+known-third-party = [
     "homeassistant",
+]
+known-first-party = [
+    "plugwise",
 ]
 combine-as-imports = true
 split-on-trailing-comma = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,7 +116,6 @@ fixture-parentheses = false
 force-sort-within-sections = true
 known-first-party = [
     "homeassistant",
-    "plugwise",
 ]
 combine-as-imports = true
 split-on-trailing-comma = false

--- a/scripts/core-testing.sh
+++ b/scripts/core-testing.sh
@@ -121,6 +121,8 @@ if [ -z "${GITHUB_ACTIONS}" ] || [ "$1" == "core_prep" ] ; then
 		echo ""
 		echo " ** Resetting to ${core_branch} **"
 		echo ""
+		git stash || echo " - Nothing to stash"
+		git stash drop -q || echo " - Nothing in stash"
 		git config pull.rebase true
 		git reset --hard || echo " - Nothing to reset to"
 		git checkout "${core_branch}"

--- a/scripts/core-testing.sh
+++ b/scripts/core-testing.sh
@@ -119,12 +119,9 @@ if [ -z "${GITHUB_ACTIONS}" ] || [ "$1" == "core_prep" ] ; then
 		fi
 		cd "${coredir}" || exit
 		echo ""
-		echo " ** Resetting to ${core_branch} **"
-		echo ""
-		git stash || echo " - Nothing to stash"
-		git stash drop -q || echo " - Nothing in stash"
 		git config pull.rebase true
-		git reset --hard || echo " - Nothing to reset to"
+		echo " ** Resetting to ${core_branch} (just cloned) **"
+		git reset --hard || echo " - Should have nothing to reset to after cloning"
 		git checkout "${core_branch}"
 		echo ""
 		echo " ** Running setup script from HA core **"
@@ -148,9 +145,10 @@ if [ -z "${GITHUB_ACTIONS}" ] || [ "$1" == "core_prep" ] ; then
 	else
 		cd "${coredir}" || exit
 		echo ""
-		echo " ** Resetting/rebasing core **"
+		echo " ** Resetting/rebasing core (re-using clone)**"
 		echo ""
 		# Always start from ${core_branch}, dropping any leftovers
+		git reset --hard || echo " - Nothing to reset from"
 		git stash || echo " - Nothing to stash"
 		git stash drop -q || echo " - Nothing in stash"
 		git checkout "${core_branch}" || echo " - Already in ${core_branch}-branch"

--- a/scripts/core-testing.sh
+++ b/scripts/core-testing.sh
@@ -148,9 +148,10 @@ if [ -z "${GITHUB_ACTIONS}" ] || [ "$1" == "core_prep" ] ; then
 		echo " ** Resetting/rebasing core (re-using clone)**"
 		echo ""
 		# Always start from ${core_branch}, dropping any leftovers
-		git reset --hard || echo " - Nothing to reset from"
 		git stash || echo " - Nothing to stash"
-		git stash drop -q || echo " - Nothing in stash"
+		git stash drop -q || echo " - Nothing to stash drop"
+		git clean -nfd || echo " - Nothing to clean up (show/dry-run)"
+		git clean -fd || echo " - Nothing to clean up (clean)"
 		git checkout "${core_branch}" || echo " - Already in ${core_branch}-branch"
 		git branch -D fake_branch || echo " - No fake_branch to delete"
 		# Force pull

--- a/scripts/core-testing.sh
+++ b/scripts/core-testing.sh
@@ -51,7 +51,7 @@ which jq || ( echo "You should have jq installed, exiting"; exit 1)
 # - quality
 
 
-pyversions=("3.11" "3.10" 3.9 dummy) 
+pyversions=("3.11" "3.10" dummy) 
 my_path=$(git rev-parse --show-toplevel)
 my_venv=${my_path}/venv
 

--- a/scripts/core-testing.sh
+++ b/scripts/core-testing.sh
@@ -122,6 +122,7 @@ if [ -z "${GITHUB_ACTIONS}" ] || [ "$1" == "core_prep" ] ; then
 		echo " ** Resetting to ${core_branch} **"
 		echo ""
 		git config pull.rebase true
+		git reset --hard || echo " - Nothing to reset to"
 		git checkout "${core_branch}"
 		echo ""
 		echo " ** Running setup script from HA core **"

--- a/scripts/python-venv.sh
+++ b/scripts/python-venv.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eu
 
-pyversions=(3.11 3.10 3.9)
+pyversions=(3.11 3.10)
 my_path=$(git rev-parse --show-toplevel)
 my_venv=${my_path}/venv
 

--- a/tests/components/plugwise/conftest.py
+++ b/tests/components/plugwise/conftest.py
@@ -6,6 +6,7 @@ import json
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from plugwise import PlugwiseData
 import pytest
 
 from homeassistant.components.plugwise.const import DOMAIN
@@ -17,7 +18,7 @@ from homeassistant.const import (
     CONF_USERNAME,
 )
 from homeassistant.core import HomeAssistant
-from plugwise import PlugwiseData
+
 from tests.common import MockConfigEntry, load_fixture
 
 

--- a/tests/components/plugwise/fixtures/p1v4_442_triple/all_data.json
+++ b/tests/components/plugwise/fixtures/p1v4_442_triple/all_data.json
@@ -51,7 +51,7 @@
   },
   "gateway": {
     "gateway_id": "03e65b16e4b247a29ae0d75a78cb492e",
-    "notifications": {{
+    "notifications": {
       "97a04c0c263049b29350a660b4cdd01e": {
         "warning": "The Smile P1 does not seem to be connected to a smart meter."
       }

--- a/tests/components/plugwise/fixtures/p1v4_442_triple/all_data.json
+++ b/tests/components/plugwise/fixtures/p1v4_442_triple/all_data.json
@@ -2,7 +2,7 @@
   "devices": {
     "03e65b16e4b247a29ae0d75a78cb492e": {
       "binary_sensors": {
-        "plugwise_notification": false
+        "plugwise_notification": true
       },
       "dev_class": "gateway",
       "firmware": "4.4.2",
@@ -51,7 +51,11 @@
   },
   "gateway": {
     "gateway_id": "03e65b16e4b247a29ae0d75a78cb492e",
-    "notifications": {},
+    "notifications": {{
+      "97a04c0c263049b29350a660b4cdd01e": {
+        "warning": "The Smile P1 does not seem to be connected to a smart meter."
+      }
+    },
     "smile_name": "Smile P1"
   }
 }

--- a/tests/components/plugwise/fixtures/p1v4_442_triple/notifications.json
+++ b/tests/components/plugwise/fixtures/p1v4_442_triple/notifications.json
@@ -1,1 +1,5 @@
-{}
+{
+  "97a04c0c263049b29350a660b4cdd01e": {
+    "warning": "The Smile P1 does not seem to be connected to a smart meter."
+  }
+}

--- a/tests/components/plugwise/test_binary_sensor.py
+++ b/tests/components/plugwise/test_binary_sensor.py
@@ -73,6 +73,5 @@ async def test_p1_v4_binary_sensor_entity(
     assert state
     assert state.state == STATE_ON
     assert "warning_msg" in state.attributes
-    assert "unreachable" in state.attributes["warning_msg"][0]
-    assert not state.attributes.get("error_msg")
-    assert not state.attributes.get("other_msg")
+    assert "connected" in state.attributes["warning_msg"][0]
+

--- a/tests/components/plugwise/test_binary_sensor.py
+++ b/tests/components/plugwise/test_binary_sensor.py
@@ -63,3 +63,16 @@ async def test_adam_climate_binary_sensor_change(
     assert "unreachable" in state.attributes["warning_msg"][0]
     assert not state.attributes.get("error_msg")
     assert not state.attributes.get("other_msg")
+
+
+async def test_p1_v4_binary_sensor_entity(
+    hass: HomeAssistant, mock_smile_p1_2: MagicMock, init_integration: MockConfigEntry
+) -> None:
+    """Test change of climate related binary_sensor entities."""
+    state = hass.states.get("binary_sensor.smile_p1_plugwise_notification")
+    assert state
+    assert state.state == STATE_ON
+    assert "warning_msg" in state.attributes
+    assert "unreachable" in state.attributes["warning_msg"][0]
+    assert not state.attributes.get("error_msg")
+    assert not state.attributes.get("other_msg")

--- a/tests/components/plugwise/test_binary_sensor.py
+++ b/tests/components/plugwise/test_binary_sensor.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
+
 from tests.common import MockConfigEntry
 
 
@@ -74,4 +75,3 @@ async def test_p1_v4_binary_sensor_entity(
     assert state.state == STATE_ON
     assert "warning_msg" in state.attributes
     assert "connected" in state.attributes["warning_msg"][0]
-

--- a/tests/components/plugwise/test_climate.py
+++ b/tests/components/plugwise/test_climate.py
@@ -2,12 +2,13 @@
 
 from unittest.mock import MagicMock
 
+from plugwise.exceptions import PlugwiseError
 import pytest
 
 from homeassistant.components.climate.const import HVACMode
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
-from plugwise.exceptions import PlugwiseError
+
 from tests.common import MockConfigEntry
 
 TEST_HOST = "1.1.1.1"

--- a/tests/components/plugwise/test_config_flow.py
+++ b/tests/components/plugwise/test_config_flow.py
@@ -1,6 +1,13 @@
 """Test the Plugwise config flow."""
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from plugwise.exceptions import (
+    ConnectionFailedError,
+    InvalidAuthentication,
+    InvalidSetupError,
+    InvalidXMLError,
+    UnsupportedDeviceError,
+)
 import pytest
 
 from homeassistant.components import zeroconf
@@ -23,13 +30,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
-from plugwise.exceptions import (
-    ConnectionFailedError,
-    InvalidAuthentication,
-    InvalidSetupError,
-    InvalidXMLError,
-    UnsupportedDeviceError,
-)
+
 from tests.common import MockConfigEntry
 
 TEST_HOST = "1.1.1.1"

--- a/tests/components/plugwise/test_diagnostics.py
+++ b/tests/components/plugwise/test_diagnostics.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 from aiohttp import ClientSession
 
 from homeassistant.core import HomeAssistant
+
 from tests.common import MockConfigEntry
 from tests.components.diagnostics import get_diagnostics_for_config_entry
 

--- a/tests/components/plugwise/test_diagnostics.py
+++ b/tests/components/plugwise/test_diagnostics.py
@@ -2,7 +2,6 @@
 from unittest.mock import MagicMock
 
 from aiohttp import ClientSession
-
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry

--- a/tests/components/plugwise/test_init.py
+++ b/tests/components/plugwise/test_init.py
@@ -1,6 +1,13 @@
 """Tests for the Plugwise Climate integration."""
 from unittest.mock import MagicMock
 
+from plugwise.exceptions import (
+    ConnectionFailedError,
+    InvalidAuthentication,
+    InvalidXMLError,
+    ResponseError,
+    UnsupportedDeviceError,
+)
 import pytest
 
 from homeassistant.components.plugwise.const import DOMAIN
@@ -9,13 +16,7 @@ from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_registry import async_get
-from plugwise.exceptions import (
-    ConnectionFailedError,
-    InvalidAuthentication,
-    InvalidXMLError,
-    ResponseError,
-    UnsupportedDeviceError,
-)
+
 from tests.common import MockConfigEntry
 
 HEATER_ID = "1cbf783bb11e4a7c8a6843dee3a86927"  # Opentherm device_id for migration

--- a/tests/components/plugwise/test_number.py
+++ b/tests/components/plugwise/test_number.py
@@ -9,6 +9,7 @@ from homeassistant.components.number import (
 )
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
+
 from tests.common import MockConfigEntry
 
 

--- a/tests/components/plugwise/test_select.py
+++ b/tests/components/plugwise/test_select.py
@@ -9,6 +9,7 @@ from homeassistant.components.select import (
 )
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant
+
 from tests.common import MockConfigEntry
 
 

--- a/tests/components/plugwise/test_sensor.py
+++ b/tests/components/plugwise/test_sensor.py
@@ -6,6 +6,7 @@ from homeassistant.components.plugwise.const import DOMAIN
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_registry import async_get
+
 from tests.common import MockConfigEntry
 
 

--- a/tests/components/plugwise/test_switch.py
+++ b/tests/components/plugwise/test_switch.py
@@ -1,6 +1,7 @@
 """Tests for the Plugwise switch integration."""
 from unittest.mock import MagicMock
 
+from plugwise.exceptions import PlugwiseException
 import pytest
 
 from homeassistant.components.plugwise.const import DOMAIN
@@ -8,7 +9,7 @@ from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_registry import async_get
-from plugwise.exceptions import PlugwiseException
+
 from tests.common import MockConfigEntry
 
 


### PR DESCRIPTION
All changes:
- Link to [plugwise v0.32.1](https://github.com/plugwise/python-plugwise/releases/tag/v0.32.1)
- Remove python3.9 compatibility: remove/replace all python3.9 references.
- Implement Ruff sorting fixes - tnx @CoMPaTech for achieving the line-up with the Core Plugwise code.
- Update p1v4_442_triple testfixture, adding a Plugwise notification for the Smile P1. Add a related testcase.
- Bump PW-beta to v0.41.2