### PR TITLE
Follow Core PR 135653 for 2025.2.0 (moving ZeroconfServiceInfo)

### DIFF
--- a/.github/workflows/hassfest.yaml
+++ b/.github/workflows/hassfest.yaml
@@ -1,8 +1,8 @@
 name: Validate with hassfest
 
+# Removed push not to duplicate
 on:
   workflow_dispatch:
-  push:
   pull_request:
   schedule:
     - cron: "0 0 * * *"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,10 @@
 # This workflow will install Python dependencies, run tests and lint with a variety of Python versions
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Test PRs against HA-core
+name: Test PR against HA-core
 
 env:
-  CACHE_VERSION: 29
+  CACHE_VERSION: 30
   DEFAULT_PYTHON: "3.13"
 
 # Do not run on 'push' (as the flow doesn't have access to the labels) - also disabled workflow_dispatch as such
@@ -124,10 +124,10 @@ jobs:
           GITHUB_ACTIONS="" scripts/core-testing.sh
           if [ $? -ne 0 ]; then
             echo "::warning::Release HA core incompatibility"
-            echo "failed=true" >> $GITHUB_OUTPUT
+            echo "failed=true" >> "$GITHUB_OUTPUT"
           else
             echo "Successfully tested against released HA-core"
-            echo "failed=false" >> $GITHUB_OUTPUT
+            echo "failed=false" >> "$GITHUB_OUTPUT"
           fi
 
   ha-core-dev:
@@ -178,10 +178,10 @@ jobs:
           GITHUB_ACTIONS="" BRANCH="dev" scripts/core-testing.sh
           if [ $? -ne 0 ]; then
             echo "::warning::Development HA core incompatibility"
-            echo "failed=true" >> $GITHUB_OUTPUT
+            echo "failed=true" >> "$GITHUB_OUTPUT"
           else
             echo "Successfully tested against dev HA-core"
-            echo "failed=false" >> $GITHUB_OUTPUT
+            echo "failed=false" >> "$GITHUB_OUTPUT"
           fi
 
   final-comment:
@@ -238,6 +238,8 @@ jobs:
           echo "COMMENT_BODY = ${COMMENT_BODY}"
           echo "DEV_TESTS_FAILED = ${DEV_TESTS_FAILED}"
           echo "RELEASE_TESTS_FAILED = ${RELEASE_TESTS_FAILED}"
+          echo "DEV_TESTS_FAILED=${{ needs.ha-core-dev.outputs.dev_failed }}"
+          echo "RELEASE_TESTS_FAILED=${{ needs.ha-core-release.outputs.release_failed }}"
 
           if [[ $FAIL_COUNT -eq 1 ]]; then
             echo "Creating a comment on the pull request"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,6 +79,7 @@ jobs:
   ha-core-release:
     runs-on: ubuntu-latest
     name: Setup for HA-core (release/master)
+    continue-on-error: true
     needs:
       - pre-commit
     outputs:
@@ -132,6 +133,7 @@ jobs:
   ha-core-dev:
     runs-on: ubuntu-latest
     name: Setup for HA-core (dev)
+    continue-on-error: true
     needs:
       - pre-commit
     outputs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -121,14 +121,14 @@ jobs:
         id: ha_core_release_tests
         continue-on-error: ${{ env.STRICT_DEV == 'true' }} # Allow master failures only if dev is strict
         run: |
-          echo "failed=true" > result.txt
+          echo "true" > result.txt
           GITHUB_ACTIONS="" scripts/core-testing.sh
           if [ $? -ne 0 ]; then
             echo "::warning::Release  HA core incompatibility"
-            echo "failed=true" > result.txt
+            echo "true" > result.txt
           else
             echo "Successfully tested against released HA-core"
-            echo "failed=false" > result.txt
+            echo "false" > result.txt
           fi
       - name: Set output explicitly
         id: capture_release
@@ -183,14 +183,14 @@ jobs:
         id: ha_core_dev_tests
         continue-on-error: ${{ env.STRICT_DEV == 'false' }} # Allow dev failures unless strict
         run: |
-          echo "failed=true" > result.txt
+          echo "true" > result.txt
           GITHUB_ACTIONS="" BRANCH="dev" scripts/core-testing.sh
           if [ $? -ne 0 ]; then
             echo "::warning::Development HA core incompatibility"
-            echo "failed=true" > result.txt
+            echo "true" > result.txt
           else
             echo "Successfully tested against dev HA-core"
-            echo "failed=false" > result.txt
+            echo "false" > result.txt
           fi
       - name: Set output explicitly
         id: capture_dev

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -249,11 +249,11 @@ jobs:
           fi
 
           if [[ $FAIL_COUNT -eq 1 ]]; then
-            echo "Creating a comment on the pull request"
+            echo "Comment and approve the pull request"
             curl -s -X POST \
             -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
             -H "Content-Type: application/json" \
-            --data "{\"body\": \"$COMMENT_BODY\"}" \
+            --data "{\"event\": \"APPROVE\", \"body\": \"$COMMENT_BODY\"}" \
             "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments"
           fi
           if [[ $FAIL_COUNT -eq 2 ]]; then

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,7 +117,7 @@ jobs:
             ${{ env.CACHE_VERSION}}-${{ runner.os }}
             ${{ env.CACHE_VERSION}}
       - name: Test through HA-core (master/release) - continue-on-error = ${{ env.STRICT_DEV == 'true' }}
-        id: ha-core-tests
+        id: ha_core_tests
         continue-on-error: ${{ env.STRICT_DEV == 'true' }} # Allow master failures only if dev is strict
         run: |
           GITHUB_ACTIONS="" scripts/core-testing.sh
@@ -170,7 +170,7 @@ jobs:
             ${{ env.CACHE_VERSION}}-${{ runner.os }}
             ${{ env.CACHE_VERSION}}
       - name: Test through HA-core (dev) - continue-on-error = ${{ env.STRICT_DEV == 'false' }}
