### PR TITLE
Improve warning through issue creation on Core DEV (RC/Beta) commits

### DIFF
--- a/.github/workflows/core_next.yml
+++ b/.github/workflows/core_next.yml
@@ -4,7 +4,7 @@
 name: Validate plugwise-beta against HA-core dev
 
 env:
-  # Uses a different key/restore key than test.yml for master
+  # Uses a different key/restore key than test.yml
   CACHE_VERSION: 1
   DEFAULT_PYTHON: "3.11"
 
@@ -47,7 +47,7 @@ jobs:
             ${{ env.CACHE_VERSION}}
       - name: Test against HA-core DEV (for active or upcoming RC/Beta)
         run: |
-          GITHUB_ACTIONS="" BRANCH="master" scripts/core-testing.sh
+          GITHUB_ACTIONS="" BRANCH="dev" scripts/core-testing.sh
       - name: Create failure issue as warning
         if: failure()
         uses: imjohnbo/issue-bot@v3

--- a/.github/workflows/core_next.yml
+++ b/.github/workflows/core_next.yml
@@ -53,7 +53,7 @@ jobs:
         uses: imjohnbo/issue-bot@v3
         with:
           # include any handles without @
-          assignees: "plugwise/plugwise-smile"
+          # assignees: "plugwise/plugwise-smile"
           labels: "core-dev-compat"
           pinned: false
           # closes existing issue if all labels match

--- a/.github/workflows/core_next.yml
+++ b/.github/workflows/core_next.yml
@@ -19,7 +19,7 @@ jobs:
   # Prepare default python version environment
   ha-core-prepare:
     runs-on: ubuntu-latest
-    name: Setup for HA-core
+    name: Setup for HA-core (DEV)
     steps:
       - name: Check out committed code
         uses: actions/checkout@v4.0.0
@@ -45,7 +45,7 @@ jobs:
             ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-hacore
             ${{ env.CACHE_VERSION}}-${{ runner.os }}
             ${{ env.CACHE_VERSION}}
-      - name: Test through core (full, not split)
+      - name: Test against HA-core DEV (for active or upcoming RC/Beta)
         run: |
           GITHUB_ACTIONS="" BRANCH="master" scripts/core-testing.sh
       - name: Create failure issue as warning

--- a/.github/workflows/core_next.yml
+++ b/.github/workflows/core_next.yml
@@ -1,0 +1,62 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Validate plugwise-beta against HA-core dev
+
+env:
+  # Uses a different key/restore key than test.yml for master
+  CACHE_VERSION: 1
+  DEFAULT_PYTHON: "3.11"
+
+on:
+  #  schedule:
+  #    - cron: '0 9 * * 3' # Weekly at 9
+  # Only set to 'push' when testing/modifying
+  # otherwise this should be just scheduled runs!
+  push:
+
+jobs:
+  # Prepare default python version environment
+  ha-core-prepare:
+    runs-on: ubuntu-latest
+    name: Setup for HA-core
+    steps:
+      - name: Check out committed code
+        uses: actions/checkout@v4.0.0
+      - name: Set up Python ${{ env.DEFAULT_PYTHON }}
+        id: python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON }}
+      - name: Restore base HA-core Python ${{ env.DEFAULT_PYTHON }} environment
+        id: cache-hacore
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-hacore
+        with:
+          path: ./
+          key: >-
+            ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-hacore-dev-${{
+            steps.python.outputs.python-version }}-${{
+            hashFiles('./custom_components/plugwise/manifest.json') }}-${{
+            hashFiles('./ha-core/.git/plugwise-tracking') }}
+          restore-keys: |
+            ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-hacore-dev-${{ steps.python.outputs.python-version }}-
+            ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-hacore
+            ${{ env.CACHE_VERSION}}-${{ runner.os }}
+            ${{ env.CACHE_VERSION}}
+      - name: Test through core (full, not split)
+        run: |
+          GITHUB_ACTIONS="" BRANCH="master" scripts/core-testing.sh
+      - name: Create failure issue as warning
+        if: failure()
+        uses: imjohnbo/issue-bot@v3
+        with:
+          # include any handles without @
+          assignees: "plugwise/plugwise-smile"
+          labels: "core-dev-compat"
+          pinned: false
+          # closes existing issue if all labels match
+          close-previous: true
+          title: Next Home Assistant version incompatibility
+          body: "**Note: This does not affect users of the plugwise integration in Core nor Plugwise-Beta users on the latest version of Home Assistant.** For our beloved {{ assignees }}, please check action logs, it seems our current code is not compatible with the upcoming version (and/or Release Candidate (RC)/beta) of Home Assistant in a timely matter to conform before the next monthly release."

--- a/.github/workflows/core_next.yml
+++ b/.github/workflows/core_next.yml
@@ -9,11 +9,13 @@ env:
   DEFAULT_PYTHON: "3.11"
 
 on:
-  #  schedule:
-  #    - cron: '0 9 * * 3' # Weekly at 9
   # Only set to 'push' when testing/modifying
   # otherwise this should be just scheduled runs!
-  push:
+  # push:
+
+  # Schedule Weekly at 9
+  schedule:
+    - cron: "0 9 * * 3"
 
 jobs:
   # Prepare default python version environment

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a variety of Python versions
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Test with HA-core
+name: Test against HA-core (master/released)
 
 env:
   CACHE_VERSION: 21
@@ -10,19 +10,13 @@ env:
 on:
   workflow_dispatch:
   push:
-#  schedule:
-#    - cron: '0 0 * * 0' # weekly
 # pull_request:
 
 jobs:
   # Prepare default python version environment
   ha-core-prepare:
     runs-on: ubuntu-latest
-    name: Setup for HA-core
-    strategy:
-      matrix:
-        branch: ["master", "dev"]
-    continue-on-error: ${{ matrix.branch == 'dev' }}
+    name: Setup for HA-core (release)
     steps:
       - name: Check out committed code
         uses: actions/checkout@v4.0.0
@@ -48,9 +42,9 @@ jobs:
             ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-hacore
             ${{ env.CACHE_VERSION}}-${{ runner.os }}
             ${{ env.CACHE_VERSION}}
-      - name: Test through core (full, not split)
+      - name: Test through HA-core (master/release)
         run: |
-          GITHUB_ACTIONS="" BRANCH="${{ matrix.branch }}" scripts/core-testing.sh
+          GITHUB_ACTIONS="" BRANCH="master" scripts/core-testing.sh
 
   shellcheck:
     name: Shellcheck


### PR DESCRIPTION
Intention would be to run this weekly and (re)create (another) issue when we have a compatibility issue between released HA-Core (i.e. `master`) and upcoming (i.e. `dev`)

Note2self: subscribed to https://github.com/imjohnbo/issue-bot/issues/90 so we can just ignore and/or amend an existing issue instead of (weekly) (re)creating the same issue