### PR TITLE
Disable switchgroups by default

### DIFF
--- a/custom_components/plugwise/entity.py
+++ b/custom_components/plugwise/entity.py
@@ -59,7 +59,7 @@ class PlugwiseEntity(CoordinatorEntity[PlugwiseDataUpdateCoordinator]):
 
         disabled_by: DeviceEntryDisabler | None = None
         if data.get("dev_class") in ("report", "switching"):
-            disabled_by = DeviceEntryDisabler.INTEGRATION
+            disabled_by = DeviceEntryDisabler.USER
 
         self._attr_device_info = DeviceInfo(
             configuration_url=configuration_url,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Report and switching device types are now automatically marked as disabled by the integration, so they won’t appear active by default and reduce clutter in device listings.
  * No user action required; devices will reflect this state after the next refresh.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->