### PR TITLE
Show full firmware-version

### DIFF
--- a/custom_components/plugwise/__init__.py
+++ b/custom_components/plugwise/__init__.py
@@ -59,7 +59,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         manufacturer="Plugwise",
         model=coordinator.api.smile_model,
         name=coordinator.api.smile_name,
-        sw_version=coordinator.api.smile_version[0],
+        sw_version=coordinator.api.smile_version,
     )
 
     async def delete_notification(


### PR DESCRIPTION
This fixes only showing the first number of the firmware for (legacy) P1.

Solution for #629 