### PR TITLE
Remove double use of entry, bump plugwise to v.1.7.4

### DIFF
--- a/custom_components/plugwise/coordinator.py
+++ b/custom_components/plugwise/coordinator.py
@@ -126,12 +126,10 @@ class PlugwiseDataUpdateCoordinator(DataUpdateCoordinator[dict[str, GwEntityData
             ) from err
 
         LOGGER.debug(f"{self.api.smile_name} data: %s", data)
-        await self._async_add_remove_devices(data, self.config_entry)
+        await self._async_add_remove_devices(data)
         return data
 
-    async def _async_add_remove_devices(
-        self, data: dict[str, GwEntityData], entry: ConfigEntry
-    ) -> None:
+    async def _async_add_remove_devices(self, data: dict[str, GwEntityData]) -> None:
         """Add new Plugwise devices, remove non-existing devices."""
         # Check for new or removed devices
         self.new_devices = set(data) - self._current_devices
@@ -139,11 +137,9 @@ class PlugwiseDataUpdateCoordinator(DataUpdateCoordinator[dict[str, GwEntityData
         self._current_devices = set(data)
 
         if removed_devices:
-            await self._async_remove_devices(data, entry)
+            await self._async_remove_devices(data)
 
-    async def _async_remove_devices(
-        self, data: dict[str, GwEntityData], entry: ConfigEntry
-    ) -> None:
+    async def _async_remove_devices(self, data: dict[str, GwEntityData]) -> None:
         """Clean registries when removed devices found."""
         device_reg = dr.async_get(self.hass)
         device_list = dr.async_entries_for_config_entry(
@@ -164,7 +160,7 @@ class PlugwiseDataUpdateCoordinator(DataUpdateCoordinator[dict[str, GwEntityData
                         and identifier[1] not in data
                     ):
                         device_reg.async_update_device(
-                            device_entry.id, remove_config_entry_id=entry.entry_id
+                            device_entry.id, remove_config_entry_id=self.config_entry.entry_id
                         )
                         LOGGER.debug(
                             "Removed %s device/zone %s %s from device_registry",

--- a/custom_components/plugwise/manifest.json
+++ b/custom_components/plugwise/manifest.json
@@ -7,7 +7,7 @@
   "integration_type": "hub",
   "iot_class": "local_polling",
   "loggers": ["plugwise"],
-  "requirements": ["plugwise==1.7.3"],
-  "version": "0.57.2",
+  "requirements": ["plugwise==1.7.4"],
+  "version": "0.57.3",
   "zeroconf": ["_plugwise._tcp.local."]
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.57.1"
 description = "Plugwise beta custom-component"
 readme = "README.md"
 requires-python = ">=3.12"
-license = {file = "LICENSE"}
+license = "MIT"
 keywords = ["Plugwise", "Adam", "Anna", "P1", "Stretch", "Smile"]
 authors = [
     {name = "@bouwew"},
@@ -22,7 +22,6 @@ classifiers = [
   "Development Status :: 4 - Beta",
   "Programming Language :: Python",
   "Intended Audience :: Testers",
-  "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3.13",
   "Topic :: Home Automation",]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated Plugwise integration to require plugwise package version 1.7.4 and bumped integration version to 0.57.3.  
- **Refactor**
  - Simplified internal device management for Plugwise integration without affecting user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->