### PR TITLE
Add wait_background_tasks=True to async_block_till_done() calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Versions from 0.40 and up
 
+## Ongoing
+
+- Solve a test-fail when testing towards HA Core dev branch in PR [#887](https://github.com/plugwise/plugwise-beta/pull/887)
+
 ## v0.57.4
 
 - Maintenance chores on CI

--- a/tests/components/plugwise/test_climate.py
+++ b/tests/components/plugwise/test_climate.py
@@ -135,7 +135,7 @@ async def test_adam_3_climate_entity_attributes(
     with patch(HA_PLUGWISE_SMILE_ASYNC_UPDATE, return_value=data):
         freezer.tick(timedelta(minutes=1))
         async_fire_time_changed(hass)
-        await hass.async_block_till_done()
+        await hass.async_block_till_done(wait_background_tasks=True)
 
         state = hass.states.get("climate.living_room")
         assert state
@@ -161,7 +161,7 @@ async def test_adam_3_climate_entity_attributes(
     with patch(HA_PLUGWISE_SMILE_ASYNC_UPDATE, return_value=data):
         freezer.tick(timedelta(minutes=1))
         async_fire_time_changed(hass)
-        await hass.async_block_till_done()
+        await hass.async_block_till_done(wait_background_tasks=True)
 
         state = hass.states.get("climate.living_room")
         assert state
@@ -440,7 +440,7 @@ async def test_anna_climate_entity_climate_changes(
     with patch(HA_PLUGWISE_SMILE_ASYNC_UPDATE, return_value=data):
         freezer.tick(timedelta(minutes=1))
         async_fire_time_changed(hass)
-        await hass.async_block_till_done()
+        await hass.async_block_till_done(wait_background_tasks=True)
 
         state = hass.states.get("climate.anna")
         assert state.state == HVACMode.HEAT

--- a/tests/components/plugwise/test_init.py
+++ b/tests/components/plugwise/test_init.py
@@ -317,7 +317,7 @@ async def test_update_device(
     with patch(HA_PLUGWISE_SMILE_ASYNC_UPDATE, return_value=data):
         freezer.tick(timedelta(minutes=1))
         async_fire_time_changed(hass)
-        await hass.async_block_till_done()
+        await hass.async_block_till_done(wait_background_tasks=True)
 
         assert (
             len(er.async_entries_for_config_entry(entity_registry, mock_config_entry.entry_id))
@@ -344,7 +344,7 @@ async def test_update_device(
     with patch(HA_PLUGWISE_SMILE_ASYNC_UPDATE, return_value=data):
         freezer.tick(timedelta(minutes=1))
         async_fire_time_changed(hass)
-        await hass.async_block_till_done()
+        await hass.async_block_till_done(wait_background_tasks=True)
 
         assert (
             len(er.async_entries_for_config_entry(entity_registry, mock_config_entry.entry_id))


### PR DESCRIPTION
This solves a test-file when testing to the HA Core dev code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Tests**
  - Improved test reliability by ensuring all background tasks are completed before state assertions in climate entity and device update tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->