-        id: ha-core-tests
+        id: ha_core_tests
         continue-on-error: ${{ env.STRICT_DEV == 'false' }} # Allow dev failures unless strict
         run: |
           GITHUB_ACTIONS="" BRANCH="dev" scripts/core-testing.sh
@@ -231,7 +231,7 @@ jobs:
             COMMENT_BODY+="**Success:** No problem with testing against released HA-core.\n"
           fi
 
-          if [[ FAIL_COUNT == 1 ]]; then
+          if [[ FAIL_COUNT -eq 1 ]]; then
             # Create a comment on the pull request
             curl -s -X POST \
             -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
@@ -239,11 +239,11 @@ jobs:
             --data "{\"body\": \"$COMMENT_BODY\"}" \
             "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments"
           fi
-          if [[ FAIL_COUNT == 2 ]]; then
+          if [[ FAIL_COUNT -eq 2 ]]; then
             # Request changes on the pull request
             curl -s -X POST \
             -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
             -H "Content-Type: application/json" \
-            --data ""{\"event\": \"REQUEST_ACTIONS\", \"body\": \"$COMMENT_BODY\"}" \
+            --data "{\"event\": \"REQUEST_ACTIONS\", \"body\": \"$COMMENT_BODY\"}" \
             "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments"
           fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -254,7 +254,7 @@ jobs:
             -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
             -H "Content-Type: application/json" \
             --data "{\"event\": \"APPROVE\", \"body\": \"$COMMENT_BODY\"}" \
-            "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments"
+            "https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews"
           fi
           if [[ $FAIL_COUNT -eq 2 ]]; then
             echo "Requesting changes on the pull request"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,14 +58,22 @@ jobs:
           SKIP: local-test-core-prep,local-test-pip-prep,local-testing,local-quality
 
   # Prepare default python version environment
-  ha-core-prepare:
+  ha-core-release:
     runs-on: ubuntu-latest
-    name: Setup for HA-core (release)
+    name: Setup for HA-core (release/master)
     needs:
       - pre-commit
     steps:
       - name: Check out committed code
         uses: actions/checkout@v4.2.2
+      - name: Determine Branch Test Mode
+        id: determine_mode
+        run: |
+          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'require-dev-pass') }}" == "true" ]]; then
+            echo "STRICT_DEV=true" >> $GITHUB_ENV
+          else
+            echo "STRICT_DEV=false" >> $GITHUB_ENV
+          fi
       - name: Set up Python ${{ env.DEFAULT_PYTHON }}
         id: python
         uses: actions/setup-python@v5.4.0
@@ -75,7 +83,7 @@ jobs:
         id: cache-hacore
         uses: actions/cache@v4.2.0
         env:
-          cache-name: cache-hacore
+          cache-name: cache-hacore-release
         with:
           path: ./
           key: >-
@@ -89,8 +97,52 @@ jobs:
             ${{ env.CACHE_VERSION}}-${{ runner.os }}
             ${{ env.CACHE_VERSION}}
       - name: Test through HA-core (master/release)
+        continue-on-error: ${{ env.STRICT_DEV == 'true' }} # Allow master failures only if dev is strict
         run: |
-          GITHUB_ACTIONS="" BRANCH="master" scripts/core-testing.sh
+          GITHUB_ACTIONS="" scripts/core-testing.sh
+
+  ha-core-dev:
+    runs-on: ubuntu-latest
+    name: Setup for HA-core (dev)
+    needs:
+      - pre-commit
+    steps:
+      - name: Check out committed code
+        uses: actions/checkout@v4.2.2
+      - name: Determine Branch Test Mode
+        id: determine_mode
+        run: |
+          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'require-dev-pass') }}" == "true" ]]; then
+            echo "STRICT_DEV=true" >> $GITHUB_ENV
+          else
+            echo "STRICT_DEV=false" >> $GITHUB_ENV
+          fi
+      - name: Set up Python ${{ env.DEFAULT_PYTHON }}
+        id: python
+        uses: actions/setup-python@v5.4.0
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON }}
+      - name: Restore base HA-core Python ${{ env.DEFAULT_PYTHON }} environment
+        id: cache-hacore
+        uses: actions/cache@v4.2.0
+        env:
+          cache-name: cache-hacore-dev
+        with:
+          path: ./
+          key: >-
+            ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-hacore-${{
+            steps.python.outputs.python-version }}-${{
+            hashFiles('./custom_components/plugwise/manifest.json') }}-${{
+            hashFiles('./ha-core/.git/plugwise-tracking') }}
+          restore-keys: |
+            ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-hacore-${{ steps.python.outputs.python-version }}-
+            ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-hacore
+            ${{ env.CACHE_VERSION}}-${{ runner.os }}
+            ${{ env.CACHE_VERSION}}
+      - name: Test through HA-core (dev)
+        continue-on-error: ${{ env.STRICT_DEV == 'false' }} # Allow dev failures unless strict
+        run: |
+          GITHUB_ACTIONS="" BRANCH="dev" scripts/core-testing.sh
 
   shellcheck:
     name: Shellcheck

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,7 +83,7 @@ jobs:
     needs:
       - pre-commit
     outputs:
-      release_failed: ${{ steps.ha_core_release_tests.outputs.failed }}
+      release_failed: ${{ steps.capture_release.outputs.failed }}
     steps:
       - name: Check out committed code
         uses: actions/checkout@v4.2.2
@@ -131,10 +131,11 @@ jobs:
             echo "failed=false" > result.txt
           fi
       - name: Set output explicitly
+        id: capture_release
         if: always()
         run: |
           FAILED=$(cat result.txt)
-          echo "dev_failed=$FAILED" >> "$GITHUB_ENV"  # Set as environment variable
+          echo "dev_failed=$FAILED" >> "$GITHUB_OUTPUT"
           echo "Failed release status: $FAILED"  # Print out for debugging
 
   ha-core-dev:
