### PR TITLE
Correct CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## v0.53.0
 
-- New Feature: show model_id's of all devices (Adam, Anna, and P1, not for legacy gateways).
+- New Feature: show model_id's of all devices (Adam, Anna, not for legacy gateways).
 
 ## v0.52.2
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced display of `model_id` for devices Adam and Anna, enhancing clarity by excluding legacy gateways and removing the previously included device P1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->