### PR TITLE
Bump plugwise to v1.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Versions from 0.40 and up
 
+## v0.55.3
+
+- Bugfix for HA Core issue [#132479](https://github.com/home-assistant/core/issues/132479) via plugwise [v1.6.3](https://github.com/plugwise/python-plugwise/releases/tag/v1.6.3).
+
 ## v0.55.2
 
 - Link to plugwise [v1.6.2](https://github.com/plugwise/python-plugwise/releases/tag/v1.6.2), implementing Adam `control_state` related improvements.

--- a/custom_components/plugwise/manifest.json
+++ b/custom_components/plugwise/manifest.json
@@ -7,7 +7,7 @@
   "integration_type": "hub",
   "iot_class": "local_polling",
   "loggers": ["plugwise"],
-  "requirements": ["https://test-files.pythonhosted.org/packages/f0/98/e3a25304443aedcf8612ff5f26a57ad416d13c780549857a57df0c84b011/plugwise-1.6.3a0.tar.gz#plugwise==1.6.3a0"],
-  "version": "0.55.3a0",
+  "requirements": ["plugwise==1.6.3"],
+  "version": "0.55.3",
   "zeroconf": ["_plugwise._tcp.local."]
 }

--- a/custom_components/plugwise/manifest.json
+++ b/custom_components/plugwise/manifest.json
@@ -7,7 +7,7 @@
   "integration_type": "hub",
   "iot_class": "local_polling",
   "loggers": ["plugwise"],
-  "requirements": ["plugwise==1.6.2"],
-  "version": "0.55.2",
+  "requirements": ["https://test-files.pythonhosted.org/packages/f0/98/e3a25304443aedcf8612ff5f26a57ad416d13c780549857a57df0c84b011/plugwise-1.6.3a0.tar.gz#plugwise==1.6.3a0"],
+  "version": "0.55.3a0",
   "zeroconf": ["_plugwise._tcp.local."]
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plugwise-beta"
-version = "0.55.2"
+version = "0.55.3"
 description = "Plugwise beta custom-component"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
Trying to solve HA Core issue https://github.com/home-assistant/core/issues/132479

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated version to v0.55.3 in the changelog.
  
- **Bug Fixes**
	- Addressed HA Core issue #132479 through an update to the Plugwise library.

- **Documentation**
	- Changelog now includes detailed records of previous versions and updates.

- **Chores**
	- Incremented version number and updated package requirements in the manifest and project configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->