@@ -144,7 +145,7 @@ jobs:
     needs:
       - pre-commit
     outputs:
-      dev_failed: ${{ steps.ha_core_dev_tests.outputs.failed }}
+      dev_failed: ${{ steps.capture_dev.outputs.failed }}
     steps:
       - name: Check out committed code
         uses: actions/checkout@v4.2.2
@@ -192,10 +193,11 @@ jobs:
             echo "failed=false" > result.txt
           fi
       - name: Set output explicitly
+        id: capture_dev
         if: always()
         run: |
           FAILED=$(cat result.txt)
-          echo "dev_failed=$FAILED" >> "$GITHUB_ENV"  # Set as environment variable
+          echo "dev_failed=$FAILED" >> "$GITHUB_OUTPUT"
           echo "Failed dev status: $FAILED"  # Print out for debugging
 
   final-comment:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -129,6 +129,10 @@ jobs:
             echo "Successfully tested against released HA-core"
             echo "failed=false" >> "$GITHUB_OUTPUT"
           fi
+      - name: Set output explicitly
+        if: always()
+        run: |
+          echo "release_failed=${{ steps.ha_core_release_tests.outputs.failed }}" >> "$GITHUB_ENV"
 
   ha-core-dev:
     runs-on: ubuntu-latest
@@ -183,6 +187,10 @@ jobs:
             echo "Successfully tested against dev HA-core"
             echo "failed=false" >> "$GITHUB_OUTPUT"
           fi
+      - name: Set output explicitly
+        if: always()
+        run: |
+          echo "release_failed=${{ steps.ha_core_dev_tests.outputs.failed }}" >> "$GITHUB_ENV"
 
   final-comment:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -124,10 +124,10 @@ jobs:
           GITHUB_ACTIONS="" scripts/core-testing.sh
           if [ $? -ne 0 ]; then
             echo "::warning::Release HA core incompatibility"
-            echo "RELEASE_TESTS_FAILED=true" >> $GITHUB_ENV
+            echo "RELEASE_TESTS_FAILED=true" >> $GITHUB_OUTPUT
           else
             echo "Successfully tested against released HA-core"
-            echo "RELEASE_TESTS_FAILED=false" >> $GITHUB_ENV
+            echo "RELEASE_TESTS_FAILED=false" >> $GITHUB_OUTPUT
           fi
 
   ha-core-dev:
@@ -178,10 +178,10 @@ jobs:
           GITHUB_ACTIONS="" BRANCH="dev" scripts/core-testing.sh
           if [ $? -ne 0 ]; then
             echo "::warning::Development HA core incompatibility"
-            echo "DEV_TESTS_FAILED=true" >> $GITHUB_ENV
+            echo "DEV_TESTS_FAILED=true" >> $GITHUB_OUTPUT
           else
             echo "Successfully tested against dev HA-core"
-            echo "DEV_TESTS_FAILED=false" >> $GITHUB_ENV
+            echo "DEV_TESTS_FAILED=false" >> $GITHUB_OUTPUT
           fi
 
   final-comment:
@@ -200,13 +200,14 @@ jobs:
         run: |
           # Get the results of the previous scripts
           STRICT_DEV=$STRICT_DEV
-          DEV_TESTS_FAILED=$DEV_TESTS_FAILED
-          RELEASE_TESTS_FAILED=$RELEASE_TESTS_FAILED
+          DEV_TESTS_FAILED=${{ needs.ha-core-dev.outputs.dev_failed }}
+          RELEASE_TESTS_FAILED=${{ needs.ha-core-release.outputs.release_failed }}
           FAIL_COUNT=0
 
-          COMMENT_BODY="**Error while testing for RELEASED HA-core:**\n"
           if [[ $DEV_TESTS_FAILED == "true" ]]; then
-            COMMENT_BODY="**Error while testing for Development HA-core:**\n"
+            COMMENT_BODY="**Error while testing for Development HA-core:**\n\n"
+          else
+            COMMENT_BODY="**Error while testing for RELEASED HA-core:**\n\n"
           fi
 
           if [[ $DEV_TESTS_FAILED == "true" ]]; then

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,7 @@ on:
       - opened
       - synchronize
       - labeled
+      - unlabeled
 
 jobs:
   # Run pre-commit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -122,7 +122,8 @@ jobs:
         continue-on-error: ${{ env.STRICT_DEV == 'true' }} # Allow master failures only if dev is strict
         run: |
           echo "true" > result.txt
-          GITHUB_ACTIONS="" scripts/core-testing.sh
+          #GITHUB_ACTIONS="" scripts/core-testing.sh
+          $(exit 1)
           if [ $? -ne 0 ]; then
             echo "::warning::Release  HA core incompatibility"
             echo "true" > result.txt
@@ -184,7 +185,8 @@ jobs:
         continue-on-error: ${{ env.STRICT_DEV == 'false' }} # Allow dev failures unless strict
         run: |
           echo "true" > result.txt
-          GITHUB_ACTIONS="" BRANCH="dev" scripts/core-testing.sh
+          #GITHUB_ACTIONS="" BRANCH="dev" scripts/core-testing.sh
+          $(exit 0)
           if [ $? -ne 0 ]; then
             echo "::warning::Development HA core incompatibility"
             echo "true" > result.txt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,19 +61,19 @@ jobs:
             ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-hacore
             ${{ env.CACHE_VERSION}}-${{ runner.os }}
             ${{ env.CACHE_VERSION}}
