### PR TITLE
Py312

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,7 +59,7 @@ repos:
       - id: yamllint
         name: "Linting yaml"
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.1.0
+    rev: v4.0.0-alpha.8
     hooks:
       - id: prettier
         name: "Verifying/updating code with prettier"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Versions from 0.40 and up
 
+## ongoing
+
+- Require python 3.12 (as Core 2024.2 already does)
+
 ## v0.48.1
 
 - Redact sensitive data in the diagnostics-download

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,11 +3,11 @@
 "Bug Reports" = "https://github.com/plugwise/plugwise-beta/issues"
 
 [tool.black]
-target-version = ["py310", "py311"]
+target-version = ["py312"]
 exclude = 'generated'
 
 [tool.ruff]
-target-version = "py311"
+target-version = "py312"
 
 lint.select = [
     "B002", # Python does not support the unary prefix increment

--- a/scripts/core-testing.sh
+++ b/scripts/core-testing.sh
@@ -51,7 +51,7 @@ which jq || ( echo "You should have jq installed, exiting"; exit 1)
 # - quality
 
 
-pyversions=("3.11" "3.10" dummy) 
+pyversions=("3.12" dummy) 
 my_path=$(git rev-parse --show-toplevel)
 my_venv=${my_path}/venv
 

--- a/scripts/python-venv.sh
+++ b/scripts/python-venv.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eu
 
-pyversions=(3.11 3.10)
+pyversions=(3.12)
 my_path=$(git rev-parse --show-toplevel)
 my_venv=${my_path}/venv
 


### PR DESCRIPTION
Lets get rid of the weekly 'core' dev compatibility, 3.12 is required as of 2024.2

Also allow #603 to update, not sure why renovate doesn't pick up, but mirrors-prettier has no branches so we can't limit