### PR TITLE
Fixing issue #776

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Versions from 0.40 and up
 
+## Ongoing
+
+- Bugfix for Issue #776
+
 ## v0.55.0
 
 - **BREAKING change for Adam**: the existing device-based climate entities will be replaced by new zone-based climate entities, most likely with a different name.

--- a/custom_components/plugwise/climate.py
+++ b/custom_components/plugwise/climate.py
@@ -257,7 +257,7 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity):
             ):
                 return cast(HVACAction, control_state)
         # Anna
-        else: 
+        else:
             heater: str = self._gateway["heater_id"]
             heater_data = self._devices[heater]
             if heater_data[BINARY_SENSORS][HEATING_STATE]:


### PR DESCRIPTION
The fix consist of returning `HVACAction.IDLE` when `controls_state` is not present in the Adam-data, and forcing different methods for Adam and Anna types of systems.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Implemented zone-based climate entities for the Adam integration, addressing Home Assistant Core Issue [130597].
	- Added provided zone sensors.
- **Bug Fixes**
	- Documented a fix for Issue #776.
- **Refactor**
	- Improved data encapsulation for gateway and device information in the climate control component, enhancing clarity and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->