-#      - name: Set-up environment
-#        run: |
-#          scripts/setup.sh
-#      - name: Install pre-commit dependencies
-#        run: |
-#          . venv/bin/activate
-#          pre-commit install-hooks
-#      - name: Run all-files pre-commit excluding testing
-#        run: |
-#          . venv/bin/activate
-#          pre-commit run --all-files --show-diff-on-failure
-#        env: # While not problematic, save time on performing the local hooks as they are run from the complete script in the next job
-#          SKIP: local-test-core-prep,local-test-pip-prep,local-testing,local-quality
+      - name: Set-up environment
+        run: |
+          scripts/setup.sh
+      - name: Install pre-commit dependencies
+        run: |
+          . venv/bin/activate
+          pre-commit install-hooks
+      - name: Run all-files pre-commit excluding testing
+        run: |
+          . venv/bin/activate
+          pre-commit run --all-files --show-diff-on-failure
+        env: # While not problematic, save time on performing the local hooks as they are run from the complete script in the next job
+          SKIP: local-test-core-prep,local-test-pip-prep,local-testing,local-quality
 
   # Prepare default python version environment
   ha-core-release:
@@ -122,8 +122,7 @@ jobs:
         continue-on-error: ${{ env.STRICT_DEV == 'true' }} # Allow master failures only if dev is strict
         run: |
           echo "true" > result.txt
-          #GITHUB_ACTIONS="" scripts/core-testing.sh
-          $(exit 0)
+          GITHUB_ACTIONS="" scripts/core-testing.sh
           if [ $? -ne 0 ]; then
             echo "::warning::Release  HA core incompatibility"
             echo "true" > result.txt
@@ -137,7 +136,6 @@ jobs:
         run: |
           FAILED=$(cat result.txt)
           echo "failed=$FAILED" >> "$GITHUB_OUTPUT"
-          echo "Failed release status: $FAILED"  # Print out for debugging
 
   ha-core-dev:
     runs-on: ubuntu-latest
@@ -185,8 +183,7 @@ jobs:
         continue-on-error: ${{ env.STRICT_DEV == 'false' }} # Allow dev failures unless strict
         run: |
           echo "true" > result.txt
-          #GITHUB_ACTIONS="" BRANCH="dev" scripts/core-testing.sh
-          $(exit 1)
+          GITHUB_ACTIONS="" BRANCH="dev" scripts/core-testing.sh
           if [ $? -ne 0 ]; then
             echo "::warning::Development HA core incompatibility"
             echo "true" > result.txt
@@ -200,7 +197,6 @@ jobs:
         run: |
           FAILED=$(cat result.txt)
           echo "failed=$FAILED" >> "$GITHUB_OUTPUT"
-          echo "Failed dev status: $FAILED"  # Print out for debugging
 
   final-comment:
     runs-on: ubuntu-latest
@@ -223,41 +219,34 @@ jobs:
           FAIL_COUNT=0
 
           if [[ $DEV_TESTS_FAILED == "true" ]]; then
-            COMMENT_BODY="**Error while testing for Development HA-core:**\n\n"
+            COMMENT_BODY=":x: **Error while testing for Development HA-core:**\n\n"
           else
-            COMMENT_BODY="**Error while testing for RELEASED HA-core:**\n\n"
+            COMMENT_BODY=":warning: **Warning while testing for RELEASED HA-core:**\n\n"
           fi
 
           if [[ $DEV_TESTS_FAILED == "true" ]]; then
             if [[ $STRICT_DEV == "true" ]]; then
-              COMMENT_BODY+="**Error:** Incompatible while testing against dev HA-core and required to pass.\n"
+              COMMENT_BODY+=":x: **Error:** Incompatible while testing against dev HA-core and required to pass.\n"
               FAIL_COUNT=2
             else
-              COMMENT_BODY+="**Warning:** Incompatible while testing against dev HA-core.\n"
+              COMMENT_BODY+=":warning: **Warning:** Incompatible while testing against dev HA-core.\n"
               FAIL_COUNT=1
             fi
           else
-            COMMENT_BODY+="**Success:** No problem with testing against dev HA-core.\n"
+            COMMENT_BODY+=":heavy_check_mark: **Success:** No problem with testing against dev HA-core.\n"
           fi
 
           if [[ $RELEASE_TESTS_FAILED == "true" ]]; then
             if [[ $STRICT_DEV == "false" ]]; then
-              COMMENT_BODY+="**Error:** Incompatible while testing against released HA-core and required to pass.\n"
+              COMMENT_BODY+=":x: **Error:** Incompatible while testing against released HA-core and required to pass.\n"
               FAIL_COUNT=2
             else
-              COMMENT_BODY+="**Warning:** Incompatible while testing against released HA-core.\n"
+              COMMENT_BODY+=":warning: **Warning:** Incompatible while testing against released HA-core.\n"
               FAIL_COUNT=1
             fi
           else
-            COMMENT_BODY+="**Success:** No problem with testing against released HA-core.\n"
+            COMMENT_BODY+=":heavy_check_mark: **Success:** No problem with testing against released HA-core.\n"
           fi
-
-          echo "FAIL_COUNT = ${FAIL_COUNT}"
-          echo "COMMENT_BODY = ${COMMENT_BODY}"
-          echo "DEV_TESTS_FAILED = ${DEV_TESTS_FAILED}"
-          echo "RELEASE_TESTS_FAILED = ${RELEASE_TESTS_FAILED}"
-          echo "DEV_TESTS_FAILED=${{ needs.ha-core-dev.outputs.dev_failed }}"
-          echo "RELEASE_TESTS_FAILED=${{ needs.ha-core-release.outputs.release_failed }}"
 
           if [[ $FAIL_COUNT -eq 1 ]]; then
             echo "Creating a comment on the pull request"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -124,10 +124,10 @@ jobs:
           GITHUB_ACTIONS="" scripts/core-testing.sh
           if [ $? -ne 0 ]; then
             echo "::warning::Release HA core incompatibility"
-            echo "RELEASE_TESTS_FAILED=true" >> $GITHUB_OUTPUT
+            echo "failed=true" >> $GITHUB_OUTPUT
           else
             echo "Successfully tested against released HA-core"
