### PR TITLE
Add off-icon for thermostat schedules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Versions from 0.40 and up
 
+## v0.47.3
+
+- Add off-icon for thermostat schedules.
+
 ## v0.47.2
 
 - Add icons for the options of the Selects DHW mode, Gateway mode and Regulation mode.

--- a/custom_components/plugwise/icons.json
+++ b/custom_components/plugwise/icons.json
@@ -92,7 +92,10 @@
         }
       },
       "select_schedule": {
-        "default": "mdi:calendar-clock"
+        "default": "mdi:calendar-clock",
+        "state": {
+          "off": "mdi:circle-off-outline"
+        }
       }
     },
     "sensor": {

--- a/custom_components/plugwise/select.py
+++ b/custom_components/plugwise/select.py
@@ -37,7 +37,7 @@ class PlugwiseSelectEntityDescription(SelectEntityDescription):
 SELECT_TYPES = (
     PlugwiseSelectEntityDescription(
         key="select_schedule",
-        translation_key="thermostat_schedule",
+        translation_key="select_schedule",
         command=lambda api, loc, opt: api.set_schedule_state(loc, STATE_ON, opt),
         options_key="available_schedules",
     ),

--- a/custom_components/plugwise/strings.json
+++ b/custom_components/plugwise/strings.json
@@ -126,7 +126,7 @@
           "vacation": "Vacation"
         }
       },
-      "thermostat_schedule": {
+      "select_schedule": {
         "name": "Thermostat schedule",
         "state": {
           "off": "Off"

--- a/custom_components/plugwise/translations/en.json
+++ b/custom_components/plugwise/translations/en.json
@@ -126,7 +126,7 @@
           "vacation": "Vacation"
         }
       },
-      "thermostat_schedule": {
+      "select_schedule": {
         "name": "Thermostat schedule",
         "state": {
           "off": "Off"

--- a/custom_components/plugwise/translations/nl.json
+++ b/custom_components/plugwise/translations/nl.json
@@ -126,7 +126,7 @@
           "vacation": "Vakantie"
         }
       },
-      "thermostat_schedule": {
+      "select_schedule": {
         "name": "Thermostaatschema",
         "state": {
           "off": "Uit"


### PR DESCRIPTION
Also, line up key-naming with Core, now the thermostat-schedule icons are not working.