### PR TITLE
Remove user-configuration of port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Versions from 0.40 and up
 
+## Ongoing
+
+- Remove user-configuration of port
+
 ## v0.56.1
 
 - Config_flow: follow [Core PR](https://github.com/home-assistant/core/pull/135653) movement of ZeroconfServiceInfo

--- a/custom_components/plugwise/config_flow.py
+++ b/custom_components/plugwise/config_flow.py
@@ -88,8 +88,6 @@ def smile_user_schema(cf_input: ZeroconfServiceInfo | dict[str, Any] | None) -> 
             {
                 vol.Required(CONF_HOST): str,
                 vol.Required(CONF_PASSWORD): str,
-                # Port under investigation for removal (hence not added in #132878)
-                vol.Optional(CONF_PORT, default=DEFAULT_PORT): int,
                 vol.Required(CONF_USERNAME, default=SMILE): vol.In(
                     {SMILE: FLOW_SMILE, STRETCH: FLOW_STRETCH}
                 ),
@@ -103,7 +101,6 @@ def smile_user_schema(cf_input: ZeroconfServiceInfo | dict[str, Any] | None) -> 
         {
             vol.Required(CONF_HOST, default=cf_input[CONF_HOST]): str,
             vol.Required(CONF_PASSWORD, default=cf_input[CONF_PASSWORD]): str,
-            vol.Optional(CONF_PORT, default=cf_input[CONF_PORT]): int,
             vol.Required(CONF_USERNAME, default=cf_input[CONF_USERNAME]): vol.In(
                 {SMILE: FLOW_SMILE, STRETCH: FLOW_STRETCH}
             ),
@@ -239,6 +236,7 @@ class PlugwiseConfigFlow(ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
 
         if user_input is not None:
+            user_input[CONF_PORT] = DEFAULT_PORT
             if self.discovery_info:
                 user_input[CONF_HOST] = self.discovery_info.host
                 user_input[CONF_PORT] = self.discovery_info.port

--- a/tests/components/plugwise/test_config_flow.py
+++ b/tests/components/plugwise/test_config_flow.py
@@ -409,7 +409,6 @@ async def test_form_cannot_connect_port(
         user_input={
             CONF_HOST: TEST_HOST,
             CONF_PASSWORD: TEST_PASSWORD,
-            CONF_PORT: TEST_PORT,
         },
     )
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Streamlined device setup by removing the manual network port option. The system now automatically applies a default port, simplifying the configuration process and reducing potential setup issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->