-            echo "RELEASE_TESTS_FAILED=false" >> $GITHUB_OUTPUT
+            echo "failed=false" >> $GITHUB_OUTPUT
           fi
 
   ha-core-dev:
@@ -178,10 +178,10 @@ jobs:
           GITHUB_ACTIONS="" BRANCH="dev" scripts/core-testing.sh
           if [ $? -ne 0 ]; then
             echo "::warning::Development HA core incompatibility"
-            echo "DEV_TESTS_FAILED=true" >> $GITHUB_OUTPUT
+            echo "failed=true" >> $GITHUB_OUTPUT
           else
             echo "Successfully tested against dev HA-core"
-            echo "DEV_TESTS_FAILED=false" >> $GITHUB_OUTPUT
+            echo "failed=false" >> $GITHUB_OUTPUT
           fi
 
   final-comment:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,7 +123,7 @@ jobs:
         run: |
           echo "true" > result.txt
           #GITHUB_ACTIONS="" scripts/core-testing.sh
-          $(exit 1)
+          $(exit 0)
           if [ $? -ne 0 ]; then
             echo "::warning::Release  HA core incompatibility"
             echo "true" > result.txt
@@ -186,7 +186,7 @@ jobs:
         run: |
           echo "true" > result.txt
           #GITHUB_ACTIONS="" BRANCH="dev" scripts/core-testing.sh
-          $(exit 0)
+          $(exit 1)
           if [ $? -ne 0 ]; then
             echo "::warning::Development HA core incompatibility"
             echo "true" > result.txt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,7 +96,7 @@ jobs:
             ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-hacore
             ${{ env.CACHE_VERSION}}-${{ runner.os }}
             ${{ env.CACHE_VERSION}}
-      - name: Test through HA-core (master/release)
+      - name: Test through HA-core (master/release) - continue-on-error = ${{ env.STRICT_DEV == 'true' }}
         continue-on-error: ${{ env.STRICT_DEV == 'true' }} # Allow master failures only if dev is strict
         run: |
           GITHUB_ACTIONS="" scripts/core-testing.sh
@@ -139,7 +139,7 @@ jobs:
             ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-hacore
             ${{ env.CACHE_VERSION}}-${{ runner.os }}
             ${{ env.CACHE_VERSION}}
-      - name: Test through HA-core (dev)
+      - name: Test through HA-core (dev) - continue-on-error = ${{ env.STRICT_DEV == 'false' }}
         continue-on-error: ${{ env.STRICT_DEV == 'false' }} # Allow dev failures unless strict
         run: |
           GITHUB_ACTIONS="" BRANCH="dev" scripts/core-testing.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,22 +117,25 @@ jobs:
             ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-hacore
             ${{ env.CACHE_VERSION}}-${{ runner.os }}
             ${{ env.CACHE_VERSION}}
-      - name: Test through HA-core (master/release) - continue-on-error = ${{ env.STRICT_DEV == 'true' }}
+      - name: Test through HA-core (master/release) - continue-on-error = ${{ env.STRICT_DEV == 'false' }}
         id: ha_core_release_tests
         continue-on-error: ${{ env.STRICT_DEV == 'true' }} # Allow master failures only if dev is strict
         run: |
+          echo "failed=true" > result.txt
           GITHUB_ACTIONS="" scripts/core-testing.sh
           if [ $? -ne 0 ]; then
-            echo "::warning::Release HA core incompatibility"
-            echo "failed=true" >> "$GITHUB_OUTPUT"
+            echo "::warning::Release  HA core incompatibility"
+            echo "failed=true" > result.txt
           else
             echo "Successfully tested against released HA-core"
-            echo "failed=false" >> "$GITHUB_OUTPUT"
+            echo "failed=false" > result.txt
           fi
       - name: Set output explicitly
         if: always()
         run: |
-          echo "release_failed=${{ steps.ha_core_release_tests.outputs.failed }}" >> "$GITHUB_ENV"
+          FAILED=$(cat result.txt)
+          echo "dev_failed=$FAILED" >> "$GITHUB_ENV"  # Set as environment variable
+          echo "Failed release status: $FAILED"  # Print out for debugging
 
   ha-core-dev:
     runs-on: ubuntu-latest
@@ -179,18 +182,21 @@ jobs:
         id: ha_core_dev_tests
         continue-on-error: ${{ env.STRICT_DEV == 'false' }} # Allow dev failures unless strict
         run: |
+          echo "failed=true" > result.txt
           GITHUB_ACTIONS="" BRANCH="dev" scripts/core-testing.sh
           if [ $? -ne 0 ]; then
             echo "::warning::Development HA core incompatibility"
-            echo "failed=true" >> "$GITHUB_OUTPUT"
+            echo "failed=true" > result.txt
           else
             echo "Successfully tested against dev HA-core"
-            echo "failed=false" >> "$GITHUB_OUTPUT"
+            echo "failed=false" > result.txt
           fi
       - name: Set output explicitly
         if: always()
         run: |
-          echo "release_failed=${{ steps.ha_core_dev_tests.outputs.failed }}" >> "$GITHUB_ENV"
+          FAILED=$(cat result.txt)
+          echo "dev_failed=$FAILED" >> "$GITHUB_ENV"  # Set as environment variable
+          echo "Failed dev status: $FAILED"  # Print out for debugging
 
   final-comment:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,7 +83,7 @@ jobs:
     needs:
       - pre-commit
     outputs:
-      release_failed: ${{ steps.ha_core_tests.outputs.failed }}
+      release_failed: ${{ steps.ha_core_release_tests.outputs.failed }}
     steps:
       - name: Check out committed code
         uses: actions/checkout@v4.2.2
@@ -118,7 +118,7 @@ jobs:
             ${{ env.CACHE_VERSION}}-${{ runner.os }}
             ${{ env.CACHE_VERSION}}
       - name: Test through HA-core (master/release) - continue-on-error = ${{ env.STRICT_DEV == 'true' }}
