### PR TITLE
Fix device_registry clean-up for systems with more than 1 Plugwise Gateway

### DIFF
--- a/custom_components/plugwise/coordinator.py
+++ b/custom_components/plugwise/coordinator.py
@@ -35,7 +35,7 @@ def cleanup_device_registry(
     """Remove deleted devices from device-registry."""
     device_registry = dr.async_get(hass)
     via_id_list: list[list[str]] = []
-    # Collect the required data of the Plugwise Gateway's 
+    # Collect the required data of the Plugwise Gateway's
     for device_entry in list(device_registry.devices.values()):
         if device_entry.manufacturer == "Plugwise" and device_entry.model == "Gateway":
             for item in device_entry.identifiers:

--- a/custom_components/plugwise/coordinator.py
+++ b/custom_components/plugwise/coordinator.py
@@ -38,17 +38,15 @@ def cleanup_device_registry(
     # Find the device_entry-id's of the available Plugwise Gateway's
     for device_entry in list(device_registry.devices.values()):
         if device_entry.manufacturer == "Plugwise" and device_entry.model == "Gateway":
-            via_id_list.append([device_entry.id, api.gateway_id])
-    LOGGER.debug("HOI via-id-list: %s", via_id_list)
+            for item in device_entry.identifiers:
+                via_id_list.append([device_entry.id, item[1]])
 
     # Process the devices connected to the active Gateway
     for via_id in via_id_list:
-        LOGGER.debug("HOI via_id(1), gateway_id: %s, &s", via_id[1], api.gateway_id)
         if via_id[1] != api.gateway_id:
             continue  # pragma: no cover
 
         for dev_id, device_entry in list(device_registry.devices.items()):
-            LOGGER.debug("HOI dev_id: %s", dev_id)
             if device_entry.via_device_id == via_id[0]:
                 for item in device_entry.identifiers:
                     if item[0] == DOMAIN and item[1] in api.device_list:

--- a/custom_components/plugwise/coordinator.py
+++ b/custom_components/plugwise/coordinator.py
@@ -34,16 +34,16 @@ def cleanup_device_registry(
 ) -> None:
     """Remove deleted devices from device-registry."""
     device_registry = dr.async_get(hass)
-    via_id_list: list[list[str, str]] = []
+    via_id_list: list[list[str]] = []
     # Find the device_entry-id's of the available Plugwise Gateway's
-    for dev_id, device_entry in list(device_registry.devices.items()):
+    for device_entry in list(device_registry.devices.values()):
         if device_entry.manufacturer == "Plugwise" and device_entry.model == "Gateway":
             via_id_list.append([device_entry.id, api.gateway_id])
-    
+
     # Process the devices connected to the active Gateway
     for via_id in via_id_list:
         if via_id[1] != api.gateway_id:
-            continue  # pragma: no cover 
+            continue  # pragma: no cover
 
         for dev_id, device_entry in list(device_registry.devices.items()):
             if device_entry.via_device_id == via_id[0]:

--- a/custom_components/plugwise/coordinator.py
+++ b/custom_components/plugwise/coordinator.py
@@ -54,7 +54,7 @@ def cleanup_device_registry(
                     if item[0] == DOMAIN and item[1] in api.device_list:
                         continue
 
-                    #device_registry.async_remove_device(dev_id)
+                    # device_registry.async_remove_device(dev_id)
                     LOGGER.debug(
                         "Removed device %s %s %s from device_registry",
                         DOMAIN,

--- a/custom_components/plugwise/coordinator.py
+++ b/custom_components/plugwise/coordinator.py
@@ -39,19 +39,22 @@ def cleanup_device_registry(
     for device_entry in list(device_registry.devices.values()):
         if device_entry.manufacturer == "Plugwise" and device_entry.model == "Gateway":
             via_id_list.append([device_entry.id, api.gateway_id])
+    LOGGER.debug("HOI via-id-list: %s", via_id_list)
 
     # Process the devices connected to the active Gateway
     for via_id in via_id_list:
+        LOGGER.debug("HOI via_id(1), gateway_id: %s, &s", via_id[1], api.gateway_id)
         if via_id[1] != api.gateway_id:
             continue  # pragma: no cover
 
         for dev_id, device_entry in list(device_registry.devices.items()):
+            LOGGER.debug("HOI dev_id: %s", dev_id)
             if device_entry.via_device_id == via_id[0]:
                 for item in device_entry.identifiers:
                     if item[0] == DOMAIN and item[1] in api.device_list:
                         continue
 
-                    device_registry.async_remove_device(dev_id)
+                    #device_registry.async_remove_device(dev_id)
                     LOGGER.debug(
                         "Removed device %s %s %s from device_registry",
                         DOMAIN,

--- a/custom_components/plugwise/coordinator.py
+++ b/custom_components/plugwise/coordinator.py
@@ -30,27 +30,23 @@ from .const import DEFAULT_PORT, DEFAULT_SCAN_INTERVAL, DEFAULT_USERNAME, DOMAIN
 
 def remove_stale_devices(
     api: Smile,
-    via_id_list: list[list[str]],
     device_registry: dr.DeviceRegistry,
+    via_id: str,
 ) -> None:
     """Process the Plugwise devices present in the device_registry connected to a specific Gateway."""
-    for via_id in via_id_list:
-        if via_id[0] != api.gateway_id:
-            continue  # pragma: no cover
+    for dev_id, device_entry in list(device_registry.devices.items()):
+        if device_entry.via_device_id == via_id:
+            for item in device_entry.identifiers:
+                if item[0] == DOMAIN and item[1] in api.device_list:
+                    continue
 
-        for dev_id, device_entry in list(device_registry.devices.items()):
-            if device_entry.via_device_id == via_id[1]:
-                for item in device_entry.identifiers:
-                    if item[0] == DOMAIN and item[1] in api.device_list:
-                        continue
-
-                    device_registry.async_remove_device(dev_id)
-                    LOGGER.debug(
-                        "Removed device %s %s %s from device_registry",
-                        DOMAIN,
-                        device_entry.model,
-                        dev_id,
-                    )
+                device_registry.async_remove_device(dev_id)
+                LOGGER.debug(
+                    "Removed device %s %s %s from device_registry",
+                    DOMAIN,
+                    device_entry.model,
+                    dev_id,
+                )
 
 
 def cleanup_device_registry(
@@ -66,7 +62,11 @@ def cleanup_device_registry(
             for item in device_entry.identifiers:
                 via_id_list.append([item[1], device_entry.id])
 
-    remove_stale_devices(api, via_id_list, device_registry)
+    for via_id in via_id_list:
+        if via_id[0] != api.gateway_id:
+            continue  # pragma: no cover
+
+        remove_stale_devices(api, device_registry, via_id[1])
 
 
 class PlugwiseDataUpdateCoordinator(DataUpdateCoordinator[PlugwiseData]):

--- a/custom_components/plugwise/coordinator.py
+++ b/custom_components/plugwise/coordinator.py
@@ -43,7 +43,7 @@ def cleanup_device_registry(
     # Process the devices connected to the active Gateway
     for via_id in via_id_list:
         if via_id[1] != api.gateway_id:
-            continue
+            continue  # pragma: no cover 
 
         for dev_id, device_entry in list(device_registry.devices.items()):
             if device_entry.via_device_id == via_id[0]:

--- a/custom_components/plugwise/coordinator.py
+++ b/custom_components/plugwise/coordinator.py
@@ -52,7 +52,7 @@ def cleanup_device_registry(
                     if item[0] == DOMAIN and item[1] in api.device_list:
                         continue
 
-                    # device_registry.async_remove_device(dev_id)
+                    device_registry.async_remove_device(dev_id)
                     LOGGER.debug(
                         "Removed device %s %s %s from device_registry",
                         DOMAIN,

--- a/custom_components/plugwise/coordinator.py
+++ b/custom_components/plugwise/coordinator.py
@@ -35,19 +35,20 @@ def cleanup_device_registry(
     """Remove deleted devices from device-registry."""
     device_registry = dr.async_get(hass)
     via_id_list: list[list[str]] = []
-    # Find the device_entry-id's of the available Plugwise Gateway's
+    # Collect the required data of the Plugwise Gateway's 
     for device_entry in list(device_registry.devices.values()):
         if device_entry.manufacturer == "Plugwise" and device_entry.model == "Gateway":
             for item in device_entry.identifiers:
-                via_id_list.append([device_entry.id, item[1]])
+                via_id_list.append([item[1], device_entry.id])
 
-    # Process the devices connected to the active Gateway
+    # Process the Plugwise devices present in the device_registry,
+    # connected to a specific Gateway
     for via_id in via_id_list:
-        if via_id[1] != api.gateway_id:
+        if via_id[0] != api.gateway_id:
             continue  # pragma: no cover
 
         for dev_id, device_entry in list(device_registry.devices.items()):
-            if device_entry.via_device_id == via_id[0]:
+            if device_entry.via_device_id == via_id[1]:
                 for item in device_entry.identifiers:
                     if item[0] == DOMAIN and item[1] in api.device_list:
                         continue

--- a/custom_components/plugwise/manifest.json
+++ b/custom_components/plugwise/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "loggers": ["plugwise"],
   "requirements": ["plugwise==0.34.4"],
-  "version": "0.44.0"
+  "version": "0.44.0a0"
 }

--- a/custom_components/plugwise/manifest.json
+++ b/custom_components/plugwise/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "loggers": ["plugwise"],
   "requirements": ["plugwise==0.34.4"],
-  "version": "0.44.0a0"
+  "version": "0.44.0a1"
 }

--- a/custom_components/plugwise/manifest.json
+++ b/custom_components/plugwise/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "loggers": ["plugwise"],
   "requirements": ["plugwise==0.34.4"],
-  "version": "0.44.0a1"
+  "version": "0.44.0"
 }


### PR DESCRIPTION
Fixes for the 2nd try releasing v0.44.0, a follow-up on https://github.com/plugwise/plugwise-beta/pull/515

Device-cleaning is done in `coordinator.py` because there can be more than one Plugwise-gateway in a HA system.
So care must be taken to avoid devices being removed for the other gateway(s) when the `device_registry` is processed for one gateway.

Also, it is planned for the future to extend this function by triggering a reload when new devices are detected.