### PR TITLE
Add test-coverage for persistent_notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Versions from 0.40 and up
 ## Ongoing
 
 - Internal: Fixes for the CI process
+- Add test-coverage for persistent_notification-use in binary_sensor
 
 ## v0.55.5
 

--- a/custom_components/plugwise/binary_sensor.py
+++ b/custom_components/plugwise/binary_sensor.py
@@ -8,12 +8,14 @@ from typing import Any
 
 from plugwise.constants import BinarySensorType
 
+from homeassistant.components import (
+    persistent_notification,  # pw-beta Plugwise notifications
+)
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
     BinarySensorEntityDescription,
 )
-import homeassistant.components.persistent_notification as pn  # pw-beta Plugwise notifications
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -170,7 +172,7 @@ class PlugwiseBinarySensorEntity(PlugwiseEntity, BinarySensorEntity):
         # pw-beta: show Plugwise notifications as HA persistent notifications
         if self._notification:
             for notify_id, message in self._notification.items():
-                pn.async_create(
+                persistent_notification.async_create(
                     self.hass, message, "Plugwise Notification:", f"{DOMAIN}.{notify_id}"
                 )
 

--- a/tests/components/plugwise/test_binary_sensor.py
+++ b/tests/components/plugwise/test_binary_sensor.py
@@ -1,14 +1,16 @@
 """Tests for the Plugwise binary_sensor integration."""
 
-from unittest.mock import MagicMock
+from datetime import timedelta
+from unittest.mock import MagicMock, patch
 
+from freezegun.api import FrozenDateTimeFactory
 import pytest
 
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_component import async_update_entity
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, async_fire_time_changed
 
 
 @pytest.mark.parametrize("chosen_env", ["anna_heatpump_heating"], indirect=True)
@@ -69,7 +71,10 @@ async def test_adam_climate_binary_sensor_change(
 @pytest.mark.parametrize("chosen_env", ["p1v4_442_triple"], indirect=True)
 @pytest.mark.parametrize("gateway_id", ["03e65b16e4b247a29ae0d75a78cb492e"], indirect=True)
 async def test_p1_v4_binary_sensor_entity(
-    hass: HomeAssistant, mock_smile_p1: MagicMock, init_integration: MockConfigEntry
+    hass: HomeAssistant,
+    mock_smile_p1: MagicMock,
+    init_integration: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test of a Smile P1 related plugwise-notification binary_sensor."""
     state = hass.states.get("binary_sensor.smile_p1_plugwise_notification")
@@ -77,3 +82,12 @@ async def test_p1_v4_binary_sensor_entity(
     assert state.state == STATE_ON
     assert "warning_msg" in state.attributes
     assert "connected" in state.attributes["warning_msg"][0]
+
+    with patch(
+        "homeassistant.components.plugwise.binary_sensor.persistent_notification"
+    ) as persistent_notification_mock:
+        freezer.tick(timedelta(minutes=1))
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+
+        persistent_notification_mock.async_create.assert_called()

--- a/tests/components/plugwise/test_binary_sensor.py
+++ b/tests/components/plugwise/test_binary_sensor.py
@@ -3,9 +3,9 @@
 from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
-from freezegun.api import FrozenDateTimeFactory
 import pytest
 
+from freezegun.api import FrozenDateTimeFactory
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_component import async_update_entity


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced notification handling for the Plugwise binary sensor integration.
	- Improved clarity of notifications presented to users based on severity.

- **Bug Fixes**
	- Updates to the test suite for better verification of notification behavior and time-dependent scenarios.

- **Documentation**
	- Added a new entry in the CHANGELOG noting the addition of test coverage for persistent notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->