-        id: ha_core_tests
+        id: ha_core_release_tests
         continue-on-error: ${{ env.STRICT_DEV == 'true' }} # Allow master failures only if dev is strict
         run: |
           GITHUB_ACTIONS="" scripts/core-testing.sh
@@ -137,7 +137,7 @@ jobs:
     needs:
       - pre-commit
     outputs:
-      dev_failed: ${{ steps.ha_core_tests.outputs.failed }}
+      dev_failed: ${{ steps.ha_core_dev_tests.outputs.failed }}
     steps:
       - name: Check out committed code
         uses: actions/checkout@v4.2.2
@@ -172,7 +172,7 @@ jobs:
             ${{ env.CACHE_VERSION}}-${{ runner.os }}
             ${{ env.CACHE_VERSION}}
       - name: Test through HA-core (dev) - continue-on-error = ${{ env.STRICT_DEV == 'false' }}
-        id: ha_core_tests
+        id: ha_core_dev_tests
         continue-on-error: ${{ env.STRICT_DEV == 'false' }} # Allow dev failures unless strict
         run: |
           GITHUB_ACTIONS="" BRANCH="dev" scripts/core-testing.sh
@@ -233,19 +233,24 @@ jobs:
             COMMENT_BODY+="**Success:** No problem with testing against released HA-core.\n"
           fi
 
-          if [[ FAIL_COUNT -eq 1 ]]; then
-            # Create a comment on the pull request
+          echo "FAIL_COUNT = ${FAIL_COUNT}"
+          echo "COMMENT_BODY = ${COMMENT_BODY}"
+          echo "DEV_TESTS_FAILED = ${DEV_TESTS_FAILED}"
+          echo "RELEASE_TESTS_FAILED = ${RELEASE_TESTS_FAILED}"
+
+          if [[ $FAIL_COUNT -eq 1 ]]; then
+            echo "Creating a comment on the pull request"
             curl -s -X POST \
             -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
             -H "Content-Type: application/json" \
             --data "{\"body\": \"$COMMENT_BODY\"}" \
             "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments"
           fi
-          if [[ FAIL_COUNT -eq 2 ]]; then
-            # Request changes on the pull request
+          if [[ $FAIL_COUNT -eq 2 ]]; then
+            echo "Requesting changes on the pull request"
             curl -s -X POST \
             -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
             -H "Content-Type: application/json" \
             --data "{\"event\": \"REQUEST_ACTIONS\", \"body\": \"$COMMENT_BODY\"}" \
-            "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments"
+            "https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews"
           fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -135,7 +135,7 @@ jobs:
         if: always()
         run: |
           FAILED=$(cat result.txt)
-          echo "dev_failed=$FAILED" >> "$GITHUB_OUTPUT"
+          echo "failed=$FAILED" >> "$GITHUB_OUTPUT"
           echo "Failed release status: $FAILED"  # Print out for debugging
 
   ha-core-dev:
@@ -197,7 +197,7 @@ jobs:
         if: always()
         run: |
           FAILED=$(cat result.txt)
-          echo "dev_failed=$FAILED" >> "$GITHUB_OUTPUT"
+          echo "failed=$FAILED" >> "$GITHUB_OUTPUT"
           echo "Failed dev status: $FAILED"  # Print out for debugging
 
   final-comment:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,16 +1,26 @@
 # This workflow will install Python dependencies, run tests and lint with a variety of Python versions
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Test against HA-core (master/released)
+name: Test PRs against HA-core
 
 env:
   CACHE_VERSION: 29
   DEFAULT_PYTHON: "3.13"
 
+# Do not run on 'push' (as the flow doesn't have access to the labels) - also disabled workflow_dispatch as such
+# Workaround could be something like
+#      - name: Get PR labels
+#        run: |
+#          PR_LABELS=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+#          "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels")
+#          echo "PR Labels: $PR_LABELS"
+
 on:
-  workflow_dispatch:
-  push:
-# pull_request:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - labeled
 
 jobs:
   # Run pre-commit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,14 @@ on:
       - unlabeled
 
 jobs:
-  # Run pre-commit
+  shellcheck:
+    name: Shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.2.2
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@master
+
   pre-commit:
     name: Validate pre-commit requirements
     runs-on: ubuntu-latest
@@ -74,6 +81,8 @@ jobs:
     name: Setup for HA-core (release/master)
     needs:
       - pre-commit
+    outputs:
+      release_failed: ${{ steps.ha_core_tests.outputs.failed }}
     steps:
       - name: Check out committed code
         uses: actions/checkout@v4.2.2
@@ -108,15 +117,25 @@ jobs:
             ${{ env.CACHE_VERSION}}-${{ runner.os }}
             ${{ env.CACHE_VERSION}}
       - name: Test through HA-core (master/release) - continue-on-error = ${{ env.STRICT_DEV == 'true' }}
+        id: ha-core-tests
         continue-on-error: ${{ env.STRICT_DEV == 'true' }} # Allow master failures only if dev is strict
         run: |
           GITHUB_ACTIONS="" scripts/core-testing.sh
+          if [ $? -ne 0 ]; then
+            echo "::warning::Release HA core incompatibility"
+            echo "RELEASE_TESTS_FAILED=true" >> $GITHUB_ENV
+          else
+            echo "Successfully tested against released HA-core"
+            echo "RELEASE_TESTS_FAILED=false" >> $GITHUB_ENV
+          fi
 
   ha-core-dev:
     runs-on: ubuntu-latest
     name: Setup for HA-core (dev)
     needs:
       - pre-commit
+    outputs:
+      dev_failed: ${{ steps.ha_core_tests.outputs.failed }}
     steps:
       - name: Check out committed code
         uses: actions/checkout@v4.2.2
@@ -151,14 +170,80 @@ jobs:
             ${{ env.CACHE_VERSION}}-${{ runner.os }}
             ${{ env.CACHE_VERSION}}
       - name: Test through HA-core (dev) - continue-on-error = ${{ env.STRICT_DEV == 'false' }}
