### PR TITLE
Intermediate Core downstream / prepare tagging upstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ## Ongoing
 
-- Downstream Core changes
+- Downstream the latest Core Plugwise updates.
+- Document code-differences vs Core Plugwise - parts for future upstreaming and parts that will not be downstreamed.
+- Code improvements.
 
 ## v0.52.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,14 @@
 
 ## Versions from 0.40 and up
 
+## Ongoing
+
+- Downstream Core changes
+
 ## v0.52.0
 
 - Add battery-state binary_sensors for battery-powered devices.
 - Fix climate-test error: implement homeassistant.exceptions.ServiceValidationError
-- Downstream Core changes
 
 ## v0.51.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Versions from 0.40 and up
 
-## Ongoing
+## v0.52.1
 
 - Downstream the latest Core Plugwise updates.
 - Document code-differences vs Core Plugwise - parts for future upstreaming and parts that will not be downstreamed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Add battery-state binary_sensors for battery-powered devices.
 - Fix climate-test error: implement homeassistant.exceptions.ServiceValidationError
+- Downstream Core changes
 
 ## v0.51.6
 

--- a/custom_components/plugwise/__init__.py
+++ b/custom_components/plugwise/__init__.py
@@ -9,9 +9,9 @@ import voluptuous as vol  # pw-beta delete_notification
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
-from homeassistant.core import (  # ServiceCall for delete_notification
+from homeassistant.core import (
     HomeAssistant,
-    ServiceCall,
+    ServiceCall,  # pw-beta delete_notification
     callback,
 )
 from homeassistant.helpers import device_registry as dr, entity_registry as er
@@ -46,7 +46,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: PlugwiseConfigEntry) -> 
 
     migrate_sensor_entities(hass, coordinator)
 
-    entry.runtime_data = coordinator  # pw-beta
+    entry.runtime_data = coordinator
 
     device_registry = dr.async_get(hass)
     device_registry.async_get_or_create(
@@ -114,12 +114,11 @@ def async_migrate_entity_entry(entry: er.RegistryEntry) -> dict[str, Any] | None
         "-relative_humidity"
     ):
         return {
-            "new_unique_id": entry.unique_id.replace(
-                "-relative_humidity", "-humidity"
-            )
+            "new_unique_id": entry.unique_id.replace("-relative_humidity", "-humidity")
         }
     if entry.domain == Platform.SWITCH and entry.unique_id.endswith("-plug"):
         return {"new_unique_id": entry.unique_id.replace("-plug", "-relay")}
+
     # No migration needed
     return None
 

--- a/custom_components/plugwise/__init__.py
+++ b/custom_components/plugwise/__init__.py
@@ -29,7 +29,7 @@ type PlugwiseConfigEntry = ConfigEntry[PlugwiseDataUpdateCoordinator]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: PlugwiseConfigEntry) -> bool:
-    """Set up Plugwise components from a config entry."""
+    """Set up Plugwise from a config entry."""
     await er.async_migrate_entries(hass, entry.entry_id, async_migrate_entity_entry)
 
     cooldown = 1.5  # pw-beta frontend refresh-interval
@@ -93,7 +93,7 @@ async def update_listener(
     await hass.config_entries.async_reload(entry.entry_id)
 
 async def async_unload_entry(hass: HomeAssistant, entry: PlugwiseConfigEntry) -> bool:
-    """Unload the Plugwise components."""
+    """Unload Plugwise."""
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
 @callback
@@ -140,10 +140,5 @@ def migrate_sensor_entities(
             Platform.SENSOR, DOMAIN, old_unique_id
         ):
             new_unique_id = f"{device_id}-outdoor_air_temperature"
-            LOGGER.debug(
-                "Migrating entity %s from old unique ID '%s' to new unique ID '%s'",
-                entity_id,
-                old_unique_id,
-                new_unique_id,
-            )
+            # Upstream remove LOGGER debug
             ent_reg.async_update_entity(entity_id, new_unique_id=new_unique_id)

--- a/custom_components/plugwise/__init__.py
+++ b/custom_components/plugwise/__init__.py
@@ -29,7 +29,7 @@ type PlugwiseConfigEntry = ConfigEntry[PlugwiseDataUpdateCoordinator]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: PlugwiseConfigEntry) -> bool:
-    """Set up the Plugwise components from a config entry."""
+    """Set up Plugwise components from a config entry."""
     await er.async_migrate_entries(hass, entry.entry_id, async_migrate_entity_entry)
 
     cooldown = 1.5  # pw-beta frontend refresh-interval

