### PR TITLE
Implement plugwise v0.37.0

### DIFF
--- a/custom_components/plugwise/manifest.json
+++ b/custom_components/plugwise/manifest.json
@@ -8,6 +8,6 @@
   "integration_type": "hub",
   "iot_class": "local_polling",
   "loggers": ["plugwise"],
-  "requirements": ["plugwise==0.36.3"],
-  "version": "0.46.3"
+  "requirements": ["https://test-files.pythonhosted.org/packages/be/ce/514d7f50b217e9c03d915fa7c110561835554594a8a35232b632eca8c498/plugwise-0.37.0a0.tar.gz#plugwise==0.37.0a0"],
+  "version": "0.47.0a0"
 }

--- a/custom_components/plugwise/manifest.json
+++ b/custom_components/plugwise/manifest.json
@@ -8,6 +8,6 @@
   "integration_type": "hub",
   "iot_class": "local_polling",
   "loggers": ["plugwise"],
-  "requirements": ["https://test-files.pythonhosted.org/packages/96/fb/882deff392ed1ae57758fe4f5ea60f1b6a41b5dcfbce876469a4e8a73fd0/plugwise-0.37.0a2.tar.gz#plugwise==0.37.0a2"],
-  "version": "0.47.0a1"
+  "requirements": ["plugwise==0.37.0"],
+  "version": "0.47.0"
 }

--- a/custom_components/plugwise/manifest.json
+++ b/custom_components/plugwise/manifest.json
@@ -8,6 +8,6 @@
   "integration_type": "hub",
   "iot_class": "local_polling",
   "loggers": ["plugwise"],
-  "requirements": ["https://test-files.pythonhosted.org/packages/9c/eb/ddd6dbd9f8cde1344cfbd3dc7757c2efeab693a8fa832a399b6341cdf906/plugwise-0.37.0a1.tar.gz#plugwise==0.37.0a1"],
-  "version": "0.47.0a0"
+  "requirements": ["https://test-files.pythonhosted.org/packages/96/fb/882deff392ed1ae57758fe4f5ea60f1b6a41b5dcfbce876469a4e8a73fd0/plugwise-0.37.0a2.tar.gz#plugwise==0.37.0a2"],
+  "version": "0.47.0a1"
 }

--- a/custom_components/plugwise/manifest.json
+++ b/custom_components/plugwise/manifest.json
@@ -8,6 +8,6 @@
   "integration_type": "hub",
   "iot_class": "local_polling",
   "loggers": ["plugwise"],
-  "requirements": ["https://test-files.pythonhosted.org/packages/be/ce/514d7f50b217e9c03d915fa7c110561835554594a8a35232b632eca8c498/plugwise-0.37.0a0.tar.gz#plugwise==0.37.0a0"],
+  "requirements": ["https://test-files.pythonhosted.org/packages/9c/eb/ddd6dbd9f8cde1344cfbd3dc7757c2efeab693a8fa832a399b6341cdf906/plugwise-0.37.0a1.tar.gz#plugwise==0.37.0a1"],
   "version": "0.47.0a0"
 }

--- a/tests/components/plugwise/fixtures/adam_multiple_devices_per_zone/all_data.json
+++ b/tests/components/plugwise/fixtures/adam_multiple_devices_per_zone/all_data.json
@@ -28,7 +28,7 @@
       "model": "Plug",
       "name": "Playstation Smart Plug",
       "sensors": {
-        "electricity_consumed": 82.6,
+        "electricity_consumed": 84.1,
         "electricity_consumed_interval": 8.6,
         "electricity_produced": 0.0,
         "electricity_produced_interval": 0.0

--- a/tests/components/plugwise/fixtures/m_adam_cooling/all_data.json
+++ b/tests/components/plugwise/fixtures/m_adam_cooling/all_data.json
@@ -5,7 +5,7 @@
       "binary_sensors": {
         "cooling_state": true,
         "dhw_state": false,
-        "flame_state": true,
+        "flame_state": false,
         "heating_state": false
       },
       "dev_class": "heater_central",

--- a/tests/components/plugwise/fixtures/m_adam_heating/all_data.json
+++ b/tests/components/plugwise/fixtures/m_adam_heating/all_data.json
@@ -4,7 +4,7 @@
       "available": true,
       "binary_sensors": {
         "dhw_state": false,
-        "flame_state": true,
+        "flame_state": false,
         "heating_state": true
       },
       "dev_class": "heater_central",

--- a/tests/components/plugwise/fixtures/m_adam_jip/all_data.json
+++ b/tests/components/plugwise/fixtures/m_adam_jip/all_data.json
@@ -67,7 +67,7 @@
       "name": "Tom Slaapkamer",
       "sensors": {
         "setpoint": 13.0,
-        "temperature": 24.3,
+        "temperature": 24.2,
         "temperature_difference": 1.7,
         "valve_position": 0.0
       },

--- a/tests/components/plugwise/fixtures/stretch_v31/all_data.json
+++ b/tests/components/plugwise/fixtures/stretch_v31/all_data.json
@@ -23,7 +23,7 @@
         "electricity_produced": 0.0
       },
       "switches": {
-        "lock": false,
+        "lock": true,
         "relay": true
       },
       "vendor": "Plugwise",

--- a/tests/components/plugwise/snapshots/test_diagnostics.ambr
+++ b/tests/components/plugwise/snapshots/test_diagnostics.ambr
@@ -30,7 +30,7 @@
         'model': 'Plug',
         'name': 'Playstation Smart Plug',
         'sensors': dict({
-          'electricity_consumed': 82.6,
+          'electricity_consumed': 84.1,
           'electricity_consumed_interval': 8.6,
           'electricity_produced': 0.0,
           'electricity_produced_interval': 0.0,


### PR DESCRIPTION
More info:
- The backend-code for actual and legacy Plugwise devices has been separated.
- For actual devices xml-data is now only collected from `/core/domain_objects`.