### PR TITLE
Adapt to plugwise v.1.7.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,19 @@
 
 Versions from 0.40 and up
 
-## Ongoing
+## v0.57.4
+
+- Don't raise an error when toggling a locked switch via plugwise to [v1.7.6](https://github.com/plugwise/python-plugwise/releases/tag/v1.7.6) via PR [#878](https://github.com/plugwise/plugwise-beta/pull/878)
+
+## v0.57.3
+
+- Improve code via PR [#875](https://github.com/plugwise/plugwise-beta/pull/865)
+- Bump plugwise to [v1.7.4](https://github.com/plugwise/python-plugwise/releases/tag/v1.7.4)
+
+## v0.57.2
 
 - Downstream HA [Core PR](https://github.com/home-assistant/core/pull/138201) update signature of platforms' async_setup_entry
+- Bump plugwise to [v1.7.3](https://github.com/plugwise/python-plugwise/releases/tag/v1.7.3)
 
 ## v0.57.1
 

--- a/custom_components/plugwise/manifest.json
+++ b/custom_components/plugwise/manifest.json
@@ -7,7 +7,7 @@
   "integration_type": "hub",
   "iot_class": "local_polling",
   "loggers": ["plugwise"],
-  "requirements": ["plugwise==1.7.4"],
-  "version": "0.57.3",
+  "requirements": ["plugwise==1.7.6"],
+  "version": "0.57.4",
   "zeroconf": ["_plugwise._tcp.local."]
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plugwise-beta"
-version = "0.57.1"
+version = "0.57.4"
 description = "Plugwise beta custom-component"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
Via this update, `set_switch_state()` in plugwise doesn't raise an error when a locked switch is toggled.

This corrects the behavior in the frontend: when a locked switch is toggled it will return to it's previous state after a few seconds. 

At present, the switch toggles to the opposite state when clicked and stays in that state, which is wrong. Only after a browser-refresh the correct switch state is shown.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved switch state handling to ensure accurate status updates when turning switches on or off.

- **Tests**
	- Added a test to verify correct behavior when attempting to turn off a locked switch, ensuring the state remains unchanged but the command is still issued.

- **Chores**
	- Updated the integration dependency to use a newer alpha version of the underlying package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->