### PR TITLE
Fix coordinator connection-method: don't use defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Versions from 0.40 and up
 
+## Ongoing
+
+- Fix coordinator connection-method: don't use defaults
+
 ## v0.53.5
 
 - Link to plugwise [v1.4.3](https://github.com/plugwise/python-plugwise/releases/tag/v1.4.3).

--- a/custom_components/plugwise/coordinator.py
+++ b/custom_components/plugwise/coordinator.py
@@ -29,10 +29,7 @@ from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import (
-    DEFAULT_PORT,
     DEFAULT_SCAN_INTERVAL,
-    DEFAULT_TIMEOUT,
-    DEFAULT_USERNAME,
     DOMAIN,
     GATEWAY_ID,
     LOGGER,
@@ -73,9 +70,9 @@ class PlugwiseDataUpdateCoordinator(DataUpdateCoordinator[PlugwiseData]):
         self.api = Smile(
             host=self.config_entry.data[CONF_HOST],
             password=self.config_entry.data[CONF_PASSWORD],
-            port=self.config_entry.data.get(CONF_PORT, DEFAULT_PORT),
-            timeout=self.config_entry.data.get(CONF_TIMEOUT, DEFAULT_TIMEOUT),
-            username=self.config_entry.data.get(CONF_USERNAME, DEFAULT_USERNAME),
+            port=self.config_entry.data.[CONF_PORT],
+            timeout=self.config_entry.data[CONF_TIMEOUT],
+            username=self.config_entry.data[CONF_USERNAME],
             websession=async_get_clientsession(hass, verify_ssl=False),
         )
         self._current_devices: set[str] = set()

--- a/custom_components/plugwise/coordinator.py
+++ b/custom_components/plugwise/coordinator.py
@@ -28,12 +28,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import (
-    DEFAULT_SCAN_INTERVAL,
-    DOMAIN,
-    GATEWAY_ID,
-    LOGGER,
-)
+from .const import DEFAULT_SCAN_INTERVAL, DOMAIN, GATEWAY_ID, LOGGER
 
 
 class PlugwiseDataUpdateCoordinator(DataUpdateCoordinator[PlugwiseData]):

--- a/custom_components/plugwise/coordinator.py
+++ b/custom_components/plugwise/coordinator.py
@@ -70,7 +70,7 @@ class PlugwiseDataUpdateCoordinator(DataUpdateCoordinator[PlugwiseData]):
         self.api = Smile(
             host=self.config_entry.data[CONF_HOST],
             password=self.config_entry.data[CONF_PASSWORD],
-            port=self.config_entry.data.[CONF_PORT],
+            port=self.config_entry.data[CONF_PORT],
             timeout=self.config_entry.data[CONF_TIMEOUT],
             username=self.config_entry.data[CONF_USERNAME],
             websession=async_get_clientsession(hass, verify_ssl=False),

--- a/custom_components/plugwise/coordinator.py
+++ b/custom_components/plugwise/coordinator.py
@@ -101,7 +101,7 @@ class PlugwiseDataUpdateCoordinator(DataUpdateCoordinator[PlugwiseData]):
             raise ConfigEntryError("Authentication failed") from err
         except (InvalidXMLError, ResponseError) as err:
             raise UpdateFailed(
-                "Invalid XML data, or error indication received from the Plugwise Adam/Smile/Stretch"
+                f"Invalid XML data or error from Plugwise device: {err}"
             ) from err
         except PlugwiseError as err:
             raise UpdateFailed("Data incomplete or missing") from err


### PR DESCRIPTION
Falling back to defaults would not work for the Stretch and when a non-default port is used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new "Ongoing" section in the changelog for improved tracking of updates.

- **Bug Fixes**
	- Enhanced connection method for the coordinator to avoid using default settings, improving reliability.

- **Improvements**
	- Streamlined initialization of the Plugwise API by removing unused default constants.
	- Improved error handling during data fetching, providing clearer feedback on connection issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->