### PR TITLE
Restore config_flow functionality showing provided user_input after error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Versions from 0.40 and up
 
 - Internal: Fixes for the CI process
 - Add test-coverage for persistent_notification-use in binary_sensor
+- Config_flow: restore showing provided user_input when an error occurs
 
 ## v0.55.5
 

--- a/custom_components/plugwise/config_flow.py
+++ b/custom_components/plugwise/config_flow.py
@@ -252,11 +252,13 @@ class PlugwiseConfigFlow(ConfigFlow, domain=DOMAIN):
                 self._abort_if_unique_id_configured()
                 return self.async_create_entry(title=api.smile_name, data=user_input)
 
+        configure_input = self.discovery_info or user_input
         return self.async_show_form(
             step_id=SOURCE_USER,
-            data_schema=smile_user_schema(self.discovery_info),
+            data_schema=smile_user_schema(configure_input),
             errors=errors,
         )
+
 
     async def async_step_reconfigure(
         self, user_input: dict[str, Any] | None = None


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced configuration flow to restore user input display during errors, improving user feedback and troubleshooting.
  
- **Bug Fixes**
	- Improved handling of user input and discovery information in the configuration flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->