### PR TITLE
Fix leading space in translations

### DIFF
--- a/custom_components/plugwise/strings.json
+++ b/custom_components/plugwise/strings.json
@@ -149,7 +149,7 @@
         "name": "Cooling setpoint"
       },
       "heating_setpoint": {
-        "name": " Heating setpoint"
+        "name": "Heating setpoint"
       },
       "intended_boiler_temperature": {
         "name": "Intended boiler temperature"

--- a/custom_components/plugwise/translations/en.json
+++ b/custom_components/plugwise/translations/en.json
@@ -149,7 +149,7 @@
         "name": "Cooling setpoint"
       },
       "heating_setpoint": {
-        "name": " Heating setpoint"
+        "name": "Heating setpoint"
       },
       "intended_boiler_temperature": {
         "name": "Intended boiler temperature"


### PR DESCRIPTION
As detected by #731

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected formatting of the "heating_setpoint" string for improved consistency in display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->