+        id: ha-core-tests
         continue-on-error: ${{ env.STRICT_DEV == 'false' }} # Allow dev failures unless strict
         run: |
           GITHUB_ACTIONS="" BRANCH="dev" scripts/core-testing.sh
+          if [ $? -ne 0 ]; then
+            echo "::warning::Development HA core incompatibility"
+            echo "DEV_TESTS_FAILED=true" >> $GITHUB_ENV
+          else
+            echo "Successfully tested against dev HA-core"
+            echo "DEV_TESTS_FAILED=false" >> $GITHUB_ENV
+          fi
 
-  shellcheck:
-    name: Shellcheck
+  final-comment:
     runs-on: ubuntu-latest
+    needs: [ha-core-release, ha-core-dev]
     steps:
-      - uses: actions/checkout@v4.2.2
-      - name: Run ShellCheck
-        uses: ludeeus/action-shellcheck@master
+      - name: Determine Branch Test Mode
+        id: determine_mode
+        run: |
+          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'require-dev-pass') }}" == "true" ]]; then
+            echo "STRICT_DEV=true" >> $GITHUB_ENV
+          else
+            echo "STRICT_DEV=false" >> $GITHUB_ENV
+          fi
+      - name: Create combined comment
+        run: |
+          # Get the results of the previous scripts
+          STRICT_DEV=$STRICT_DEV
+          DEV_TESTS_FAILED=$DEV_TESTS_FAILED
+          RELEASE_TESTS_FAILED=$RELEASE_TESTS_FAILED
+          FAIL_COUNT=0
+
+          COMMENT_BODY="**Error while testing for RELEASED HA-core:**\n"
+          if [[ $DEV_TESTS_FAILED == "true" ]]; then
+            COMMENT_BODY="**Error while testing for Development HA-core:**\n"
+          fi
+
+          if [[ $DEV_TESTS_FAILED == "true" ]]; then
+            if [[ $STRICT_DEV == "true" ]]; then
+              COMMENT_BODY+="**Error:** Incompatible while testing against dev HA-core and required to pass.\n"
+              FAIL_COUNT=2
+            else
+              COMMENT_BODY+="**Warning:** Incompatible while testing against dev HA-core.\n"
+              FAIL_COUNT=1
+            fi
+          else
+            COMMENT_BODY+="**Success:** No problem with testing against dev HA-core.\n"
+          fi
+
+          if [[ $RELEASE_TESTS_FAILED == "true" ]]; then
+            if [[ $STRICT_DEV == "false" ]]; then
+              COMMENT_BODY+="**Error:** Incompatible while testing against released HA-core and required to pass.\n"
+              FAIL_COUNT=2
+            else
+              COMMENT_BODY+="**Warning:** Incompatible while testing against released HA-core.\n"
+              FAIL_COUNT=1
+            fi
+          else
+            COMMENT_BODY+="**Success:** No problem with testing against released HA-core.\n"
+          fi
+
+          if [[ FAIL_COUNT == 1 ]]; then
+            # Create a comment on the pull request
+            curl -s -X POST \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Content-Type: application/json" \
+            --data "{\"body\": \"$COMMENT_BODY\"}" \
+            "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments"
+          fi
+          if [[ FAIL_COUNT == 2 ]]; then
+            # Request changes on the pull request
+            curl -s -X POST \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Content-Type: application/json" \
+            --data ""{\"event\": \"REQUEST_ACTIONS\", \"body\": \"$COMMENT_BODY\"}" \
+            "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments"
+          fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,19 +61,19 @@ jobs:
             ${{ env.CACHE_VERSION}}-${{ runner.os }}-base-hacore
             ${{ env.CACHE_VERSION}}-${{ runner.os }}
             ${{ env.CACHE_VERSION}}
-      - name: Set-up environment
-        run: |
-          scripts/setup.sh
-      - name: Install pre-commit dependencies
-        run: |
-          . venv/bin/activate
-          pre-commit install-hooks
-      - name: Run full pre-commit
-        run: |
-          . venv/bin/activate
-          pre-commit run --all-files --show-diff-on-failure
-        env: # While not problematic, save time on performing the local hooks as they are run from the complete script in the next job
-          SKIP: local-test-core-prep,local-test-pip-prep,local-testing,local-quality
+#      - name: Set-up environment
+#        run: |
+#          scripts/setup.sh
+#      - name: Install pre-commit dependencies
+#        run: |
+#          . venv/bin/activate
+#          pre-commit install-hooks
+#      - name: Run all-files pre-commit excluding testing
+#        run: |
+#          . venv/bin/activate
+#          pre-commit run --all-files --show-diff-on-failure
+#        env: # While not problematic, save time on performing the local hooks as they are run from the complete script in the next job
+#          SKIP: local-test-core-prep,local-test-pip-prep,local-testing,local-quality
 
   # Prepare default python version environment
   ha-core-release:
@@ -272,6 +272,6 @@ jobs:
             curl -s -X POST \
             -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
             -H "Content-Type: application/json" \
-            --data "{\"event\": \"REQUEST_ACTIONS\", \"body\": \"$COMMENT_BODY\"}" \
+            --data "{\"event\": \"REQUEST_CHANGES\", \"body\": \"$COMMENT_BODY\"}" \
             "https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews"
           fi

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ venv
 *.orig
 node_modules
 manual_clone_ha
+package-lock.json

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -75,30 +75,30 @@ repos:
     hooks:
       - id: local-test-core-prep
         # yamllint disable-line rule:line-length
-        name: "Home Assistant Core Testing - Cloning/updating HA core#master - patience!"
+        name: "Home Assistant Core Testing - Cloning/updating HA core - patience!"
         # yamllint disable-line rule:line-length
-        entry: /usr/bin/env bash -c 'exec env GITHUB_ACTIONS="1" scripts/core-testing.sh core_prep'
+        entry: /usr/bin/env bash -c 'exec env GITHUB_ACTIONS="1" BRANCH="${BRANCH:-}" scripts/core-testing.sh core_prep'
         language: script
         pass_filenames: false
       - id: local-test-pip-prep
         # yamllint disable-line rule:line-length
         name: "Home Assistant Core Testing - Installing dependencies - patience!"
         # yamllint disable-line rule:line-length
-        entry: /usr/bin/env bash -c 'exec env GITHUB_ACTIONS="1" scripts/core-testing.sh pip_prep'
+        entry: /usr/bin/env bash -c 'exec env GITHUB_ACTIONS="1" BRANCH="${BRANCH:-}" scripts/core-testing.sh pip_prep'
         language: script
         pass_filenames: false
       - id: local-testing
         # yamllint disable-line rule:line-length
         name: "Home Assistant Core Testing - Performing Tests"
         # yamllint disable-line rule:line-length
-        entry: /usr/bin/env bash -c 'exec env GITHUB_ACTIONS="1" scripts/core-testing.sh testing'
+        entry: /usr/bin/env bash -c 'exec env GITHUB_ACTIONS="1" BRANCH="${BRANCH:-}" scripts/core-testing.sh testing'
         language: script
         pass_filenames: false
       - id: local-quality
         # yamllint disable-line rule:line-length
         name: "Home Assistant Core Testing - Quality checks - might need patience"
         # yamllint disable-line rule:line-length
-        entry: /usr/bin/env bash -c 'exec env GITHUB_ACTIONS="1" scripts/core-testing.sh quality'
+        entry: /usr/bin/env bash -c 'exec env GITHUB_ACTIONS="1" BRANCH="${BRANCH:-}" scripts/core-testing.sh quality'
         language: script
         pass_filenames: false
   - repo: https://github.com/igorshubovych/markdownlint-cli

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Versions from 0.40 and up
 
+## v0.56.1 / ONGOING
+
+- Config_flow: follow [Core PR](https://github.com/home-assistant/core/pull/135653) movement of ZeroconfServiceInfo
+
 ## v0.56.0
 
 - Internal: Fixes for the CI process

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 Versions from 0.40 and up
 
-## v0.56.1 / ONGOING
+## v0.56.1
 
 - Config_flow: follow [Core PR](https://github.com/home-assistant/core/pull/135653) movement of ZeroconfServiceInfo
+- Github actions: added `require-dev-pass` label to invert testing from passing HA Core release to HA Core dev
+  - The actions will now indicate and request changes or approve depending on the testing outcome
+  - When developing a PR for `dev` not just release pre-fix your `git commit` and `scripts/core-testing` with `BRANCH=dev`
+  - When creating the PR set the `require-dev-pass` label accordingly
 
 ## v0.56.0
 

--- a/custom_components/plugwise/config_flow.py
+++ b/custom_components/plugwise/config_flow.py
@@ -17,7 +17,6 @@ from plugwise.exceptions import (
 )
 import voluptuous as vol
 
-from homeassistant.components.zeroconf import ZeroconfServiceInfo
 from homeassistant.config_entries import (
     SOURCE_USER,
     ConfigEntry,
@@ -42,6 +41,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
 from .const import (
     ANNA_WITH_ADAM,

--- a/custom_components/plugwise/manifest.json
+++ b/custom_components/plugwise/manifest.json
@@ -8,6 +8,6 @@
   "iot_class": "local_polling",
   "loggers": ["plugwise"],
   "requirements": ["plugwise==1.7.0"],
-  "version": "0.56.0",
+  "version": "0.56.1a0",
   "zeroconf": ["_plugwise._tcp.local."]
 }

--- a/custom_components/plugwise/manifest.json
+++ b/custom_components/plugwise/manifest.json
@@ -8,6 +8,6 @@
   "iot_class": "local_polling",
   "loggers": ["plugwise"],
   "requirements": ["plugwise==1.7.0"],
-  "version": "0.56.1a0",
+  "version": "0.56.1",
   "zeroconf": ["_plugwise._tcp.local."]
 }

--- a/hacs.json
+++ b/hacs.json
@@ -9,6 +9,6 @@
     "sensor",
     "switch"
   ],
-  "homeassistant": "2024.12.0b2",
+  "homeassistant": "2025.2.0",
   "render_readme": true
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plugwise-beta"
-version = "0.55.4"
+version = "0.56.1a0"
 description = "Plugwise beta custom-component"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plugwise-beta"
-version = "0.56.1a0"
+version = "0.56.1"
 description = "Plugwise beta custom-component"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/components/plugwise/test_config_flow.py
+++ b/tests/components/plugwise/test_config_flow.py
@@ -19,7 +19,6 @@ from homeassistant.components.plugwise.const import (
     DEFAULT_PORT,
     DOMAIN,
 )
-from homeassistant.components.zeroconf import ZeroconfServiceInfo
 from homeassistant.config_entries import SOURCE_USER, SOURCE_ZEROCONF, ConfigFlowResult
 from homeassistant.const import (
     CONF_HOST,
@@ -33,6 +32,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 from packaging.version import Version
 
 from tests.common import MockConfigEntry


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated Home Assistant compatibility to version 2025.2.0

- **Chores**
	- Bumped Plugwise integration version to 0.56.1
	- Updated Python requirement to version 3.13
	- Added `package-lock.json` to `.gitignore`
	- Removed `push` event trigger from the workflow configuration

- **Documentation**
	- Updated changelog with version 0.56.1 entry

- **Tests**
	- Adjusted test configurations for `ZeroconfServiceInfo` imports and variables
	- Enhanced local testing hooks with configurable branch support
	- Improved GitHub Actions workflow for testing pull requests against HA-core
<!-- end of auto-generated comment: release notes by coderabbit.ai -->