--- a/custom_components/plugwise/__init__.py
+++ b/custom_components/plugwise/__init__.py
@@ -77,7 +77,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: PlugwiseConfigEntry) -> 
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
-    entry.async_on_unload(entry.add_update_listener(update_listener))  # pw-beta delete_notification
+    entry.async_on_unload(entry.add_update_listener(update_listener))  # pw-beta options_flow
     for component in PLATFORMS:  # pw-beta delete_notification
         if component == Platform.BINARY_SENSOR:
             hass.services.async_register(

--- a/custom_components/plugwise/binary_sensor.py
+++ b/custom_components/plugwise/binary_sensor.py
@@ -35,11 +35,11 @@ from .const import (
     SEVERITIES,
 )
 
-# upstream
+# Upstream
 from .coordinator import PlugwiseDataUpdateCoordinator
 from .entity import PlugwiseEntity
 
-PARALLEL_UPDATES = 0  # upstream
+PARALLEL_UPDATES = 0  # Upstream
 
 
 @dataclass(frozen=True)
@@ -123,7 +123,7 @@ async def async_setup_entry(
         #             BINARY_SENSORS
         #         )
         #     )
-        #     for description in PLUGWISE_BINARY_SENSORS  # upstream from const
+        #     for description in PLUGWISE_BINARY_SENSORS
         #     if description.key in binary_sensors
         # )
 

--- a/custom_components/plugwise/binary_sensor.py
+++ b/custom_components/plugwise/binary_sensor.py
@@ -105,7 +105,7 @@ async def async_setup_entry(
     entry: PlugwiseConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up the Plugwise binary_sensors from a config entry."""
+    """Set up Plugwise binary_sensors from a config entry."""
     coordinator = entry.runtime_data
 
     @callback
@@ -147,7 +147,7 @@ async def async_setup_entry(
 
 
 class PlugwiseBinarySensorEntity(PlugwiseEntity, BinarySensorEntity):
-    """Represent Plugwise binary_sensors from a config entry."""
+    """Set up Plugwise binary_sensors from a config entry."""
 
     entity_description: PlugwiseBinarySensorEntityDescription
 

--- a/custom_components/plugwise/button.py
+++ b/custom_components/plugwise/button.py
@@ -8,7 +8,11 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import PlugwiseConfigEntry
-from .const import GATEWAY_ID, REBOOT
+from .const import (
+    GATEWAY_ID,
+    LOGGER,  # pw-betea
+    REBOOT,
+)
 from .coordinator import PlugwiseDataUpdateCoordinator
 from .entity import PlugwiseEntity
 from .util import plugwise_command
@@ -25,11 +29,18 @@ async def async_setup_entry(
     coordinator = entry.runtime_data
 
     gateway = coordinator.data.gateway
-    async_add_entities(
-        PlugwiseButtonEntity(coordinator, device_id)
-        for device_id in coordinator.data.devices
-        if device_id == gateway[GATEWAY_ID] and REBOOT in gateway
-    )
+    # async_add_entities(
+    #     PlugwiseButtonEntity(coordinator, device_id)
+    #     for device_id in coordinator.data.devices
+    #     if device_id == gateway[GATEWAY_ID] and REBOOT in gateway
+    # )
+    # pw-beta alternative for debugging
+    entities: list[PlugwiseButtonEntity] = []
+    for device_id, device in coordinator.data.devices.items():
+        if device_id == gateway[GATEWAY_ID] and REBOOT in gateway:
+            entities.append(PlugwiseButtonEntity(coordinator, device_id))
+            LOGGER.debug("Add %s reboot button", device["name"])
+    async_add_entities(entities)
 
 
 class PlugwiseButtonEntity(PlugwiseEntity, ButtonEntity):

--- a/custom_components/plugwise/button.py
+++ b/custom_components/plugwise/button.py
@@ -25,7 +25,7 @@ async def async_setup_entry(
     entry: PlugwiseConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up the Plugwise buttons from a config entry."""
+    """Set up Plugwise buttons from a config entry."""
     coordinator = entry.runtime_data
 
     gateway = coordinator.data.gateway

--- a/custom_components/plugwise/climate.py
+++ b/custom_components/plugwise/climate.py
@@ -105,8 +105,8 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity):
     _attr_translation_key = DOMAIN
     _enable_turn_on_off_backwards_compatibility = False
 
-    _homekit_mode: str | None = None  # pw-beta homekit emulation
-    _previous_mode: str = HVACAction.HEATING
+    _previous_mode: str = HVACAction.HEATING  # Upstream
+    _homekit_mode: str | None = None  # pw-beta homekit emulation + intentional unsort
 
     def __init__(
         self,

--- a/custom_components/plugwise/climate.py
+++ b/custom_components/plugwise/climate.py
@@ -15,7 +15,13 @@ from homeassistant.components.climate.const import (
     HVACAction,
     HVACMode,
 )
-from homeassistant.const import ATTR_NAME, ATTR_TEMPERATURE, STATE_ON, UnitOfTemperature
+from homeassistant.const import (
+    ATTR_NAME,
+    ATTR_TEMPERATURE,
+    STATE_OFF,
+    STATE_ON,
+    UnitOfTemperature,
+)
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -285,7 +291,7 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity):
         if hvac_mode != HVACMode.OFF:
             await self.coordinator.api.set_schedule_state(
                 self.device[LOCATION],
-                STATE_ON if hvac_mode == HVACMode.AUTO else HVACMode.OFF,
+                STATE_ON if hvac_mode == HVACMode.AUTO else STATE_OFF,
             )
 
         if (

--- a/custom_components/plugwise/climate.py
+++ b/custom_components/plugwise/climate.py
@@ -268,6 +268,8 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity):
         if ATTR_TARGET_TEMP_LOW in kwargs:
             data[TARGET_TEMP_LOW] = kwargs.get(ATTR_TARGET_TEMP_LOW)
 
+        # Upstream removed input-valid check
+
         if mode := kwargs.get(ATTR_HVAC_MODE):
             await self.async_set_hvac_mode(mode)
 

--- a/custom_components/plugwise/climate.py
+++ b/custom_components/plugwise/climate.py
@@ -1,4 +1,5 @@
 """Plugwise Climate component for Home Assistant."""
+
 from __future__ import annotations
 
 from typing import Any
@@ -57,6 +58,8 @@ from .const import (
 from .coordinator import PlugwiseDataUpdateCoordinator
 from .entity import PlugwiseEntity
 from .util import plugwise_command
+
+PARALLEL_UPDATES = 0  # Upstream
 
 
 async def async_setup_entry(

--- a/custom_components/plugwise/climate.py
+++ b/custom_components/plugwise/climate.py
@@ -268,12 +268,6 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity):
         if ATTR_TARGET_TEMP_LOW in kwargs:
             data[TARGET_TEMP_LOW] = kwargs.get(ATTR_TARGET_TEMP_LOW)
 
-        for temperature in data.values():
-            if temperature is None or not (
-                self._attr_min_temp <= temperature <= self._attr_max_temp
-            ):
-                raise ValueError("Invalid temperature change requested")
-
         if mode := kwargs.get(ATTR_HVAC_MODE):
             await self.async_set_hvac_mode(mode)
 

--- a/custom_components/plugwise/climate.py
+++ b/custom_components/plugwise/climate.py
@@ -15,13 +15,7 @@ from homeassistant.components.climate.const import (
     HVACAction,
     HVACMode,
 )
-from homeassistant.const import (
-    ATTR_NAME,
-    ATTR_TEMPERATURE,
-    STATE_OFF,
-    STATE_ON,
-    UnitOfTemperature,
-)
+from homeassistant.const import ATTR_NAME, ATTR_TEMPERATURE, STATE_ON, UnitOfTemperature
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -67,7 +61,7 @@ async def async_setup_entry(
     entry: PlugwiseConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up the Plugwise thermostats from a ConfigEntry."""
+    """Set up Plugwise thermostats from a config entry."""
     coordinator = entry.runtime_data
     homekit_enabled: bool = entry.options.get(
         CONF_HOMEKIT_EMULATION, False
@@ -237,13 +231,9 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity):
         self._previous_action_mode(self.coordinator)
 
         # Adam provides the hvac_action for each thermostat
-        if (control_state := self.device.get(CONTROL_STATE)) == HVACAction.COOLING:
-            return HVACAction.COOLING
-        if control_state == HVACAction.HEATING:
-            return HVACAction.HEATING
-        if control_state == HVACAction.PREHEATING:
-            return HVACAction.PREHEATING
-        if control_state == STATE_OFF:
+        if (control_state := self.device.get(CONTROL_STATE)) in (HVACAction.COOLING, HVACAction.HEATING, HVACAction.PREHEATING):
+            return control_state
+        if control_state == HVACMode.OFF:
             return HVACAction.IDLE
 
         # Anna
@@ -295,7 +285,7 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity):
         if hvac_mode != HVACMode.OFF:
             await self.coordinator.api.set_schedule_state(
                 self.device[LOCATION],
-                STATE_ON if hvac_mode == HVACMode.AUTO else STATE_OFF,
+                STATE_ON if hvac_mode == HVACMode.AUTO else HVACMode.OFF,
             )
 
         if (

--- a/custom_components/plugwise/config_flow.py
+++ b/custom_components/plugwise/config_flow.py
@@ -1,4 +1,5 @@
 """Config flow for Plugwise integration."""
+
 from __future__ import annotations
 
 import datetime as dt  # pw-beta options
@@ -24,6 +25,8 @@ from homeassistant.config_entries import (
     OptionsFlow,
     OptionsFlowWithConfigEntry,
 )
+
+# Upstream
 from homeassistant.const import (
     ATTR_CONFIGURATION_URL,
     CONF_BASE,
@@ -34,6 +37,8 @@ from homeassistant.const import (
     CONF_SCAN_INTERVAL,
     CONF_USERNAME,
 )
+
+# Upstream
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -62,9 +67,13 @@ from .const import (
     VERSION,
     ZEROCONF_MAP,
 )
+
+# Upstream
 from .coordinator import PlugwiseDataUpdateCoordinator
 
 type PlugwiseConfigEntry = ConfigEntry[PlugwiseDataUpdateCoordinator]
+
+# Upstream basically the whole file (excluding the pw-beta options)
 
 
 def _base_schema(

--- a/custom_components/plugwise/const.py
+++ b/custom_components/plugwise/const.py
@@ -1,9 +1,12 @@
 """Constants for Plugwise component."""
+
 from datetime import timedelta
 import logging
 from typing import Final, Literal
 
 from homeassistant.const import Platform
+
+# Upstream basically the whole file excluding pw-beta options
 
 DOMAIN: Final = "plugwise"
 

--- a/custom_components/plugwise/const.py
+++ b/custom_components/plugwise/const.py
@@ -190,19 +190,19 @@ ZEROCONF_MAP: Final[dict[str, str]] = {
     "stretch": "Stretch",
 }
 
-NumberType = Literal[
+type NumberType = Literal[
     "maximum_boiler_temperature",
     "max_dhw_temperature",
     "temperature_offset",
 ]
 
-SelectType = Literal[
+type SelectType = Literal[
     "select_dhw_mode",
     "select_gateway_mode",
     "select_regulation_mode",
     "select_schedule",
 ]
-SelectOptionsType = Literal[
+type SelectOptionsType = Literal[
     "dhw_modes",
     "gateway_modes",
     "regulation_modes",

--- a/custom_components/plugwise/diagnostics.py
+++ b/custom_components/plugwise/diagnostics.py
@@ -1,4 +1,5 @@
 """Diagnostics support for Plugwise."""
+
 from __future__ import annotations
 
 from typing import Any

--- a/custom_components/plugwise/entity.py
+++ b/custom_components/plugwise/entity.py
@@ -1,4 +1,5 @@
 """Generic Plugwise Entity Class."""
+
 from __future__ import annotations
 
 from plugwise.constants import DeviceData
@@ -23,6 +24,8 @@ from .const import (
     VENDOR,
     ZIGBEE_MAC_ADDRESS,
 )
+
+# Upstream consts
 from .coordinator import PlugwiseDataUpdateCoordinator
 
 
@@ -77,9 +80,9 @@ class PlugwiseEntity(CoordinatorEntity[PlugwiseDataUpdateCoordinator]):
     def available(self) -> bool:
         """Return if entity is available."""
         return (
+            # Upstream: Do not change the AVAILABLE line below: some Plugwise devices
+            # Upstream: do not provide their availability-status!
             self._dev_id in self.coordinator.data.devices
-            # Do not change the below line: some Plugwise devices
-            # do not provide their availability-status!
             and (AVAILABLE not in self.device or self.device[AVAILABLE] is True)
             and super().available
         )

--- a/custom_components/plugwise/manifest.json
+++ b/custom_components/plugwise/manifest.json
@@ -8,5 +8,6 @@
   "iot_class": "local_polling",
   "loggers": ["plugwise"],
   "requirements": ["plugwise==1.1.0"],
-  "version": "0.52.0"
+  "version": "0.52.0",
+  "zeroconf": ["_plugwise._tcp.local."]
 }

--- a/custom_components/plugwise/manifest.json
+++ b/custom_components/plugwise/manifest.json
@@ -8,6 +8,6 @@
   "iot_class": "local_polling",
   "loggers": ["plugwise"],
   "requirements": ["plugwise==1.1.0"],
-  "version": "0.52.0",
+  "version": "0.52.1",
   "zeroconf": ["_plugwise._tcp.local."]
 }

--- a/custom_components/plugwise/manifest.json
+++ b/custom_components/plugwise/manifest.json
@@ -1,7 +1,6 @@
 {
   "domain": "plugwise",
-  "name": "Plugwise Smile/Stretch Beta",
-  "after_dependencies": ["zeroconf"],
+  "name": "Plugwise Beta",
   "codeowners": ["@CoMPaTech", "@bouwew"],
   "config_flow": true,
   "documentation": "https://github.com/plugwise/plugwise-beta",

--- a/custom_components/plugwise/number.py
+++ b/custom_components/plugwise/number.py
@@ -72,7 +72,7 @@ async def async_setup_entry(
     entry: PlugwiseConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up the Plugwise number platform from a configentry."""
+    """Set up Plugwise number platform from a config entry."""
     # Upstream above to adhere to standard used
     coordinator = entry.runtime_data
 

--- a/custom_components/plugwise/number.py
+++ b/custom_components/plugwise/number.py
@@ -1,4 +1,5 @@
 """Number platform for Plugwise integration."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -9,7 +10,7 @@ from homeassistant.components.number import (
     NumberEntityDescription,
     NumberMode,
 )
-from homeassistant.const import ATTR_NAME, EntityCategory, UnitOfTemperature
+from homeassistant.const import EntityCategory, UnitOfTemperature
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -24,9 +25,13 @@ from .const import (
     UPPER_BOUND,
     NumberType,
 )
+
+# Upstream consts
 from .coordinator import PlugwiseDataUpdateCoordinator
 from .entity import PlugwiseEntity
 from .util import plugwise_command
+
+PARALLEL_UPDATES = 0  # Upstream
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -66,28 +71,22 @@ async def async_setup_entry(
     entry: PlugwiseConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up the Plugwise numbers from a ConfigEntry."""
+    """Set up the Plugwise number platform from a configentry."""
+    # Upstream above to adhere to standard used
     coordinator = entry.runtime_data
 
     @callback
     def _add_entities() -> None:
-        """Add Entities during init and runtime."""
+        """Add Entities."""
         if not coordinator.new_devices:
             return
 
-        entities: list[PlugwiseNumberEntity] = []
-        for device_id in coordinator.new_devices:
-            device = coordinator.data.devices[device_id]
-            for description in NUMBER_TYPES:
-                if description.key in device:
-                    entities.append(
-                        PlugwiseNumberEntity(coordinator, device_id, description)
-                    )
-                    LOGGER.debug(
-                        "Add %s %s number", device[ATTR_NAME], description.translation_key
-                    )
-
-        async_add_entities(entities)
+        async_add_entities(
+            PlugwiseNumberEntity(coordinator, device_id, description)
+            for device_id in coordinator.new_devices
+            for description in NUMBER_TYPES
+            if description.key in coordinator.data.devices[device_id]
+        )
 
     _add_entities()
     entry.async_on_unload(coordinator.async_add_listener(_add_entities))
@@ -106,16 +105,16 @@ class PlugwiseNumberEntity(PlugwiseEntity, NumberEntity):
     ) -> None:
         """Initiate Plugwise Number."""
         super().__init__(coordinator, device_id)
-        self.actuator = self.device[description.key]
+        self.actuator = self.device[description.key]  # Upstream
         self.device_id = device_id
         self.entity_description = description
         self._attr_unique_id = f"{device_id}-{description.key}"
         self._attr_mode = NumberMode.BOX
-        self._attr_native_max_value = self.device[description.key][UPPER_BOUND]
-        self._attr_native_min_value = self.device[description.key][LOWER_BOUND]
+        self._attr_native_max_value = self.device[description.key][UPPER_BOUND]  # Upstream const
+        self._attr_native_min_value = self.device[description.key][LOWER_BOUND]  # Upstream const
 
-        native_step = self.device[description.key][RESOLUTION]
-        if description.key != TEMPERATURE_OFFSET:
+        native_step = self.device[description.key][RESOLUTION]  # Upstream const
+        if description.key != TEMPERATURE_OFFSET:  # Upstream const
             native_step = max(native_step, 0.5)
         self._attr_native_step = native_step
 

--- a/custom_components/plugwise/number.py
+++ b/custom_components/plugwise/number.py
@@ -41,6 +41,7 @@ class PlugwiseNumberEntityDescription(NumberEntityDescription):
     key: NumberType
 
 
+# Upstream + is there a reason we didn't rename this one prefixed?
 NUMBER_TYPES = (
     PlugwiseNumberEntityDescription(
         key=MAX_BOILER_TEMP,

--- a/custom_components/plugwise/number.py
+++ b/custom_components/plugwise/number.py
@@ -82,12 +82,28 @@ async def async_setup_entry(
         if not coordinator.new_devices:
             return
 
-        async_add_entities(
-            PlugwiseNumberEntity(coordinator, device_id, description)
-            for device_id in coordinator.new_devices
-            for description in NUMBER_TYPES
-            if description.key in coordinator.data.devices[device_id]
-        )
+        # Upstream consts
+        # async_add_entities(
+        #     PlugwiseNumberEntity(coordinator, device_id, description)
+        #     for device_id in coordinator.new_devices
+        #     for description in NUMBER_TYPES
+        #     if description.key in coordinator.data.devices[device_id]
+        # )
+
+        # pw-beta alternative for debugging
+        entities: list[PlugwiseNumberEntity] = []
+        for device_id in coordinator.new_devices:
+            device = coordinator.data.devices[device_id]
+            for description in NUMBER_TYPES:
+                if description.key in device:
+                    entities.append(
+                        PlugwiseNumberEntity(coordinator, device_id, description)
+                    )
+                    LOGGER.debug(
+                        "Add %s %s number", device["name"], description.translation_key
+                    )
+
+        async_add_entities(entities)
 
     _add_entities()
     entry.async_on_unload(coordinator.async_add_listener(_add_entities))

--- a/custom_components/plugwise/select.py
+++ b/custom_components/plugwise/select.py
@@ -86,12 +86,26 @@ async def async_setup_entry(
         if not coordinator.new_devices:
             return
 
-        async_add_entities(
-            PlugwiseSelectEntity(coordinator, device_id, description)
-            for device_id in coordinator.new_devices
-            for description in SELECT_TYPES
-            if description.options_key in coordinator.data.devices[device_id]
-        )
+        # Upstream consts
+        # async_add_entities(
+        #     PlugwiseSelectEntity(coordinator, device_id, description)
+        #     for device_id in coordinator.new_devices
+        #     for description in SELECT_TYPES
+        #     if description.options_key in coordinator.data.devices[device_id]
+        # )
+        # pw-beta alternative for debugging
+        entities: list[PlugwiseSelectEntity] = []
+        for device_id in coordinator.new_devices:
+            device = coordinator.data.devices[device_id]
+            for description in SELECT_TYPES:
+                if description.options_key in device:
+                    entities.append(
+                        PlugwiseSelectEntity(coordinator, device_id, description)
+                    )
+                    LOGGER.debug(
+                        "Add %s %s selector", device["name"], description.translation_key
+                    )
+        async_add_entities(entities)
 
     _add_entities()
     entry.async_on_unload(coordinator.async_add_listener(_add_entities))

--- a/custom_components/plugwise/select.py
+++ b/custom_components/plugwise/select.py
@@ -1,10 +1,11 @@
 """Plugwise Select component for Home Assistant."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass
 
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
-from homeassistant.const import ATTR_NAME, STATE_ON, EntityCategory
+from homeassistant.const import STATE_ON, EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -26,11 +27,13 @@ from .const import (
     SelectOptionsType,
     SelectType,
 )
+
+# Upstream consts
 from .coordinator import PlugwiseDataUpdateCoordinator
 from .entity import PlugwiseEntity
 from .util import plugwise_command
 
-PARALLEL_UPDATES = 0
+PARALLEL_UPDATES = 0  # Upstream
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -41,6 +44,7 @@ class PlugwiseSelectEntityDescription(SelectEntityDescription):
     options_key: SelectOptionsType
 
 
+# Upstream + is there a reason we didn't rename this one prefixed?
 SELECT_TYPES = (
     PlugwiseSelectEntityDescription(
         key=SELECT_SCHEDULE,
@@ -73,28 +77,21 @@ async def async_setup_entry(
     entry: PlugwiseConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up the Plugwise selectors from a ConfigEntry."""
+    """Set up the Plugwise selector from a config entry."""
     coordinator = entry.runtime_data
 
     @callback
     def _add_entities() -> None:
-        """Add Entities during init and runtime."""
+        """Add Entities."""
         if not coordinator.new_devices:
             return
 
-        entities: list[PlugwiseSelectEntity] = []
-        for device_id in coordinator.new_devices:
-            device = coordinator.data.devices[device_id]
-            for description in SELECT_TYPES:
-                if description.options_key in device:
-                    entities.append(
-                        PlugwiseSelectEntity(coordinator, device_id, description)
-                    )
-                    LOGGER.debug(
-                        "Add %s %s selector", device[ATTR_NAME], description.translation_key
-                    )
-
-        async_add_entities(entities)
+        async_add_entities(
+            PlugwiseSelectEntity(coordinator, device_id, description)
+            for device_id in coordinator.new_devices
+            for description in SELECT_TYPES
+            if description.options_key in coordinator.data.devices[device_id]
+        )
 
     _add_entities()
     entry.async_on_unload(coordinator.async_add_listener(_add_entities))

--- a/custom_components/plugwise/select.py
+++ b/custom_components/plugwise/select.py
@@ -77,7 +77,7 @@ async def async_setup_entry(
     entry: PlugwiseConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up the Plugwise selector from a config entry."""
+    """Set up Plugwise selector from a config entry."""
     coordinator = entry.runtime_data
 
     @callback

--- a/custom_components/plugwise/sensor.py
+++ b/custom_components/plugwise/sensor.py
@@ -461,7 +461,7 @@ async def async_setup_entry(
     entry: PlugwiseConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up the Plugwise sensors from a config entry."""
+    """Set up Plugwise sensors from a config entry."""
     # Upstream as Plugwise not Smile
     coordinator = entry.runtime_data
 

--- a/custom_components/plugwise/sensor.py
+++ b/custom_components/plugwise/sensor.py
@@ -1,4 +1,5 @@
 """Plugwise Sensor component for Home Assistant."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -12,8 +13,7 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.const import (
-    ATTR_NAME,
-    ATTR_TEMPERATURE,
+    ATTR_TEMPERATURE,  # Upstream
     LIGHT_LUX,
     PERCENTAGE,
     EntityCategory,
@@ -59,7 +59,6 @@ from .const import (
     GAS_CONS_CUMULATIVE,
     GAS_CONS_INTERVAL,
     INTENDED_BOILER_TEMP,
-    LOGGER,
     MOD_LEVEL,
     NET_EL_CUMULATIVE,
     NET_EL_POINT,
@@ -78,6 +77,8 @@ from .const import (
     WATER_PRESSURE,
     WATER_TEMP,
 )
+
+# Upstream consts
 from .coordinator import PlugwiseDataUpdateCoordinator
 from .entity import PlugwiseEntity
 
@@ -91,6 +92,7 @@ class PlugwiseSensorEntityDescription(SensorEntityDescription):
     key: SensorType
 
 
+# Upstream consts
 PLUGWISE_SENSORS: tuple[PlugwiseSensorEntityDescription, ...] = (
     PlugwiseSensorEntityDescription(
         key=TARGET_TEMP,
@@ -458,29 +460,23 @@ async def async_setup_entry(
     entry: PlugwiseConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up the Plugwise sensors from a ConfigEntry."""
+    """Set up the Plugwise sensors from a config entry."""
+    # Upstream as Plugwise not Smile
     coordinator = entry.runtime_data
 
     @callback
     def _add_entities() -> None:
-        """Add Entities during init and runtime."""
+        """Add Entities."""
         if not coordinator.new_devices:
             return
 
-        entities: list[PlugwiseSensorEntity] = []
-        for device_id in coordinator.new_devices:
-            device = coordinator.data.devices[device_id]
-            if not (sensors := device.get(SENSORS)):
-                continue
-            for description in PLUGWISE_SENSORS:
-                if description.key not in sensors:
-                    continue
-                entities.append(PlugwiseSensorEntity(coordinator, device_id, description))
-                LOGGER.debug(
-                    "Add %s %s sensor", device[ATTR_NAME], description.translation_key or description.key
-                )
-
-        async_add_entities(entities)
+        async_add_entities(
+            PlugwiseSensorEntity(coordinator, device_id, description)
+            for device_id in coordinator.new_devices
+            if (sensors := coordinator.data.devices[device_id].get(SENSORS))
+            for description in PLUGWISE_SENSORS
+            if description.key in sensors
+        )  # Upstream consts
 
     _add_entities()
     entry.async_on_unload(coordinator.async_add_listener(_add_entities))
@@ -505,4 +501,4 @@ class PlugwiseSensorEntity(PlugwiseEntity, SensorEntity):
     @property
     def native_value(self) -> int | float:
         """Return the value reported by the sensor."""
-        return self.device[SENSORS][self.entity_description.key]
+        return self.device[SENSORS][self.entity_description.key]  # Upstream consts

--- a/custom_components/plugwise/switch.py
+++ b/custom_components/plugwise/switch.py
@@ -75,7 +75,7 @@ async def async_setup_entry(
     entry: PlugwiseConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up the Plugwise switches from a config entry."""
+    """Set up Plugwise switches from a config entry."""
     coordinator = entry.runtime_data
 
     @callback

--- a/custom_components/plugwise/util.py
+++ b/custom_components/plugwise/util.py
@@ -1,8 +1,9 @@
 """Utilities for Plugwise."""
+
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable, Coroutine
-from typing import Any, Concatenate, ParamSpec, TypeVar
+from typing import Any, Concatenate
 
 from plugwise.exceptions import PlugwiseException
 
@@ -10,13 +11,14 @@ from homeassistant.exceptions import HomeAssistantError
 
 from .entity import PlugwiseEntity
 
-_PlugwiseEntityT = TypeVar("_PlugwiseEntityT", bound=PlugwiseEntity)
-_R = TypeVar("_R")
-_P = ParamSpec("_P")
+# For reference:
+# _PlugwiseEntityT = TypeVar("_PlugwiseEntityT", bound=PlugwiseEntity)
+# _R = TypeVar("_R")
+# _P = ParamSpec("_P")
 
 
-def plugwise_command(
-    func: Callable[Concatenate[_PlugwiseEntityT, _P], Awaitable[_R]]
+def plugwise_command[_PlugwiseEntityT: PlugwiseEntity, **_P, _R](
+    func: Callable[Concatenate[_PlugwiseEntityT, _P], Awaitable[_R]],
 ) -> Callable[Concatenate[_PlugwiseEntityT, _P], Coroutine[Any, Any, _R]]:
     """Decorate Plugwise calls that send commands/make changes to the device.
 

--- a/hacs.json
+++ b/hacs.json
@@ -1,13 +1,14 @@
 {
-  "name": "Plugwise Smile/Stretch beta",
+  "name": "Plugwise beta",
   "domains": [
     "binary_sensor",
+    "button",
     "climate",
     "number",
     "select",
     "sensor",
     "switch"
   ],
-  "homeassistant": "2024.2.0",
+  "homeassistant": "2024.8.0",
   "render_readme": true
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "plugwise-beta"
 version = "0.51.6"
-description = "Plugwise Smile/Stretch custom_component (BETA)"
+description = "Plugwise beta custom-component"
 readme = "README.md"
 requires-python = ">=3.12"
 license = {file = "LICENSE"}


### PR DESCRIPTION
Points to notice:
 - [ ] We must check and thoroughly test the zeroconf change in manifest (not sure if this works in custom_components)
 - [ ] Mostly mentions of consts, but we might want to validate before upstreaming
 - [ ] Downstream most of the add_entities constructors
 - [ ] Language still to compare
 - [ ] Tests still to compare
 - [ ] `climate.py` has issues when rewriting as separate pw-beta and core functionality (rough progress in gist; https://gist.github.com/CoMPaTech/664d3d15a4572be5769fb510df154f2b)
 - [ ] We need to check alignment on the `Set up [Plugwise/Smile] ...` descriptors :)
 - [ ] Added parallels on all platforms (as induced from https://developers.home-assistant.io/docs/integration_fetching_data?_highlight=paral#request-parallelism)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Enhanced automatic discovery of Plugwise devices through updated integration metadata.

- **Improvements**
  - Updated integration name to "Plugwise Beta" for simplicity and clarity.
  - Added support for button controls in the integration, expanding its functionality.
  - Updated Home Assistant version requirement to ensure compatibility with the latest features and fixes.
  - Adjusted update handling in the Plugwise Climate component to improve stability.

- **Documentation**
  - Updated the CHANGELOG to reflect recent changes and improvements, providing better insights into updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->