### PR TITLE
Improve device-delete related functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 ## Versions from 0.40 and up
 
-## Ongoing
+## v0.48.0
 
+- Add a delete-button per device, enables the user to manually delete a removed Plugwise device
+- Add automatic deletion of removed Plugwise devices after a HA restart
 - Replace outdated test-fixture, update related test-case.
 
 ## v0.47.4

--- a/custom_components/plugwise/__init__.py
+++ b/custom_components/plugwise/__init__.py
@@ -108,6 +108,7 @@ def cleanup_device_registry(
     # Find and remove the orphaned device(s) connected to the via_device
     for dev_id, device_entry in dev_reg_list:
         item = list(list(device_entry.identifiers)[0])
+        LOGGER.debug("HOI device_entry: %s", device_entry)
         if item[0] != DOMAIN:
             continue
         elif not (

--- a/custom_components/plugwise/__init__.py
+++ b/custom_components/plugwise/__init__.py
@@ -99,13 +99,18 @@ def cleanup_device_registry(
     for dev_id, device_entry in list(device_registry.devices.items()):
         item = list(device_entry.identifiers)[0]
         item = list(item)
+        if item[0] != DOMAIN:
+            continue
+
         # The first device is always the gateway
-        if device_entry.via_device_id is None:
+        if (
+            item[1] == data.gateway["gateway_id"]
+            and device_entry.via_device_id is None
+        ):
             via_device = dev_id
         elif not (
-            device_entry.via_device_id == via_device
-            and item[0] == DOMAIN
-            and item[1] in plugwise_device_list
+            item[1] in plugwise_device_list
+            and device_entry.via_device_id == via_device
         ):
             # device_registry.async_remove_device(dev_id)
             LOGGER.debug(

--- a/custom_components/plugwise/__init__.py
+++ b/custom_components/plugwise/__init__.py
@@ -111,7 +111,7 @@ def cleanup_device_registry(
     for dev_id, device_entry in dev_reg_list:
         if not (
             item[0] == DOMAIN
-            item[1] in plugwise_device_list
+            and item[1] in plugwise_device_list
             and device_entry.via_device_id == via_device
         ):
             # device_registry.async_remove_device(dev_id)

--- a/custom_components/plugwise/__init__.py
+++ b/custom_components/plugwise/__init__.py
@@ -94,13 +94,14 @@ def cleanup_device_registry(
     data: PlugwiseData,
 ) -> None:
     """Remove deleted devices from device-registry."""
-    device_registry = dr.async_get(hass)
     plugwise_device_list = list(data.devices.keys())
+    if len(plugwise_device_list) < 2:
+        return
+
+    device_registry = dr.async_get(hass)
     for dev_id, device_entry in list(device_registry.devices.items()):
         for item in device_entry.identifiers:
-            if item[0] == DOMAIN and (
-                len(plugwise_device_list) > 1 and item[1] in plugwise_device_list
-            ):
+            if item[0] == DOMAIN and item[1] in plugwise_device_list:
                 continue
 
             device_registry.async_remove_device(dev_id)

--- a/custom_components/plugwise/__init__.py
+++ b/custom_components/plugwise/__init__.py
@@ -96,7 +96,7 @@ def cleanup_device_registry(
     """Remove deleted devices from device-registry."""
     plugwise_device_list = list(data.devices.keys())
     if len(plugwise_device_list) < 2:
-        return
+        return  # pragma: no cover
 
     device_registry = dr.async_get(hass)
     for dev_id, device_entry in list(device_registry.devices.items()):

--- a/custom_components/plugwise/__init__.py
+++ b/custom_components/plugwise/__init__.py
@@ -94,7 +94,6 @@ def cleanup_device_registry(
     data: PlugwiseData,
 ) -> None:
     """Remove deleted devices from device-registry."""
-    gateway_id: str = data.gateway["gateway_id"]
     plugwise_device_list: list[str] = list(data.devices.keys())
     device_registry = dr.async_get(hass)
     dev_reg_list = list(device_registry.devices.items())
@@ -103,22 +102,23 @@ def cleanup_device_registry(
         if device_entry.manufacturer == "Plugwise" and device_entry.model == "Gateway":
             via_device = device_entry.id
 
+    LOGGER.debug("HOI via_device: %s", via_device)
     # Find and remove the orphaned device(s) connected to the via_device
     for dev_id, device_entry in dev_reg_list:
-        item = list(list(device_entry.identifiers)[0])
-        if (
-            item[0] == DOMAIN
-            and device_entry.via_device_id == via_device
-            and item[1] not in plugwise_device_list
-
-        ):
-            device_registry.async_remove_device(dev_id)
-            LOGGER.debug(
-                "Removed %s device %s %s from device_registry",
-                DOMAIN,
-                device_entry.model,
-                item[1],
-            )
+        LOGGER.debug("HOI device_entry: %s", device_entry)
+        # item = list(list(device_entry.identifiers)[0])
+        # if (
+        #     item[0] == DOMAIN
+        #     and device_entry.via_device_id == via_device
+        #     and item[1] not in plugwise_device_list
+        # ):
+        #     device_registry.async_remove_device(dev_id)
+        #     LOGGER.debug(
+        #         "Removed %s device %s %s from device_registry",
+        #         DOMAIN,
+        #         device_entry.model,
+        #         item[1],
+        #     )
 
 async def _update_listener(
     hass: HomeAssistant, entry: ConfigEntry

--- a/custom_components/plugwise/__init__.py
+++ b/custom_components/plugwise/__init__.py
@@ -117,7 +117,7 @@ def cleanup_device_registry(
             device_entry.via_device_id == via_device
             and item[1] not in list(data.devices.keys())
         ):
-            device_registry.async_remove_device(dev_id)
+            device_registry.async_remove_device(device_entry.id)
             LOGGER.debug(
                 "Removed %s device %s %s from device_registry",
                 DOMAIN,

--- a/custom_components/plugwise/__init__.py
+++ b/custom_components/plugwise/__init__.py
@@ -94,7 +94,6 @@ def cleanup_device_registry(
     data: PlugwiseData,
 ) -> None:
     """Remove deleted devices from device-registry."""
-    plugwise_device_list: list[str] = list(data.devices.keys())
     device_registry = dr.async_get(hass)
     dev_reg_list = list(device_registry.devices.items())
     # First find the Plugwise via_device_id
@@ -103,7 +102,7 @@ def cleanup_device_registry(
             continue
 
         item = list(list(device_entry.identifiers)[0])
-        if item[0] == DOMAIN and item[1] == gateway_id:
+        if item[0] == DOMAIN and item[1] == data.gateway["gateway_id"]:
             via_device = dev_id
 
     # Find and remove the orphaned device(s) connected to the via_device
@@ -115,7 +114,7 @@ def cleanup_device_registry(
         if (
             item[0] == DOMAIN
             and device_entry.via_device_id == via_device
-            and item[1] not in plugwise_device_list
+            and item[1] not in list(data.devices.keys())
         ):
             device_registry.async_remove_device(dev_id)
             LOGGER.debug(

--- a/custom_components/plugwise/__init__.py
+++ b/custom_components/plugwise/__init__.py
@@ -98,9 +98,13 @@ def cleanup_device_registry(
     device_registry = dr.async_get(hass)
     dev_reg_list = list(device_registry.devices.items())
     # First find the Plugwise via_device_id
-    for _, device_entry in dev_reg_list:
-        if device_entry.manufacturer == "Plugwise" and device_entry.model == "Gateway":
-            via_device = device_entry.id
+    for dev_id, device_entry in dev_reg_list:
+        if not device_entry.identifiers:
+            continue
+
+        item = list(list(device_entry.identifiers)[0])
+        if item[0] == DOMAIN and item[1] == gateway_id:
+            via_device = dev_id
 
     # Find and remove the orphaned device(s) connected to the via_device
     for dev_id, device_entry in dev_reg_list:

--- a/custom_components/plugwise/__init__.py
+++ b/custom_components/plugwise/__init__.py
@@ -99,19 +99,19 @@ def cleanup_device_registry(
     dev_reg_list = list(device_registry.devices.items())
     # First find the Plugwise via_device_id   
     for dev_id, device_entry in dev_reg_list:
-        item = list(device_entry.identifiers)[0]
-        item = list(item)
+        item = list(list(device_entry.identifiers)[0])
         if item[0] != DOMAIN:
             continue
-    
         if item[1] == data.gateway["gateway_id"]:
             via_device = dev_id
 
     # Find and remove the orphaned device(s) connected to the via_device
     for dev_id, device_entry in dev_reg_list:
-        if not (
-            item[0] == DOMAIN
-            and item[1] in plugwise_device_list
+        item = list(list(device_entry.identifiers)[0])
+        if item[0] != DOMAIN:
+            continue
+        elif not (
+            item[1] in plugwise_device_list
             and device_entry.via_device_id == via_device
         ):
             # device_registry.async_remove_device(dev_id)

--- a/custom_components/plugwise/__init__.py
+++ b/custom_components/plugwise/__init__.py
@@ -95,18 +95,21 @@ def cleanup_device_registry(
 ) -> None:
     """Remove deleted devices from device-registry."""
     plugwise_device_list = list(data.devices.keys())
-    if len(plugwise_device_list) < 2:
-        return  # pragma: no cover
-
     device_registry = dr.async_get(hass)
     for dev_id, device_entry in list(device_registry.devices.items()):
-        for item in device_entry.identifiers:
-            if item[0] == DOMAIN and item[1] in plugwise_device_list:
-                continue
-
-            device_registry.async_remove_device(dev_id)
+        item = list(device_entry.identifiers)[0]
+        item = list(item)
+        # The first device is always the gateway
+        if device_entry.via_device_id is None:
+            via_device = dev_id
+        elif not (
+            device_entry.via_device_id == via_device
+            and item[0] == DOMAIN
+            and item[1] in plugwise_device_list
+        ):
+            # device_registry.async_remove_device(dev_id)
             LOGGER.debug(
-                "Removed %s %s %s from device_registry",
+                "HOI found orphaned device: %s %s %s in device_registry",
                 DOMAIN,
                 device_entry.model,
                 item[1],

--- a/custom_components/plugwise/__init__.py
+++ b/custom_components/plugwise/__init__.py
@@ -100,6 +100,7 @@ def cleanup_device_registry(
     dev_reg_list = list(device_registry.devices.items())
     # First find the Plugwise via_device_id
     for dev_id, device_entry in dev_reg_list:
+        LOGGER.debug("HOI device_entry: %s", device_entry)
         item = list(list(device_entry.identifiers)[0])
         if item[0] == DOMAIN and item[1] == gateway_id:
             via_device = dev_id

--- a/custom_components/plugwise/__init__.py
+++ b/custom_components/plugwise/__init__.py
@@ -96,19 +96,21 @@ def cleanup_device_registry(
     """Remove deleted devices from device-registry."""
     plugwise_device_list = list(data.devices.keys())
     device_registry = dr.async_get(hass)
-    for dev_id, device_entry in list(device_registry.devices.items()):
+    dev_reg_list = list(device_registry.devices.items())
+    # First find the Plugwise via_device_id   
+    for dev_id, device_entry in dev_reg_list:
         item = list(device_entry.identifiers)[0]
         item = list(item)
         if item[0] != DOMAIN:
             continue
-
-        # The first device is always the gateway
-        if (
-            item[1] == data.gateway["gateway_id"]
-            and device_entry.via_device_id is None
-        ):
+    
+        if item[1] == data.gateway["gateway_id"]:
             via_device = dev_id
-        elif not (
+
+    # Find and remove the orphaned device(s) connected to the via_device
+    for dev_id, device_entry in dev_reg_list:
+        if not (
+            item[0] == DOMAIN
             item[1] in plugwise_device_list
             and device_entry.via_device_id == via_device
         ):

--- a/custom_components/plugwise/__init__.py
+++ b/custom_components/plugwise/__init__.py
@@ -112,7 +112,10 @@ def cleanup_device_registry(
         if (
             item[0] == DOMAIN
             and item[1] in plugwise_device_list
-            and device_entry.via_device_id == via_device
+            and (
+                device_entry.via_device_id == via_device
+                or device_entry.via_device_id is None
+            )
         ):
             continue
 

--- a/custom_components/plugwise/__init__.py
+++ b/custom_components/plugwise/__init__.py
@@ -96,24 +96,19 @@ def cleanup_device_registry(
     """Remove deleted devices from device-registry."""
     device_registry = dr.async_get(hass)
     dev_reg_list = list(device_registry.devices.items())
-    # First find the Plugwise via_device_id
     for dev_id, device_entry in dev_reg_list:
         if not device_entry.identifiers:
             continue
 
         item = list(list(device_entry.identifiers)[0])
-        if item[0] == DOMAIN and item[1] == data.gateway["gateway_id"]:
+        if item[0] != DOMAIN:
+            continue
+
+        # First find the Plugwise via_device
+        if item[1] == data.gateway["gateway_id"]:
             via_device = dev_id
-
-    # Find and remove the orphaned device(s) connected to the via_device
-    for dev_id, device_entry in dev_reg_list:
-        if not device_entry.identifiers:
-            continue
-
-        item = list(list(device_entry.identifiers)[0])
-        if (
-            item[0] == DOMAIN
-            and device_entry.via_device_id == via_device
+        elif ( # Remove the orphaned device(s) connected to the via_device
+            device_entry.via_device_id == via_device
             and item[1] not in list(data.devices.keys())
         ):
             device_registry.async_remove_device(dev_id)

--- a/custom_components/plugwise/__init__.py
+++ b/custom_components/plugwise/__init__.py
@@ -99,11 +99,9 @@ def cleanup_device_registry(
     device_registry = dr.async_get(hass)
     dev_reg_list = list(device_registry.devices.items())
     # First find the Plugwise via_device_id
-    for dev_id, device_entry in dev_reg_list:
-        LOGGER.debug("HOI device_entry: %s", device_entry)
-        item = list(list(device_entry.identifiers)[0])
-        if item[0] == DOMAIN and item[1] == gateway_id:
-            via_device = dev_id
+    for _, device_entry in dev_reg_list:
+        if device_entry.manufacturer == "Plugwise" and device_entry.model == "Gateway":
+            via_device = device_entry.id
 
     # Find and remove the orphaned device(s) connected to the via_device
     for dev_id, device_entry in dev_reg_list:

--- a/custom_components/plugwise/__init__.py
+++ b/custom_components/plugwise/__init__.py
@@ -103,10 +103,10 @@ def cleanup_device_registry(
 
             device_registry.async_remove_device(dev_id)
             LOGGER.debug(
-                "Removed device %s %s %s from device_registry",
+                "Removed %s device %s %s from device_registry",
                 DOMAIN,
                 device_entry.model,
-                dev_id,
+                item[1],
             )
 
 async def _update_listener(

--- a/custom_components/plugwise/__init__.py
+++ b/custom_components/plugwise/__init__.py
@@ -105,6 +105,7 @@ def cleanup_device_registry(
         if item[1] == data.gateway["gateway_id"]:
             via_device = dev_id
 
+    LOGGER.debug("HOI via_device: %s", via_device)
     # Find and remove the orphaned device(s) connected to the via_device
     for dev_id, device_entry in dev_reg_list:
         item = list(list(device_entry.identifiers)[0])

--- a/custom_components/plugwise/__init__.py
+++ b/custom_components/plugwise/__init__.py
@@ -132,7 +132,7 @@ async def async_remove_config_entry_device(
     return not any(
         identifier
         for identifier in device_entry.identifiers
-        if identifier[0] == DOMAIN and coordinator.data.devices[identifier[1]]
+        if identifier[0] == DOMAIN and (identifier[1] in coordinator.data.devices)
     )
 
 @callback

--- a/custom_components/plugwise/__init__.py
+++ b/custom_components/plugwise/__init__.py
@@ -98,7 +98,9 @@ def cleanup_device_registry(
     plugwise_device_list = list(data.devices.keys())
     for dev_id, device_entry in list(device_registry.devices.items()):
         for item in device_entry.identifiers:
-            if item[0] == DOMAIN and item[1] in plugwise_device_list:
+            if item[0] == DOMAIN and (
+                len(plugwise_device_list) > 1 and item[1] in plugwise_device_list
+            ):
                 continue
 
             device_registry.async_remove_device(dev_id)

--- a/custom_components/plugwise/__init__.py
+++ b/custom_components/plugwise/__init__.py
@@ -36,7 +36,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     LOGGER.debug("DUC cooldown interval: %s", cooldown)
 
     coordinator = PlugwiseDataUpdateCoordinator(
-        hass, entry, cooldown
+        hass, cooldown
     )  # pw-beta - cooldown, update_interval as extra
     await coordinator.async_config_entry_first_refresh()
     # Migrate a changed sensor unique_id

--- a/custom_components/plugwise/__init__.py
+++ b/custom_components/plugwise/__init__.py
@@ -106,7 +106,7 @@ def cleanup_device_registry(
 
             device_registry.async_remove_device(dev_id)
             LOGGER.debug(
-                "Removed %s device %s %s from device_registry",
+                "Removed %s %s %s from device_registry",
                 DOMAIN,
                 device_entry.model,
                 item[1],

--- a/custom_components/plugwise/__init__.py
+++ b/custom_components/plugwise/__init__.py
@@ -96,6 +96,9 @@ def cleanup_device_registry(
     """Remove deleted devices from device-registry."""
     device_registry = dr.async_get(hass)
     dev_reg_list = list(device_registry.devices.items())
+    # via_device cannot be None, this will result in the deletion
+    # of other Plugwise Gateways when present!
+    via_device: str = ""
     for dev_id, device_entry in dev_reg_list:
         if not device_entry.identifiers:
             continue
@@ -104,10 +107,10 @@ def cleanup_device_registry(
         if item[0] != DOMAIN:
             continue
 
-        # First find the Plugwise via_device
+        # First find the Plugwise via_device, this is always the first device
         if item[1] == data.gateway["gateway_id"]:
             via_device = dev_id
-        elif ( # Remove the orphaned device(s) connected to the via_device
+        elif ( # then remove the connected orphaned device(s)
             device_entry.via_device_id == via_device
             and item[1] not in list(data.devices.keys())
         ):

--- a/custom_components/plugwise/__init__.py
+++ b/custom_components/plugwise/__init__.py
@@ -105,24 +105,24 @@ def cleanup_device_registry(
         if item[1] == data.gateway["gateway_id"]:
             via_device = dev_id
 
-    LOGGER.debug("HOI via_device: %s", via_device)
     # Find and remove the orphaned device(s) connected to the via_device
     for dev_id, device_entry in dev_reg_list:
         item = list(list(device_entry.identifiers)[0])
         LOGGER.debug("HOI device_entry: %s", device_entry)
-        if item[0] != DOMAIN:
-            continue
-        elif not (
-            item[1] in plugwise_device_list
+        if (
+            item[0] == DOMAIN
+            and item[1] in plugwise_device_list
             and device_entry.via_device_id == via_device
         ):
-            # device_registry.async_remove_device(dev_id)
-            LOGGER.debug(
-                "HOI found orphaned device: %s %s %s in device_registry",
-                DOMAIN,
-                device_entry.model,
-                item[1],
-            )
+            continue
+
+        # device_registry.async_remove_device(dev_id)
+        LOGGER.debug(
+            "HOI found orphaned device: %s %s %s in device_registry",
+            DOMAIN,
+            device_entry.model,
+            item[1],
+        )
 
 async def _update_listener(
     hass: HomeAssistant, entry: ConfigEntry

--- a/custom_components/plugwise/__init__.py
+++ b/custom_components/plugwise/__init__.py
@@ -102,23 +102,24 @@ def cleanup_device_registry(
         if device_entry.manufacturer == "Plugwise" and device_entry.model == "Gateway":
             via_device = device_entry.id
 
-    LOGGER.debug("HOI via_device: %s", via_device)
     # Find and remove the orphaned device(s) connected to the via_device
     for dev_id, device_entry in dev_reg_list:
-        LOGGER.debug("HOI device_entry: %s", device_entry)
-        # item = list(list(device_entry.identifiers)[0])
-        # if (
-        #     item[0] == DOMAIN
-        #     and device_entry.via_device_id == via_device
-        #     and item[1] not in plugwise_device_list
-        # ):
-        #     device_registry.async_remove_device(dev_id)
-        #     LOGGER.debug(
-        #         "Removed %s device %s %s from device_registry",
-        #         DOMAIN,
-        #         device_entry.model,
-        #         item[1],
-        #     )
+        if not device_entry.identifiers:
+            continue
+
+        item = list(list(device_entry.identifiers)[0])
+        if (
+            item[0] == DOMAIN
+            and device_entry.via_device_id == via_device
+            and item[1] not in plugwise_device_list
+        ):
+            device_registry.async_remove_device(dev_id)
+            LOGGER.debug(
+                "Removed %s device %s %s from device_registry",
+                DOMAIN,
+                device_entry.model,
+                item[1],
+            )
 
 async def _update_listener(
     hass: HomeAssistant, entry: ConfigEntry

--- a/custom_components/plugwise/__init__.py
+++ b/custom_components/plugwise/__init__.py
@@ -101,17 +101,15 @@ def cleanup_device_registry(
     # First find the Plugwise via_device_id   
     for dev_id, device_entry in dev_reg_list:
         item = list(list(device_entry.identifiers)[0])
-        if item[0] != DOMAIN:
-            continue
-        if item[1] == gateway_id
+        if item[0] == DOMAIN and item[1] == gateway_id:
             via_device = dev_id
 
     # Find and remove the orphaned device(s) connected to the via_device
-    for dev_id, device_entry in dev_reg_list:
+    for _, device_entry in dev_reg_list:
         item = list(list(device_entry.identifiers)[0])
-        if not(
+        if (
             item[0] == DOMAIN
-            and item[1] in plugwise_device_list
+            and item[1] not in plugwise_device_list
             and device_entry.via_device_id == via_device
         ):
             # device_registry.async_remove_device(dev_id)

--- a/custom_components/plugwise/__init__.py
+++ b/custom_components/plugwise/__init__.py
@@ -94,7 +94,8 @@ def cleanup_device_registry(
     data: PlugwiseData,
 ) -> None:
     """Remove deleted devices from device-registry."""
-    plugwise_device_list = list(data.devices.keys())
+    gateway_id = data.gateway["gateway_id"]
+    plugwise_device_list = list(data.devices.keys()).remove(gateway_id)
     device_registry = dr.async_get(hass)
     dev_reg_list = list(device_registry.devices.items())
     # First find the Plugwise via_device_id   
@@ -102,30 +103,24 @@ def cleanup_device_registry(
         item = list(list(device_entry.identifiers)[0])
         if item[0] != DOMAIN:
             continue
-        if item[1] == data.gateway["gateway_id"]:
+        if item[1] == gateway_id
             via_device = dev_id
 
     # Find and remove the orphaned device(s) connected to the via_device
     for dev_id, device_entry in dev_reg_list:
         item = list(list(device_entry.identifiers)[0])
-        LOGGER.debug("HOI device_entry: %s", device_entry)
-        if (
+        if not(
             item[0] == DOMAIN
             and item[1] in plugwise_device_list
-            and (
-                device_entry.via_device_id == via_device
-                or device_entry.via_device_id is None
-            )
+            and device_entry.via_device_id == via_device
         ):
-            continue
-
-        # device_registry.async_remove_device(dev_id)
-        LOGGER.debug(
-            "HOI found orphaned device: %s %s %s in device_registry",
-            DOMAIN,
-            device_entry.model,
-            item[1],
-        )
+            # device_registry.async_remove_device(dev_id)
+            LOGGER.debug(
+                "HOI found orphaned device: %s %s %s in device_registry",
+                DOMAIN,
+                device_entry.model,
+                item[1],
+            )
 
 async def _update_listener(
     hass: HomeAssistant, entry: ConfigEntry

--- a/custom_components/plugwise/__init__.py
+++ b/custom_components/plugwise/__init__.py
@@ -94,27 +94,28 @@ def cleanup_device_registry(
     data: PlugwiseData,
 ) -> None:
     """Remove deleted devices from device-registry."""
-    gateway_id = data.gateway["gateway_id"]
-    plugwise_device_list = list(data.devices.keys()).remove(gateway_id)
+    gateway_id: str = data.gateway["gateway_id"]
+    plugwise_device_list: list[str] = list(data.devices.keys())
     device_registry = dr.async_get(hass)
     dev_reg_list = list(device_registry.devices.items())
-    # First find the Plugwise via_device_id   
+    # First find the Plugwise via_device_id
     for dev_id, device_entry in dev_reg_list:
         item = list(list(device_entry.identifiers)[0])
         if item[0] == DOMAIN and item[1] == gateway_id:
             via_device = dev_id
 
     # Find and remove the orphaned device(s) connected to the via_device
-    for _, device_entry in dev_reg_list:
+    for dev_id, device_entry in dev_reg_list:
         item = list(list(device_entry.identifiers)[0])
         if (
             item[0] == DOMAIN
-            and item[1] not in plugwise_device_list
             and device_entry.via_device_id == via_device
+            and item[1] not in plugwise_device_list
+
         ):
-            # device_registry.async_remove_device(dev_id)
+            device_registry.async_remove_device(dev_id)
             LOGGER.debug(
-                "HOI found orphaned device: %s %s %s in device_registry",
+                "Removed %s device %s %s from device_registry",
                 DOMAIN,
                 device_entry.model,
                 item[1],

--- a/custom_components/plugwise/coordinator.py
+++ b/custom_components/plugwise/coordinator.py
@@ -20,33 +20,11 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryError
-from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import DEFAULT_PORT, DEFAULT_SCAN_INTERVAL, DEFAULT_USERNAME, DOMAIN, LOGGER
-
-
-def cleanup_device_registry(
-    hass: HomeAssistant,
-    data: PlugwiseData,
-) -> None:
-    """Remove deleted devices from device-registry."""
-    device_registry = dr.async_get(hass)
-    plugwise_device_list = list(data.devices.keys())
-    for dev_id, device_entry in list(device_registry.devices.items()):
-        for item in device_entry.identifiers:
-            if item[0] == DOMAIN and item[1] in plugwise_device_list:
-                continue
-
-            device_registry.async_remove_device(dev_id)
-            LOGGER.debug(
-                "Removed device %s %s %s from device_registry",
-                DOMAIN,
-                device_entry.model,
-                dev_id,
-            )
 
 
 class PlugwiseDataUpdateCoordinator(DataUpdateCoordinator[PlugwiseData]):
@@ -136,8 +114,5 @@ class PlugwiseDataUpdateCoordinator(DataUpdateCoordinator[PlugwiseData]):
             if not self._unavailable_logged:  # pw-beta add to Core
                 self._unavailable_logged = True
                 raise UpdateFailed("Failed to connect") from err
-
-        # Clean-up removed devices
-        cleanup_device_registry(self.hass, data)
 
         return data

--- a/custom_components/plugwise/coordinator.py
+++ b/custom_components/plugwise/coordinator.py
@@ -113,9 +113,4 @@ class PlugwiseDataUpdateCoordinator(DataUpdateCoordinator[PlugwiseData]):
                 self._unavailable_logged = True
                 raise UpdateFailed("Failed to connect") from err
 
-        # Reload when the configuration has changed
-        if "config_changed" in data.gateway:
-            LOGGER.debug("HOI config has changed")
-            await self.hass.config_entries.async_reload(self.config_entry.entry_id)
-
         return data

--- a/custom_components/plugwise/coordinator.py
+++ b/custom_components/plugwise/coordinator.py
@@ -113,4 +113,9 @@ class PlugwiseDataUpdateCoordinator(DataUpdateCoordinator[PlugwiseData]):
                 self._unavailable_logged = True
                 raise UpdateFailed("Failed to connect") from err
 
+        # Reload when the configuration has changed
+        if "config_changed" in data.gateway:
+            LOGGER.debug("HOI config has changed")
+            await self.hass.config_entries.async_reload(self.config_entry.entry_id)
+
         return data

--- a/custom_components/plugwise/coordinator.py
+++ b/custom_components/plugwise/coordinator.py
@@ -28,46 +28,25 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 from .const import DEFAULT_PORT, DEFAULT_SCAN_INTERVAL, DEFAULT_USERNAME, DOMAIN, LOGGER
 
 
-def remove_stale_devices(
-    data: PlugwiseData,
-    device_registry: dr.DeviceRegistry,
-    via_id: str,
-) -> None:
-    """Process the Plugwise devices present in the device_registry connected to a specific Gateway."""
-    device_list = list(data.devices.keys())
-    for dev_id, device_entry in list(device_registry.devices.items()):
-        if device_entry.via_device_id == via_id:
-            for item in device_entry.identifiers:
-                if item[0] == DOMAIN and item[1] in device_list:
-                    continue
-
-                device_registry.async_remove_device(dev_id)
-                LOGGER.debug(
-                    "Removed device %s %s %s from device_registry",
-                    DOMAIN,
-                    device_entry.model,
-                    dev_id,
-                )
-
-
 def cleanup_device_registry(
     hass: HomeAssistant,
     data: PlugwiseData,
 ) -> None:
     """Remove deleted devices from device-registry."""
     device_registry = dr.async_get(hass)
-    via_id_list: list[list[str]] = []
-    # Collect the required data of the Plugwise Gateway's
-    for device_entry in list(device_registry.devices.values()):
-        if device_entry.manufacturer == "Plugwise" and device_entry.model == "Gateway":
-            for item in device_entry.identifiers:
-                via_id_list.append([item[1], device_entry.id])
+    plugwise_device_list = list(data.devices.keys())
+    for dev_id, device_entry in list(device_registry.devices.items()):
+        for item in device_entry.identifiers:
+            if item[0] == DOMAIN and item[1] in plugwise_device_list:
+                continue
 
-    for via_id in via_id_list:
-        if via_id[0] != data.gateway["gateway_id"]:
-            continue  # pragma: no cover
-
-        remove_stale_devices(data, device_registry, via_id[1])
+            device_registry.async_remove_device(dev_id)
+            LOGGER.debug(
+                "Removed device %s %s %s from device_registry",
+                DOMAIN,
+                device_entry.model,
+                dev_id,
+            )
 
 
 class PlugwiseDataUpdateCoordinator(DataUpdateCoordinator[PlugwiseData]):

--- a/custom_components/plugwise/manifest.json
+++ b/custom_components/plugwise/manifest.json
@@ -8,6 +8,6 @@
   "integration_type": "hub",
   "iot_class": "local_polling",
   "loggers": ["plugwise"],
-  "requirements": ["https://test-files.pythonhosted.org/packages/a0/df/109d0c1e41a6e79fedcfa30ceffde526728b7baace094cface3f506c45aa/plugwise-0.38.0a0.tar.gz#plugwise==0.38.0a0"],
+  "requirements": ["plugwise==0.37.1"],
   "version": "0.48.0a0"
 }

--- a/custom_components/plugwise/manifest.json
+++ b/custom_components/plugwise/manifest.json
@@ -8,6 +8,6 @@
   "integration_type": "hub",
   "iot_class": "local_polling",
   "loggers": ["plugwise"],
-  "requirements": ["plugwise==0.37.1"],
-  "version": "0.47.4"
+  "requirements": ["https://test-files.pythonhosted.org/packages/a0/df/109d0c1e41a6e79fedcfa30ceffde526728b7baace094cface3f506c45aa/plugwise-0.38.0a0.tar.gz#plugwise==0.38.0a0"],
+  "version": "0.48.0a0"
 }

--- a/custom_components/plugwise/manifest.json
+++ b/custom_components/plugwise/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "loggers": ["plugwise"],
   "requirements": ["plugwise==0.37.1"],
-  "version": "0.48.0a0"
+  "version": "0.48.0"
 }

--- a/custom_components/plugwise/util.py
+++ b/custom_components/plugwise/util.py
@@ -4,10 +4,15 @@ from __future__ import annotations
 from collections.abc import Awaitable, Callable, Coroutine
 from typing import Any, Concatenate, ParamSpec, TypeVar
 
+from plugwise import PlugwiseData
 from plugwise.exceptions import PlugwiseException
 
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import device_registry as dr
 
+from .const import DOMAIN, LOGGER
 from .entity import PlugwiseEntity
 
 _PlugwiseEntityT = TypeVar("_PlugwiseEntityT", bound=PlugwiseEntity)
@@ -37,3 +42,39 @@ def plugwise_command(
             await self.coordinator.async_request_refresh()
 
     return handler
+
+def cleanup_device_registry(
+    hass: HomeAssistant,
+    data: PlugwiseData,
+    entry: ConfigEntry,
+) -> None:
+    """Remove deleted devices from device-registry."""
+    device_registry = dr.async_get(hass)
+    device_entries = dr.async_entries_for_config_entry(
+        device_registry, entry.entry_id
+    )
+    # via_device cannot be None, this will result in the deletion
+    # of other Plugwise Gateways when present!
+    via_device: str = ""
+    for device_entry in device_entries:
+        if not device_entry.identifiers:
+            continue  # pragma: no cover
+
+        item = list(list(device_entry.identifiers)[0])
+        if item[0] != DOMAIN:
+            continue  # pragma: no cover
+
+        # First find the Plugwise via_device, this is always the first device
+        if item[1] == data.gateway["gateway_id"]:
+            via_device = device_entry.id
+        elif ( # then remove the connected orphaned device(s)
+            device_entry.via_device_id == via_device
+            and item[1] not in list(data.devices.keys())
+        ):
+            device_registry.async_remove_device(device_entry.id)
+            LOGGER.debug(
+                "Removed %s device %s %s from device_registry",
+                DOMAIN,
+                device_entry.model,
+                item[1],
+            )

--- a/tests/components/plugwise/test_init.py
+++ b/tests/components/plugwise/test_init.py
@@ -221,24 +221,8 @@ async def test_device_removal(
     for device_entry in list(dev_reg.devices.values()):
         for item in device_entry.identifiers:
             item_list.append(item[1])
-    assert "1772a4ea304041adb83f357b751341ff" not in item_list
     assert "01234567890abcdefghijklmnopqrstu" in item_list
-
-
-async def remove_device(
-    ws_client: MockHAClientWebSocket, device_id: str, config_entry_id: str
-) -> bool:
-    """Remove config entry from a device."""
-    await ws_client.send_json(
-        {
-            "id": 1,
-            "type": "config/device_registry/remove_config_entry",
-            "config_entry_id": config_entry_id,
-            "device_id": device_id,
-        }
-    )
-    response = await ws_client.receive_json()
-    return response["success"]
+    assert "1772a4ea304041adb83f357b751341ff" not in item_list
 
 
 async def test_device_remove_device(
@@ -253,7 +237,7 @@ async def test_device_remove_device(
 
     mock_config_entry.add_to_hass(hass)
 
-    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
     device_entry = device_registry.async_get_device(
@@ -280,3 +264,18 @@ async def test_device_remove_device(
         )
         is True
     )
+
+async def remove_device(
+    ws_client: MockHAClientWebSocket, device_id: str, config_entry_id: str
+) -> bool:
+    """Remove config entry from a device."""
+    await ws_client.send_json(
+        {
+            "id": 5,
+            "type": "config/device_registry/remove_config_entry",
+            "config_entry_id": config_entry_id,
+            "device_id": device_id,
+        }
+    )
+    response = await ws_client.receive_json()
+    return response["success"]

--- a/tests/components/plugwise/test_init.py
+++ b/tests/components/plugwise/test_init.py
@@ -237,7 +237,7 @@ async def test_device_remove_device(
 
     mock_config_entry.add_to_hass(hass)
 
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
     device_entry = device_registry.async_get_device(

--- a/tests/components/plugwise/test_init.py
+++ b/tests/components/plugwise/test_init.py
@@ -220,3 +220,4 @@ async def test_device_removal(
         for item in device_entry.identifiers:
             item_list.append(item[1])
     assert "1772a4ea304041adb83f357b751341ff" not in item_list
+    assert "01234567890abcdefghijklmnopqrstu" in item_list

--- a/tests/components/plugwise/test_init.py
+++ b/tests/components/plugwise/test_init.py
@@ -18,6 +18,7 @@ from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.setup import async_setup_component
 from homeassistant.util.dt import utcnow
 
 from tests.common import MockConfigEntry, async_fire_time_changed

--- a/tests/components/plugwise/test_init.py
+++ b/tests/components/plugwise/test_init.py
@@ -216,7 +216,7 @@ async def test_device_removal(
         await hass.config_entries.async_reload(mock_config_entry.entry_id)
         await hass.async_block_till_done()
 
-    devices = dr.async_entries_for_config_entry(dev_reg, mock_config_entry.entry_id)
+    dev_reg = dr.async_get(hass)
     item_list = []
     for device_entry in list(dev_reg.devices.values()):
         for item in device_entry.identifiers:

--- a/tests/components/plugwise/test_init.py
+++ b/tests/components/plugwise/test_init.py
@@ -191,7 +191,7 @@ async def test_migrate_unique_id_relay(
     )
 
 
-async def test_device_removal(
+async def test_device_registry_cleanup(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_smile_adam_2: MagicMock,
@@ -225,7 +225,7 @@ async def test_device_removal(
     assert "1772a4ea304041adb83f357b751341ff" not in item_list
 
 
-async def test_device_remove_device(
+async def test_remove_config_entry_device(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
     mock_config_entry: MockConfigEntry,

--- a/tests/components/plugwise/test_init.py
+++ b/tests/components/plugwise/test_init.py
@@ -209,10 +209,7 @@ async def test_device_removal(
     # Replace a Tom/Floor
     data.devices.pop("1772a4ea304041adb83f357b751341ff")
     data.devices.update(TOM)
-    device_list = list(data.devices.keys())
-    with patch(HA_PLUGWISE_SMILE_ASYNC_UPDATE, return_value=data), patch(
-        HA_PLUGWISE_SMILE, side_effect=device_list
-    ):
+    with patch(HA_PLUGWISE_SMILE_ASYNC_UPDATE, return_value=data):
         async_fire_time_changed(hass, utcnow() + timedelta(minutes=1))
         await hass.config_entries.async_reload(mock_config_entry.entry_id)
         await hass.async_block_till_done()


### PR DESCRIPTION
All changes:
- Improve code in `coordinator.py`
- Move automatic device removal to `__init__.py`, function to `util.py` and make it work properly so that it functions too when there are more than 1 Plugwise integrations loaded (e.g. Adam plus P1).
- Add `async_remove_config_entry_device()` function, this will allow a user to manually delete a removed Plugwise device.