### PR TITLE
v0.57.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 Versions from 0.40 and up
 
-## Ongoing
+## v0.57.0
 
-- Remove user-configuration of port
+- Removed: user-configuration of port
+- Link to plugwise [v1.7.1](https://github.com/plugwise/python-plugwise/releases/tag/v1.7.1) 
 
 ## v0.56.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Versions from 0.40 and up
 ## v0.57.0
 
 - Removed: user-configuration of port
-- Link to plugwise [v1.7.1](https://github.com/plugwise/python-plugwise/releases/tag/v1.7.1) 
+- Link to plugwise [v1.7.1](https://github.com/plugwise/python-plugwise/releases/tag/v1.7.1)
 
 ## v0.56.1
 

--- a/custom_components/plugwise/manifest.json
+++ b/custom_components/plugwise/manifest.json
@@ -8,6 +8,6 @@
   "iot_class": "local_polling",
   "loggers": ["plugwise"],
   "requirements": ["plugwise==1.7.1"],
-  "version": "0.56.1",
+  "version": "0.57.0",
   "zeroconf": ["_plugwise._tcp.local."]
 }

--- a/custom_components/plugwise/manifest.json
+++ b/custom_components/plugwise/manifest.json
@@ -7,7 +7,7 @@
   "integration_type": "hub",
   "iot_class": "local_polling",
   "loggers": ["plugwise"],
-  "requirements": ["plugwise==1.7.0"],
+  "requirements": ["plugwise==1.7.1"],
   "version": "0.56.1",
   "zeroconf": ["_plugwise._tcp.local."]
 }


### PR DESCRIPTION
## v0.57.0

- Removed: user-configuration of port
- Link to plugwise [v1.7.1](https://github.com/plugwise/python-plugwise/releases/tag/v1.7.1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated release notes now announce version 0.57.0 with a fresh release header and additional reference information.

- **Chores**
  - Removed the user option for configuring the port.
  - Updated the integration to rely on the latest Plugwise library (v1.7.1) for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->