### PR TITLE
Implement reloading when the system-config changes, move device-removal

### DIFF
--- a/custom_components/plugwise/__init__.py
+++ b/custom_components/plugwise/__init__.py
@@ -94,13 +94,14 @@ def cleanup_device_registry(
     data: PlugwiseData,
 ) -> None:
     """Remove deleted devices from device-registry."""
-    device_registry = dr.async_get(hass)
     plugwise_device_list = list(data.devices.keys())
+    if len(plugwise_device_list) < 2:
+        return
+
+    device_registry = dr.async_get(hass)
     for dev_id, device_entry in list(device_registry.devices.items()):
         for item in device_entry.identifiers:
-            if item[0] == DOMAIN and (
-                len(plugwise_device_list) > 1 and item[1] in plugwise_device_list
-            ):
+            if item[0] == DOMAIN and item[1] in plugwise_device_list:
                 continue
 
             device_registry.async_remove_device(dev_id)

--- a/custom_components/plugwise/__init__.py
+++ b/custom_components/plugwise/__init__.py
@@ -96,7 +96,7 @@ def cleanup_device_registry(
     """Remove deleted devices from device-registry."""
     plugwise_device_list = list(data.devices.keys())
     if len(plugwise_device_list) < 2:
-        return
+        return  # pragma: no cover
 
     device_registry = dr.async_get(hass)
     for dev_id, device_entry in list(device_registry.devices.items()):

--- a/custom_components/plugwise/__init__.py
+++ b/custom_components/plugwise/__init__.py
@@ -103,10 +103,10 @@ def cleanup_device_registry(
 
             device_registry.async_remove_device(dev_id)
             LOGGER.debug(
-                "Removed device %s %s %s from device_registry",
+                "Removed %s device %s %s from device_registry",
                 DOMAIN,
                 device_entry.model,
-                dev_id,
+                item[1],
             )
 
 async def _update_listener(

--- a/custom_components/plugwise/__init__.py
+++ b/custom_components/plugwise/__init__.py
@@ -132,7 +132,7 @@ async def async_remove_config_entry_device(
     return not any(
         identifier
         for identifier in device_entry.identifiers
-        if identifier[0] == DOMAIN and coordinator.data.devices[identifier[1]]
+        if identifier[0] == DOMAIN and (identifier[1] in coordinator.data.devices)
     )
 
 @callback

--- a/custom_components/plugwise/__init__.py
+++ b/custom_components/plugwise/__init__.py
@@ -98,7 +98,9 @@ def cleanup_device_registry(
     plugwise_device_list = list(data.devices.keys())
     for dev_id, device_entry in list(device_registry.devices.items()):
         for item in device_entry.identifiers:
-            if item[0] == DOMAIN and item[1] in plugwise_device_list:
+            if item[0] == DOMAIN and (
+                len(plugwise_device_list) > 1 and item[1] in plugwise_device_list
+            ):
                 continue
 
             device_registry.async_remove_device(dev_id)

--- a/custom_components/plugwise/__init__.py
+++ b/custom_components/plugwise/__init__.py
@@ -36,7 +36,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     LOGGER.debug("DUC cooldown interval: %s", cooldown)
 
     coordinator = PlugwiseDataUpdateCoordinator(
-        hass, entry, cooldown
+        hass, cooldown
     )  # pw-beta - cooldown, update_interval as extra
     await coordinator.async_config_entry_first_refresh()
     # Migrate a changed sensor unique_id

--- a/custom_components/plugwise/coordinator.py
+++ b/custom_components/plugwise/coordinator.py
@@ -20,33 +20,11 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryError
-from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import DEFAULT_PORT, DEFAULT_SCAN_INTERVAL, DEFAULT_USERNAME, DOMAIN, LOGGER
-
-
-def cleanup_device_registry(
-    hass: HomeAssistant,
-    data: PlugwiseData,
-) -> None:
-    """Remove deleted devices from device-registry."""
-    device_registry = dr.async_get(hass)
-    plugwise_device_list = list(data.devices.keys())
-    for dev_id, device_entry in list(device_registry.devices.items()):
-        for item in device_entry.identifiers:
-            if item[0] == DOMAIN and item[1] in plugwise_device_list:
-                continue
-
-            device_registry.async_remove_device(dev_id)
-            LOGGER.debug(
-                "Removed device %s %s %s from device_registry",
-                DOMAIN,
-                device_entry.model,
-                dev_id,
-            )
 
 
 class PlugwiseDataUpdateCoordinator(DataUpdateCoordinator[PlugwiseData]):
@@ -136,8 +114,5 @@ class PlugwiseDataUpdateCoordinator(DataUpdateCoordinator[PlugwiseData]):
             if not self._unavailable_logged:  # pw-beta add to Core
                 self._unavailable_logged = True
                 raise UpdateFailed("Failed to connect") from err
-
-        # Clean-up removed devices
-        cleanup_device_registry(self.hass, data)
 
         return data

--- a/custom_components/plugwise/coordinator.py
+++ b/custom_components/plugwise/coordinator.py
@@ -113,4 +113,9 @@ class PlugwiseDataUpdateCoordinator(DataUpdateCoordinator[PlugwiseData]):
                 self._unavailable_logged = True
                 raise UpdateFailed("Failed to connect") from err
 
+        # Reload when the configuration has changed
+        if "config_changed" in data.gateway:
+            LOGGER.debug("HOI config has changed")
+            await self.hass.config_entries.async_reload(self.config_entry.entry_id)
+
         return data

--- a/custom_components/plugwise/coordinator.py
+++ b/custom_components/plugwise/coordinator.py
@@ -28,46 +28,25 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 from .const import DEFAULT_PORT, DEFAULT_SCAN_INTERVAL, DEFAULT_USERNAME, DOMAIN, LOGGER
 
 
-def remove_stale_devices(
-    data: PlugwiseData,
-    device_registry: dr.DeviceRegistry,
-    via_id: str,
-) -> None:
-    """Process the Plugwise devices present in the device_registry connected to a specific Gateway."""
-    device_list = list(data.devices.keys())
-    for dev_id, device_entry in list(device_registry.devices.items()):
-        if device_entry.via_device_id == via_id:
-            for item in device_entry.identifiers:
-                if item[0] == DOMAIN and item[1] in device_list:
-                    continue
-
-                device_registry.async_remove_device(dev_id)
-                LOGGER.debug(
-                    "Removed device %s %s %s from device_registry",
-                    DOMAIN,
-                    device_entry.model,
-                    dev_id,
-                )
-
-
 def cleanup_device_registry(
     hass: HomeAssistant,
     data: PlugwiseData,
 ) -> None:
     """Remove deleted devices from device-registry."""
     device_registry = dr.async_get(hass)
-    via_id_list: list[list[str]] = []
-    # Collect the required data of the Plugwise Gateway's
-    for device_entry in list(device_registry.devices.values()):
-        if device_entry.manufacturer == "Plugwise" and device_entry.model == "Gateway":
-            for item in device_entry.identifiers:
-                via_id_list.append([item[1], device_entry.id])
+    plugwise_device_list = list(data.devices.keys())
+    for dev_id, device_entry in list(device_registry.devices.items()):
+        for item in device_entry.identifiers:
+            if item[0] == DOMAIN and item[1] in plugwise_device_list:
+                continue
 
-    for via_id in via_id_list:
-        if via_id[0] != data.gateway["gateway_id"]:
-            continue  # pragma: no cover
-
-        remove_stale_devices(data, device_registry, via_id[1])
+            device_registry.async_remove_device(dev_id)
+            LOGGER.debug(
+                "Removed device %s %s %s from device_registry",
+                DOMAIN,
+                device_entry.model,
+                dev_id,
+            )
 
 
 class PlugwiseDataUpdateCoordinator(DataUpdateCoordinator[PlugwiseData]):

--- a/custom_components/plugwise/coordinator.py
+++ b/custom_components/plugwise/coordinator.py
@@ -114,8 +114,8 @@ class PlugwiseDataUpdateCoordinator(DataUpdateCoordinator[PlugwiseData]):
                 raise UpdateFailed("Failed to connect") from err
 
         # Reload when the configuration has changed
-        if "config_changed" in data.gateway:
-            LOGGER.debug("HOI config has changed")
+        if "new_devices" in data.gateway:
+            LOGGER.debug("New Plugwise device(s) found, reloading...")
             await self.hass.config_entries.async_reload(self.config_entry.entry_id)
 
         return data

--- a/custom_components/plugwise/manifest.json
+++ b/custom_components/plugwise/manifest.json
@@ -8,6 +8,6 @@
   "integration_type": "hub",
   "iot_class": "local_polling",
   "loggers": ["plugwise"],
-  "requirements": ["https://test-files.pythonhosted.org/packages/a0/df/109d0c1e41a6e79fedcfa30ceffde526728b7baace094cface3f506c45aa/plugwise-0.38.0a0.tar.gz#plugwise==0.38.0a0"],
+  "requirements": ["https://test-files.pythonhosted.org/packages/37/f6/dd415f4333ff2c51acb195af0cdee6177073fc33fba8b2f698f937914af3/plugwise-0.38.0a1.tar.gz#plugwise==0.38.0a1"],
   "version": "0.48.0a0"
 }

--- a/custom_components/plugwise/manifest.json
+++ b/custom_components/plugwise/manifest.json
@@ -8,6 +8,6 @@
   "integration_type": "hub",
   "iot_class": "local_polling",
   "loggers": ["plugwise"],
-  "requirements": ["https://test-files.pythonhosted.org/packages/37/f6/dd415f4333ff2c51acb195af0cdee6177073fc33fba8b2f698f937914af3/plugwise-0.38.0a1.tar.gz#plugwise==0.38.0a1"],
+  "requirements": ["https://test-files.pythonhosted.org/packages/1e/c3/ac3bea4ee473f2f382a804f13dcaa67af670939083f21990c28ebc423f85/plugwise-0.38.0a2.tar.gz#plugwise==0.38.0a2"],
   "version": "0.48.0a0"
 }

--- a/custom_components/plugwise/manifest.json
+++ b/custom_components/plugwise/manifest.json
@@ -8,6 +8,6 @@
   "integration_type": "hub",
   "iot_class": "local_polling",
   "loggers": ["plugwise"],
-  "requirements": ["plugwise==0.37.1"],
-  "version": "0.47.4"
+  "requirements": ["https://test-files.pythonhosted.org/packages/a0/df/109d0c1e41a6e79fedcfa30ceffde526728b7baace094cface3f506c45aa/plugwise-0.38.0a0.tar.gz#plugwise==0.38.0a0"],
+  "version": "0.48.0a0"
 }

--- a/tests/components/plugwise/test_init.py
+++ b/tests/components/plugwise/test_init.py
@@ -221,24 +221,8 @@ async def test_device_removal(
     for device_entry in list(dev_reg.devices.values()):
         for item in device_entry.identifiers:
             item_list.append(item[1])
-    assert "1772a4ea304041adb83f357b751341ff" not in item_list
     assert "01234567890abcdefghijklmnopqrstu" in item_list
-
-
-async def remove_device(
-    ws_client: MockHAClientWebSocket, device_id: str, config_entry_id: str
-) -> bool:
-    """Remove config entry from a device."""
-    await ws_client.send_json(
-        {
-            "id": 1,
-            "type": "config/device_registry/remove_config_entry",
-            "config_entry_id": config_entry_id,
-            "device_id": device_id,
-        }
-    )
-    response = await ws_client.receive_json()
-    return response["success"]
+    assert "1772a4ea304041adb83f357b751341ff" not in item_list
 
 
 async def test_device_remove_device(
@@ -253,7 +237,7 @@ async def test_device_remove_device(
 
     mock_config_entry.add_to_hass(hass)
 
-    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
     device_entry = device_registry.async_get_device(
@@ -280,3 +264,18 @@ async def test_device_remove_device(
         )
         is True
     )
+
+async def remove_device(
+    ws_client: MockHAClientWebSocket, device_id: str, config_entry_id: str
+) -> bool:
+    """Remove config entry from a device."""
+    await ws_client.send_json(
+        {
+            "id": 5,
+            "type": "config/device_registry/remove_config_entry",
+            "config_entry_id": config_entry_id,
+            "device_id": device_id,
+        }
+    )
+    response = await ws_client.receive_json()
+    return response["success"]

--- a/tests/components/plugwise/test_init.py
+++ b/tests/components/plugwise/test_init.py
@@ -237,7 +237,7 @@ async def test_device_remove_device(
 
     mock_config_entry.add_to_hass(hass)
 
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
     device_entry = device_registry.async_get_device(

--- a/tests/components/plugwise/test_init.py
+++ b/tests/components/plugwise/test_init.py
@@ -220,3 +220,4 @@ async def test_device_removal(
         for item in device_entry.identifiers:
             item_list.append(item[1])
     assert "1772a4ea304041adb83f357b751341ff" not in item_list
+    assert "01234567890abcdefghijklmnopqrstu" in item_list

--- a/tests/components/plugwise/test_init.py
+++ b/tests/components/plugwise/test_init.py
@@ -18,6 +18,7 @@ from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.setup import async_setup_component
 from homeassistant.util.dt import utcnow
 
 from tests.common import MockConfigEntry, async_fire_time_changed

--- a/tests/components/plugwise/test_init.py
+++ b/tests/components/plugwise/test_init.py
@@ -211,7 +211,7 @@ async def test_device_removal(
     # Replace a Tom/Floor
     data.devices.pop("1772a4ea304041adb83f357b751341ff")
     data.devices.update(TOM)
-    data.gateway.update({"config_changed": "01234567890abcdefghijklmnopqrstu"})
+    data.gateway.update({"config_changed": ["01234567890abcdefghijklmnopqrstu"]})
     with patch(HA_PLUGWISE_SMILE_ASYNC_UPDATE, return_value=data):
         async_fire_time_changed(hass, utcnow() + timedelta(minutes=1))
         await hass.config_entries.async_reload(mock_config_entry.entry_id)

--- a/tests/components/plugwise/test_init.py
+++ b/tests/components/plugwise/test_init.py
@@ -211,7 +211,7 @@ async def test_device_removal(
     # Replace a Tom/Floor
     data.devices.pop("1772a4ea304041adb83f357b751341ff")
     data.devices.update(TOM)
-    data.gateway.update({"config_changed": ["01234567890abcdefghijklmnopqrstu"]})
+    data.gateway.update({"new_devices": ["01234567890abcdefghijklmnopqrstu"]})
     with patch(HA_PLUGWISE_SMILE_ASYNC_UPDATE, return_value=data):
         async_fire_time_changed(hass, utcnow() + timedelta(minutes=1))
         # await hass.config_entries.async_reload(mock_config_entry.entry_id)

--- a/tests/components/plugwise/test_init.py
+++ b/tests/components/plugwise/test_init.py
@@ -211,6 +211,7 @@ async def test_device_removal(
     # Replace a Tom/Floor
     data.devices.pop("1772a4ea304041adb83f357b751341ff")
     data.devices.update(TOM)
+    data.gateway.update({"config_changed": "01234567890abcdefghijklmnopqrstu"})
     with patch(HA_PLUGWISE_SMILE_ASYNC_UPDATE, return_value=data):
         async_fire_time_changed(hass, utcnow() + timedelta(minutes=1))
         await hass.config_entries.async_reload(mock_config_entry.entry_id)

--- a/tests/components/plugwise/test_init.py
+++ b/tests/components/plugwise/test_init.py
@@ -214,7 +214,7 @@ async def test_device_removal(
     data.gateway.update({"config_changed": ["01234567890abcdefghijklmnopqrstu"]})
     with patch(HA_PLUGWISE_SMILE_ASYNC_UPDATE, return_value=data):
         async_fire_time_changed(hass, utcnow() + timedelta(minutes=1))
-        await hass.config_entries.async_reload(mock_config_entry.entry_id)
+        # await hass.config_entries.async_reload(mock_config_entry.entry_id)
         await hass.async_block_till_done()
 
     devices = dr.async_entries_for_config_entry(dev_reg, mock_config_entry.entry_id)

--- a/tests/components/plugwise/test_init.py
+++ b/tests/components/plugwise/test_init.py
@@ -209,10 +209,7 @@ async def test_device_removal(
     # Replace a Tom/Floor
     data.devices.pop("1772a4ea304041adb83f357b751341ff")
     data.devices.update(TOM)
-    device_list = list(data.devices.keys())
-    with patch(HA_PLUGWISE_SMILE_ASYNC_UPDATE, return_value=data), patch(
-        HA_PLUGWISE_SMILE, side_effect=device_list
-    ):
+    with patch(HA_PLUGWISE_SMILE_ASYNC_UPDATE, return_value=data):
         async_fire_time_changed(hass, utcnow() + timedelta(minutes=1))
         await hass.config_entries.async_reload(mock_config_entry.entry_id)
         await hass.async_block_till_done()


### PR DESCRIPTION
Linked to https://github.com/plugwise/python-plugwise/pull/524

Remaining topic, how to test that the automatic reload has happened.

All changes:
- Improve code in `coordinator.py`
- Move device removal functions to `__init__.py` and simplify
- Implement `async_remove_config_entry_device()` allowing the user to manually delete a removed Plugwise device from HA
- Add detection of new Plugwise devices, with automatic reload to get the device (visible) in HA