### PR TITLE
Alternative reconfigure-config_flow implementation

### DIFF
--- a/custom_components/plugwise/config_flow.py
+++ b/custom_components/plugwise/config_flow.py
@@ -80,7 +80,7 @@ SMILE_RECONF_SCHEMA = vol.Schema(
 )
 
 
-def SMILE_USER_SCHEMA(
+def smile_user_schema(
     cf_input: ZeroconfServiceInfo | dict[str, Any] | None,
 ) -> vol.Schema:
     """Generate base schema for gateways."""
@@ -140,7 +140,7 @@ async def verify_connection(
 async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> Smile:
     """Validate whether the user input allows us to connect to the gateway.
 
-    Data has the keys from SMILE_USER_SCHEMA() with values provided by the user.
+    Data has the keys from smile_user_schema() with values provided by the user.
     """
     websession = async_get_clientsession(hass, verify_ssl=False)
     api = Smile(
@@ -240,7 +240,7 @@ class PlugwiseConfigFlow(ConfigFlow, domain=DOMAIN):
         if not user_input:
             return self.async_show_form(
                 step_id=SOURCE_USER,
-                data_schema=SMILE_USER_SCHEMA(self.discovery_info),
+                data_schema=smile_user_schema(self.discovery_info),
                 errors=errors,
             )
 
@@ -250,10 +250,10 @@ class PlugwiseConfigFlow(ConfigFlow, domain=DOMAIN):
             user_input[CONF_USERNAME] = self._username
 
         api = await verify_connection(self.hass, user_input)
-        if isinstance(api, dict):  # api = error
+        if isinstance(api, dict):  # error returned
             return self.async_show_form(
                 step_id=SOURCE_USER,
-                data_schema=SMILE_USER_SCHEMA(user_input),
+                data_schema=smile_user_schema(user_input),
                 errors=api,
             )
 
@@ -291,7 +291,7 @@ class PlugwiseConfigFlow(ConfigFlow, domain=DOMAIN):
         }
 
         api = await verify_connection(self.hass, full_input)
-        if isinstance(api, dict):  # api = error
+        if isinstance(api, dict):  # error returned
             return self.async_show_form(
                 step_id="reconfigure",
                 data_schema=self.add_suggested_values_to_schema(

--- a/custom_components/plugwise/config_flow.py
+++ b/custom_components/plugwise/config_flow.py
@@ -119,7 +119,7 @@ async def verify_connection(
     errors: dict[str, str] = {}
 
     try:
-        api = await validate_input(hass, user_input)
+        return await validate_input(hass, user_input)
     except ConnectionFailedError:
         errors[CONF_BASE] = "cannot_connect"
     except InvalidAuthentication:
@@ -132,9 +132,6 @@ async def verify_connection(
         errors[CONF_BASE] = "unsupported"
     except Exception:  # noqa: BLE001
         errors[CONF_BASE] = "unknown"
-    else:
-        return api
-
     return errors
 
 

--- a/custom_components/plugwise/config_flow.py
+++ b/custom_components/plugwise/config_flow.py
@@ -184,7 +184,7 @@ class PlugwiseConfigFlow(ConfigFlow, domain=DOMAIN):
                         CONF_HOST: discovery_info.host,
                         CONF_PASSWORD: config_entry.data[CONF_PASSWORD],
                         CONF_PORT: discovery_info.port,
-                        CONF_USERNAME: self._username,
+                        CONF_USERNAME: config_entry.data[CONF_USERNAME],
                     },
                 )
             except Exception:  # noqa: BLE001

--- a/custom_components/plugwise/strings.json
+++ b/custom_components/plugwise/strings.json
@@ -18,6 +18,13 @@
   },
   "config": {
     "step": {
+      "reconfigure": {
+        "description": "Update configuration for {title}.",
+        "data": {
+          "host": "IP-address",
+          "port": "Port number"
+        }
+      },
       "user": {
         "title": "Set up Plugwise Adam/Smile/Stretch",
         "description": "Enter your Plugwise device: (setup can take up to 90s)",
@@ -42,7 +49,9 @@
     },
     "abort": {
       "already_configured": "This device is already configured",
-      "anna_with_adam": "Both Anna and Adam detected. Add your Adam instead of your Anna"
+      "anna_with_adam": "Both Anna and Adam detected. Add your Adam instead of your Anna",
+      "not_the_same_smile": "The configured Smile ID does not match the Smile ID on the requested IP address",
+      "reconfigure_successful": "Reconfiguration successful"
     }
   },
   "entity": {

--- a/custom_components/plugwise/translations/en.json
+++ b/custom_components/plugwise/translations/en.json
@@ -18,6 +18,13 @@
   },
   "config": {
     "step": {
+      "reconfigure": {
+        "description": "Update configuration for {title}.",
+        "data": {
+          "host": "IP-address",
+          "port": "Port number"
+        }
+      },
       "user": {
         "title": "Set up Plugwise Adam/Smile/Stretch",
         "description": "Enter your Plugwise device: (setup can take up to 90s)",
@@ -42,7 +49,9 @@
     },
     "abort": {
       "already_configured": "This device is already configured",
-      "anna_with_adam": "Both Anna and Adam detected. Add your Adam instead of your Anna"
+      "anna_with_adam": "Both Anna and Adam detected. Add your Adam instead of your Anna",
+      "not_the_same_smile": "The configured Smile ID does not match the Smile ID on the requested IP address",
+      "reconfigure_successful": "Reconfiguration successful"
     }
   },
   "entity": {

--- a/custom_components/plugwise/translations/nl.json
+++ b/custom_components/plugwise/translations/nl.json
@@ -18,7 +18,6 @@
   },
   "config": {
     "step": {
-      "user": {
       "reconfigure": {
         "description": "Pas configuratie aan voor {title}.",
         "data": {
@@ -26,6 +25,7 @@
           "port": "Poortnumber"
         }
       },
+      "user": {
         "title": "Installeer Plugwise Adam/Smile/Stretch",
         "description": "Van uw Plugwise apparaat voer in: (installeren kan tot 90s duren)",
         "data": {
@@ -49,7 +49,7 @@
     },
     "abort": {
       "already_configured": "Dit apparaat is al geconfigureerd",
-      "anna_with_adam": "Zowel Anna als Adam gedetecteerd. Voeg alleen de Adam toe, niet de Anna"
+      "anna_with_adam": "Zowel Anna als Adam gedetecteerd. Voeg alleen de Adam toe, niet de Anna",
       "not_the_same_smile": "Het ingegeven Smile ID past niet bij het Smile ID van het ingegeven IP adres",
       "reconfigure_successful": "Herconfiguratie is gelukt"
     }

--- a/custom_components/plugwise/translations/nl.json
+++ b/custom_components/plugwise/translations/nl.json
@@ -19,6 +19,13 @@
   "config": {
     "step": {
       "user": {
+      "reconfigure": {
+        "description": "Pas configuratie aan voor {title}.",
+        "data": {
+          "host": "IP-adres",
+          "port": "Poortnumber"
+        }
+      },
         "title": "Installeer Plugwise Adam/Smile/Stretch",
         "description": "Van uw Plugwise apparaat voer in: (installeren kan tot 90s duren)",
         "data": {
@@ -43,6 +50,8 @@
     "abort": {
       "already_configured": "Dit apparaat is al geconfigureerd",
       "anna_with_adam": "Zowel Anna als Adam gedetecteerd. Voeg alleen de Adam toe, niet de Anna"
+      "not_the_same_smile": "Het ingegeven Smile ID past niet bij het Smile ID van het ingegeven IP adres",
+      "reconfigure_successful": "Herconfiguratie is gelukt"
     }
   },
   "entity": {

--- a/tests/components/plugwise/conftest.py
+++ b/tests/components/plugwise/conftest.py
@@ -98,9 +98,15 @@ def mock_smile_adam() -> Generator[MagicMock]:
     """Create a Mock Adam type for testing."""
     chosen_env = "m_adam_multiple_devices_per_zone"
     all_data = _read_json(chosen_env, "all_data")
-    with patch(
-        "homeassistant.components.plugwise.coordinator.Smile", autospec=True
-    ) as smile_mock:
+    with (
+        patch(
+            "homeassistant.components.plugwise.coordinator.Smile", autospec=True
+        ) as smile_mock,
+        patch(
+            "homeassistant.components.plugwise.config_flow.Smile",
+            new=smile_mock,
+        ),
+    ):
         smile = smile_mock.return_value
 
         smile.async_update.return_value = PlugwiseData(

--- a/tests/components/plugwise/test_config_flow.py
+++ b/tests/components/plugwise/test_config_flow.py
@@ -43,7 +43,7 @@ TEST_HOSTNAME2 = "stretchabc"
 TEST_PASSWORD = "test_password"
 TEST_PORT = 81
 TEST_USERNAME = "smile"
-TEST_USERNAME2 = "stretch"
+TEST_USERNAME_STRETCH = "stretch"
 TEST_SMILE_HOST = "smile12345"
 TEST_DISCOVERY = zeroconf.ZeroconfServiceInfo(
     ip_address=TEST_HOST,
@@ -59,7 +59,7 @@ TEST_DISCOVERY = zeroconf.ZeroconfServiceInfo(
     },
     type="mock_type",
 )
-TEST_DISCOVERY2 = zeroconf.ZeroconfServiceInfo(
+TEST_DISCOVERY_STRETCH = zeroconf.ZeroconfServiceInfo(
     ip_address=TEST_HOST,
     ip_addresses=[TEST_HOST],
     hostname=f"{TEST_HOSTNAME2}.local.",
@@ -155,7 +155,7 @@ async def test_form(
     ("discovery", "username",),
     [
         (TEST_DISCOVERY, TEST_USERNAME),
-        (TEST_DISCOVERY2, TEST_USERNAME2),
+        (TEST_DISCOVERY_STRETCH, TEST_USERNAME_STRETCH),
     ],
 )
 async def test_zeroconf_form(
@@ -189,41 +189,6 @@ async def test_zeroconf_form(
         CONF_PASSWORD: TEST_PASSWORD,
         CONF_PORT: DEFAULT_PORT,
         CONF_USERNAME: username,
-    }
-
-    assert len(mock_setup_entry.mock_calls) == 1
-    assert len(mock_smile_config_flow.connect.mock_calls) == 1
-
-
-async def test_zeroconf_stretch_form(
-    hass: HomeAssistant,
-    mock_setup_entry: AsyncMock,
-    mock_smile_config_flow: MagicMock,
-) -> None:
-    """Test config flow for Stretch devices."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={CONF_SOURCE: SOURCE_ZEROCONF},
-        data=TEST_DISCOVERY2,
-    )
-    assert result.get("type") == FlowResultType.FORM
-    assert result.get("errors") == {}
-    assert result.get("step_id") == "user"
-    assert "flow_id" in result
-
-    result2 = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        user_input={CONF_PASSWORD: TEST_PASSWORD},
-    )
-    await hass.async_block_till_done()
-
-    assert result2.get("type") == FlowResultType.CREATE_ENTRY
-    assert result2.get("title") == "Test Smile Name"
-    assert result2.get("data") == {
-        CONF_HOST: TEST_HOST,
-        CONF_PASSWORD: TEST_PASSWORD,
-        CONF_PORT: DEFAULT_PORT,
-        CONF_USERNAME: TEST_USERNAME2,
     }
 
     assert len(mock_setup_entry.mock_calls) == 1

--- a/tests/components/plugwise/test_config_flow.py
+++ b/tests/components/plugwise/test_config_flow.py
@@ -20,7 +20,7 @@ from homeassistant.components.plugwise.const import (
     DOMAIN,
 )
 from homeassistant.components.zeroconf import ZeroconfServiceInfo
-from homeassistant.config_entries import SOURCE_USER, SOURCE_ZEROCONF
+from homeassistant.config_entries import SOURCE_USER, SOURCE_ZEROCONF, ConfigFlowResult
 from homeassistant.const import (
     CONF_HOST,
     CONF_NAME,
@@ -44,6 +44,7 @@ TEST_PASSWORD = "test_password"
 TEST_PORT = 81
 TEST_USERNAME = "smile"
 TEST_USERNAME2 = "stretch"
+TEST_SMILE_HOST = "smile12345"
 TEST_DISCOVERY = zeroconf.ZeroconfServiceInfo(
     ip_address=TEST_HOST,
     ip_addresses=[TEST_HOST],
@@ -458,3 +459,82 @@ async def test_options_flow_thermo(
             CONF_REFRESH_INTERVAL: 3.0,
             CONF_SCAN_INTERVAL: 60,
         }
+
+
+async def _start_reconfigure_flow(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    host_ip: str,
+) -> ConfigFlowResult:
+    """Initialize a reconfigure flow."""
+    mock_config_entry.add_to_hass(hass)
+
+    reconfigure_result = await mock_config_entry.start_reconfigure_flow(hass)
+
+    assert reconfigure_result["type"] is FlowResultType.FORM
+    assert reconfigure_result["step_id"] == "reconfigure"
+
+    return await hass.config_entries.flow.async_configure(
+        reconfigure_result["flow_id"], {CONF_HOST: host_ip}
+    )
+
+
+async def test_reconfigure_flow(
+    hass: HomeAssistant,
+    mock_smile_adam: AsyncMock,
+    mock_setup_entry: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test reconfigure flow."""
+    result = await _start_reconfigure_flow(hass, mock_config_entry, TEST_HOST)
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+
+    entry = hass.config_entries.async_get_entry(mock_config_entry.entry_id)
+    assert entry
+    assert entry.data.get(CONF_HOST) == TEST_HOST
+
+
+async def test_reconfigure_flow_other_smile(
+    hass: HomeAssistant,
+    mock_smile_adam: AsyncMock,
+    mock_setup_entry: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test reconfigure flow aborts on other Smile ID."""
+    mock_smile_adam.smile_hostname = TEST_SMILE_HOST
+
+    result = await _start_reconfigure_flow(hass, mock_config_entry, TEST_HOST)
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "not_the_same_smile"
+
+
+@pytest.mark.parametrize(
+    ("side_effect", "reason"),
+    [
+        (ConnectionFailedError, "cannot_connect"),
+        (InvalidAuthentication, "invalid_auth"),
+        (InvalidSetupError, "invalid_setup"),
+        (InvalidXMLError, "response_error"),
+        (RuntimeError, "unknown"),
+        (UnsupportedDeviceError, "unsupported"),
+    ],
+)
+async def test_reconfigure_flow_errors(
+    hass: HomeAssistant,
+    mock_smile_adam: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    side_effect: Exception,
+    reason: str,
+) -> None:
+    """Test we handle each reconfigure exception error."""
+
+    mock_smile_adam.connect.side_effect = side_effect
+
+    result = await _start_reconfigure_flow(hass, mock_config_entry, TEST_HOST)
+
+    assert result.get("type") is FlowResultType.FORM
+    assert result.get("errors") == {"base": reason}
+    assert result.get("step_id") == "reconfigure"


### PR DESCRIPTION
@CoMPaTech I've tried to add your Core `config_flow` updates into Plugwise-beta.

Looks like all is working: discovery works, shows only the password entry-field. Manually adding works, when a typo is made and an error is returned then the  entered data with the typo is shown. Reconfiguration works but when a different (wrong) IP-address is entered the existing IP-address is shown. I'll need to think some more if this should be different. Looks like the `add_suggested_values_to_schema()` function does this.

The fault-handling in all case looks to be functioning as intended.

Also, mypy-testing is a pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced a reconfiguration step for updating Plugwise device settings.
	- Added new error messages for improved user feedback during configuration, including "not_the_same_smile" and "reconfigure_successful".

- **Bug Fixes**
	- Enhanced error handling for connection verification and reconfiguration processes.

- **Tests**
	- Expanded test suite to include reconfiguration flow tests, ensuring proper functionality and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->