### PR TITLE
Implement @pytest.mark.usefixtures()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Versions from 0.40 and up
 
 ## Ongoing
 
+- Implement @pytest.mark.usefixtures() via PR
 - Correct climate and water_heater unique_id's via PR [#1098](https://github.com/plugwise/plugwise-beta/pull/1098)
 - Implement @overload and improved snapshot-formatting as required for the Next HA version, via PR [#1096](https://github.com/plugwise/plugwise-beta/pull/1096)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Versions from 0.40 and up
 
 ## Ongoing
 
-- Implement @pytest.mark.usefixtures() via PR
+- Implement @pytest.mark.usefixtures() via PR [#1117](https://github.com/plugwise/plugwise-beta/pull/1117)
 - Correct climate and water_heater unique_id's via PR [#1098](https://github.com/plugwise/plugwise-beta/pull/1098)
 - Implement @overload and improved snapshot-formatting as required for the Next HA version, via PR [#1096](https://github.com/plugwise/plugwise-beta/pull/1096)
 

--- a/tests/components/plugwise/test_binary_sensor.py
+++ b/tests/components/plugwise/test_binary_sensor.py
@@ -1,7 +1,7 @@
 """Tests for the Plugwise binary_sensor integration."""
 
 from datetime import timedelta
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 

--- a/tests/components/plugwise/test_binary_sensor.py
+++ b/tests/components/plugwise/test_binary_sensor.py
@@ -16,11 +16,11 @@ from syrupy.assertion import SnapshotAssertion
 from tests.common import MockConfigEntry, async_fire_time_changed, snapshot_platform
 
 
+@pytest.mark.usefixtures("mock_smile_adam")
 @pytest.mark.parametrize("platforms", [(BINARY_SENSOR_DOMAIN,)])
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_adam_binary_sensor_snapshot(
     hass: HomeAssistant,
-    mock_smile_adam: MagicMock,
     snapshot: SnapshotAssertion,
     entity_registry: er.EntityRegistry,
     setup_platform: MockConfigEntry,
@@ -29,13 +29,13 @@ async def test_adam_binary_sensor_snapshot(
     await snapshot_platform(hass, entity_registry, snapshot, setup_platform.entry_id)
 
 
+@pytest.mark.usefixtures("mock_smile_anna")
 @pytest.mark.parametrize("chosen_env", ["anna_heatpump_heating"], indirect=True)
 @pytest.mark.parametrize("cooling_present", [True], indirect=True)
 @pytest.mark.parametrize("platforms", [(BINARY_SENSOR_DOMAIN,)])
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_anna_binary_sensor_snapshot(
     hass: HomeAssistant,
-    mock_smile_anna: MagicMock,
     snapshot: SnapshotAssertion,
     entity_registry: er.EntityRegistry,
     setup_platform: MockConfigEntry,
@@ -44,10 +44,11 @@ async def test_anna_binary_sensor_snapshot(
     await snapshot_platform(hass, entity_registry, snapshot, setup_platform.entry_id)
 
 
+@pytest.mark.usefixtures("mock_smile_anna")
 @pytest.mark.parametrize("chosen_env", ["anna_heatpump_heating"], indirect=True)
 @pytest.mark.parametrize("cooling_present", [True], indirect=True)
 async def test_anna_climate_binary_sensor_change(
-    hass: HomeAssistant, mock_smile_anna: MagicMock, init_integration: MockConfigEntry
+    hass: HomeAssistant, init_integration: MockConfigEntry
 ) -> None:
     """Test change of climate related binary_sensor entities."""
     hass.states.async_set("binary_sensor.opentherm_dhw_state", STATE_ON, {})
@@ -63,6 +64,7 @@ async def test_anna_climate_binary_sensor_change(
     assert state.state == STATE_OFF
 
 
+@pytest.mark.usefixtures("mock_smile_p1")
 @pytest.mark.parametrize("chosen_env", ["p1v4_442_triple"], indirect=True)
 @pytest.mark.parametrize(
     "gateway_id", ["03e65b16e4b247a29ae0d75a78cb492e"], indirect=True
@@ -71,7 +73,6 @@ async def test_anna_climate_binary_sensor_change(
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_p1_v4_binary_sensor_snapshot(
     hass: HomeAssistant,
-    mock_smile_p1: MagicMock,
     snapshot: SnapshotAssertion,
     entity_registry: er.EntityRegistry,
     setup_platform: MockConfigEntry,
@@ -81,11 +82,11 @@ async def test_p1_v4_binary_sensor_snapshot(
 
 
 # pw-beta only
+@pytest.mark.usefixtures("mock_smile_p1")
 @pytest.mark.parametrize("chosen_env", ["p1v4_442_triple"], indirect=True)
 @pytest.mark.parametrize("gateway_id", ["03e65b16e4b247a29ae0d75a78cb492e"], indirect=True)
 async def test_p1_v4_binary_sensor_entity(
     hass: HomeAssistant,
-    mock_smile_p1: MagicMock,
     init_integration: MockConfigEntry,
     freezer: FrozenDateTimeFactory,
 ) -> None:

--- a/tests/components/plugwise/test_button.py
+++ b/tests/components/plugwise/test_button.py
@@ -13,11 +13,11 @@ from syrupy.assertion import SnapshotAssertion
 from tests.common import MockConfigEntry, snapshot_platform
 
 
+@pytest.mark.usefixtures("mock_smile_adam")
 @pytest.mark.parametrize("platforms", [(BUTTON_DOMAIN,)])
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_adam_button_snapshot(
     hass: HomeAssistant,
-    mock_smile_adam: MagicMock,
     snapshot: SnapshotAssertion,
     entity_registry: er.EntityRegistry,
     setup_platform: MockConfigEntry,

--- a/tests/components/plugwise/test_climate.py
+++ b/tests/components/plugwise/test_climate.py
@@ -41,11 +41,11 @@ HA_PLUGWISE_SMILE_ASYNC_UPDATE = (
 )
 
 
+@pytest.mark.usefixtures("mock_smile_adam")
 @pytest.mark.parametrize("platforms", [(CLIMATE_DOMAIN,)])
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_adam_climate_snapshot(
     hass: HomeAssistant,
-    mock_smile_adam: MagicMock,
     snapshot: SnapshotAssertion,
     entity_registry: er.EntityRegistry,
     setup_platform: MockConfigEntry,
@@ -255,13 +255,14 @@ async def test_adam_restore_state_climate(
         )
         assert mock_smile_adam_heat_cool.set_schedule_state.call_count == 2
 
+
+@pytest.mark.usefixtures("mock_smile_adam_heat_cool")
 @pytest.mark.parametrize("chosen_env", ["m_adam_heating"], indirect=True)
 @pytest.mark.parametrize("cooling_present", [False], indirect=True)
 @pytest.mark.parametrize("platforms", [(CLIMATE_DOMAIN,)])
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_adam_2_climate_snapshot(
     hass: HomeAssistant,
-    mock_smile_adam_heat_cool: MagicMock,
     snapshot: SnapshotAssertion,
     entity_registry: er.EntityRegistry,
     setup_platform: MockConfigEntry,
@@ -518,13 +519,13 @@ async def test_adam_climate_off_mode_change(
     assert mock_smile_adam_jip.set_regulation_mode.call_count == 2
 
 
+@pytest.mark.usefixtures("mock_smile_anna")
 @pytest.mark.parametrize("chosen_env", ["anna_heatpump_heating"], indirect=True)
 @pytest.mark.parametrize("cooling_present", [True], indirect=True)
 @pytest.mark.parametrize("platforms", [(CLIMATE_DOMAIN,)])
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_anna_climate_snapshot(
     hass: HomeAssistant,
-    mock_smile_anna: MagicMock,
     snapshot: SnapshotAssertion,
     entity_registry: er.EntityRegistry,
     setup_platform: MockConfigEntry,
@@ -622,13 +623,13 @@ async def test_anna_climate_entity_climate_changes(
         assert state.attributes[ATTR_HVAC_MODES] == [HVACMode.HEAT_COOL]
 
 
+@pytest.mark.usefixtures("mock_smile_anna")
 @pytest.mark.parametrize("chosen_env", ["m_anna_heatpump_cooling"], indirect=True)
 @pytest.mark.parametrize("cooling_present", [True], indirect=True)
 @pytest.mark.parametrize("platforms", [(CLIMATE_DOMAIN,)])
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_anna_2_climate_snapshot(
     hass: HomeAssistant,
-    mock_smile_anna: MagicMock,
     snapshot: SnapshotAssertion,
     entity_registry: er.EntityRegistry,
     setup_platform: MockConfigEntry,
@@ -637,11 +638,11 @@ async def test_anna_2_climate_snapshot(
     await snapshot_platform(hass, entity_registry, snapshot, setup_platform.entry_id)
 
 
+@pytest.mark.usefixtures("mock_smile_anna_2")
 @pytest.mark.parametrize("platforms", [(CLIMATE_DOMAIN,)])
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_anna_3_climate_snapshot(
     hass: HomeAssistant,
-    mock_smile_anna_2: MagicMock,
     snapshot: SnapshotAssertion,
     entity_registry: er.EntityRegistry,
     setup_platform: MockConfigEntry,

--- a/tests/components/plugwise/test_init.py
+++ b/tests/components/plugwise/test_init.py
@@ -195,7 +195,7 @@ async def check_migration(
     assert entity_migrated
     assert entity_migrated.unique_id == new_unique_id
 
-
+@pytest.mark.usefixtures("mock_smile_anna")
 @pytest.mark.parametrize("chosen_env", ["anna_heatpump_heating"], indirect=True)
 @pytest.mark.parametrize("cooling_present", [True], indirect=True)
 @pytest.mark.parametrize(
@@ -220,7 +220,6 @@ async def test_migrate_temperature_unique_id(
     entitydata: dict,
     old_unique_id: str,
     new_unique_id: str,
-    mock_smile_anna: MagicMock,
 ) -> None:
     """Test migration of sensor unique_id."""
     await check_migration(
@@ -228,6 +227,7 @@ async def test_migrate_temperature_unique_id(
     )
 
 
+@pytest.mark.usefixtures("mock_smile_adam")
 @pytest.mark.parametrize(
     ("entitydata", "old_unique_id", "new_unique_id"),
     [
@@ -261,7 +261,6 @@ async def test_migrate_relay_unique_id(
     entitydata: dict,
     old_unique_id: str,
     new_unique_id: str,
-    mock_smile_adam: MagicMock,
 ) -> None:
     """Test migration of binary_sensor and switch unique_ids."""
     await check_migration(
@@ -269,6 +268,7 @@ async def test_migrate_relay_unique_id(
     )
 
 
+@pytest.mark.usefixtures("mock_smile_adam_jip")
 @pytest.mark.parametrize(
     ("entitydata", "old_unique_id", "new_unique_id"),
     [
@@ -291,7 +291,6 @@ async def test_migrate_climate_unique_id(
     entitydata: dict,
     old_unique_id: str,
     new_unique_id: str,
-    mock_smile_adam_jip: MagicMock,
 ) -> None:
     """Test migration of climate unique_id."""
     await check_migration(
@@ -381,11 +380,11 @@ async def test_update_device(
         assert device_entry is None
 
 
+@pytest.mark.usefixtures("mock_config_entry")
 @pytest.mark.parametrize("chosen_env", ["m_adam_heating"], indirect=True)
 @pytest.mark.parametrize("cooling_present", [False], indirect=True)
 async def test_delete_removed_device(
     hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
     mock_smile_adam_heat_cool: MagicMock,
     device_registry: dr.DeviceRegistry,
     init_integration: MockConfigEntry,
@@ -411,11 +410,11 @@ async def test_delete_removed_device(
     assert device_entry is None
 
 
+@pytest.mark.usefixtures("mock_config_entry")
 @pytest.mark.parametrize("chosen_env", ["m_adam_heating"], indirect=True)
 @pytest.mark.parametrize("cooling_present", [False], indirect=True)
 async def test_update_device_firmware(
     hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
     mock_smile_adam_heat_cool: MagicMock,
     device_registry: dr.DeviceRegistry,
     init_integration: MockConfigEntry,

--- a/tests/components/plugwise/test_number.py
+++ b/tests/components/plugwise/test_number.py
@@ -18,11 +18,11 @@ from syrupy.assertion import SnapshotAssertion
 from tests.common import MockConfigEntry, snapshot_platform
 
 
+@pytest.mark.usefixtures("mock_smile_adam")
 @pytest.mark.parametrize("platforms", [(NUMBER_DOMAIN,)])
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_adam_number_entities(
     hass: HomeAssistant,
-    mock_smile_adam: MagicMock,
     snapshot: SnapshotAssertion,
     entity_registry: er.EntityRegistry,
     setup_platform: MockConfigEntry,
@@ -51,8 +51,9 @@ async def test_adam_temperature_offset_change(
     )
 
 
+@pytest.mark.usefixtures("mock_smile_adam")
 async def test_adam_temperature_offset_out_of_bounds_change(
-    hass: HomeAssistant, mock_smile_adam: MagicMock, init_integration: MockConfigEntry
+    hass: HomeAssistant, init_integration: MockConfigEntry
 ) -> None:
     """Test changing of the temperature_offset number beyond limits."""
     with pytest.raises(ServiceValidationError, match="valid range"):
@@ -67,13 +68,13 @@ async def test_adam_temperature_offset_out_of_bounds_change(
         )
 
 
+@pytest.mark.usefixtures("mock_smile_anna")
 @pytest.mark.parametrize("chosen_env", ["anna_heatpump_heating"], indirect=True)
 @pytest.mark.parametrize("cooling_present", [True], indirect=True)
 @pytest.mark.parametrize("platforms", [(NUMBER_DOMAIN,)])
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_anna_number_entities(
     hass: HomeAssistant,
-    mock_smile_anna: MagicMock,
     snapshot: SnapshotAssertion,
     entity_registry: er.EntityRegistry,
     setup_platform: MockConfigEntry,

--- a/tests/components/plugwise/test_select.py
+++ b/tests/components/plugwise/test_select.py
@@ -18,11 +18,11 @@ from syrupy.assertion import SnapshotAssertion
 from tests.common import MockConfigEntry, snapshot_platform
 
 
+@pytest.mark.usefixtures("mock_smile_adam")
 @pytest.mark.parametrize("platforms", [(SELECT_DOMAIN,)])
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_adam_select_entities(
     hass: HomeAssistant,
-    mock_smile_adam: MagicMock,
     snapshot: SnapshotAssertion,
     entity_registry: er.EntityRegistry,
     setup_platform: MockConfigEntry,
@@ -54,13 +54,13 @@ async def test_adam_change_select_entity(
     )
 
 
+@pytest.mark.usefixtures("mock_smile_adam_heat_cool")
 @pytest.mark.parametrize("chosen_env", ["m_adam_cooling"], indirect=True)
 @pytest.mark.parametrize("cooling_present", [True], indirect=True)
 @pytest.mark.parametrize("platforms", [(SELECT_DOMAIN,)])
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_adam_2_select_entities(
     hass: HomeAssistant,
-    mock_smile_adam_heat_cool: MagicMock,
     snapshot: SnapshotAssertion,
     entity_registry: er.EntityRegistry,
     setup_platform: MockConfigEntry,
@@ -122,19 +122,21 @@ async def test_adam_select_zone_profile(
         "on",
     )
 
+
+@pytest.mark.usefixtures("mock_smile_legacy_anna")
 async def test_legacy_anna_select_entities(
     hass: HomeAssistant,
-    mock_smile_legacy_anna: MagicMock,
     init_integration: MockConfigEntry,
 ) -> None:
     """Test no select-entity for a legacy Anna without schedule."""
     assert not hass.states.get("select.anna_thermostat_schedule")
 
 
+@pytest.mark.usefixtures("mock_smile_anna")
 @pytest.mark.parametrize("chosen_env", ["anna_heatpump_heating"], indirect=True)
 @pytest.mark.parametrize("cooling_present", [True], indirect=True)
 async def test_anna_select_unavailable_schedule_mode(
-    hass: HomeAssistant, mock_smile_anna: MagicMock, init_integration: MockConfigEntry
+    hass: HomeAssistant, init_integration: MockConfigEntry
 ) -> None:
     """Fail-test an Anna thermostat_schedule select option."""
 

--- a/tests/components/plugwise/test_sensor.py
+++ b/tests/components/plugwise/test_sensor.py
@@ -1,7 +1,5 @@
 """Tests for the Plugwise Sensor integration."""
 
-from unittest.mock import MagicMock
-
 import pytest
 
 from homeassistant.components.plugwise.const import DOMAIN

--- a/tests/components/plugwise/test_sensor.py
+++ b/tests/components/plugwise/test_sensor.py
@@ -13,13 +13,13 @@ from syrupy.assertion import SnapshotAssertion
 from tests.common import MockConfigEntry, snapshot_platform
 
 
+@pytest.mark.usefixtures("mock_smile_adam_heat_cool")
 @pytest.mark.parametrize("chosen_env", ["m_adam_heating"], indirect=True)
 @pytest.mark.parametrize("cooling_present", [False], indirect=True)
 @pytest.mark.parametrize("platforms", [(SENSOR_DOMAIN,)])
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_adam_sensor_snapshot(
     hass: HomeAssistant,
-    mock_smile_adam_heat_cool: MagicMock,
     snapshot: SnapshotAssertion,
     entity_registry: er.EntityRegistry,
     setup_platform: MockConfigEntry,
@@ -28,9 +28,9 @@ async def test_adam_sensor_snapshot(
     await snapshot_platform(hass, entity_registry, snapshot, setup_platform.entry_id)
 
 
+@pytest.mark.usefixtures("mock_smile_adam_jip")
 async def test_adam_climate_sensor_humidity(
     hass: HomeAssistant,
-    mock_smile_adam_jip: MagicMock,
     init_integration: MockConfigEntry,
 ) -> None:
     """Test creation of climate related humidity sensor entity."""
@@ -39,10 +39,10 @@ async def test_adam_climate_sensor_humidity(
     assert float(state.state) == 56.2
 
 
+@pytest.mark.usefixtures("mock_smile_adam_jip")
 async def test_unique_id_migration_humidity(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
-    mock_smile_adam_jip: MagicMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test unique ID migration of -relative_humidity to -humidity."""
@@ -82,13 +82,13 @@ async def test_unique_id_migration_humidity(
     assert entity_entry.unique_id == "f61f1a2535f54f52ad006a3d18e459ca-battery"
 
 
+@pytest.mark.usefixtures("mock_smile_anna")
 @pytest.mark.parametrize("chosen_env", ["anna_heatpump_heating"], indirect=True)
 @pytest.mark.parametrize("cooling_present", [True], indirect=True)
 @pytest.mark.parametrize("platforms", [(SENSOR_DOMAIN,)])
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_anna_sensor_snapshot(
     hass: HomeAssistant,
-    mock_smile_anna: MagicMock,
     snapshot: SnapshotAssertion,
     entity_registry: er.EntityRegistry,
     setup_platform: MockConfigEntry,
@@ -97,11 +97,11 @@ async def test_anna_sensor_snapshot(
     await snapshot_platform(hass, entity_registry, snapshot, setup_platform.entry_id)
 
 
+@pytest.mark.usefixtures("mock_smile_anna_2")
 @pytest.mark.parametrize("platforms", [(SENSOR_DOMAIN,)])
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_anna_p1_sensor_snapshot(
     hass: HomeAssistant,
-    mock_smile_anna_2: MagicMock,
     snapshot: SnapshotAssertion,
     entity_registry: er.EntityRegistry,
     setup_platform: MockConfigEntry,
@@ -110,6 +110,7 @@ async def test_anna_p1_sensor_snapshot(
     await snapshot_platform(hass, entity_registry, snapshot, setup_platform.entry_id)
 
 
+@pytest.mark.usefixtures("mock_smile_p1")
 @pytest.mark.parametrize("chosen_env", ["p1v4_442_single"], indirect=True)
 @pytest.mark.parametrize(
     "gateway_id", ["a455b61e52394b2db5081ce025a430f3"], indirect=True
@@ -118,7 +119,6 @@ async def test_anna_p1_sensor_snapshot(
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_p1_dsmr_sensor_snapshot(
     hass: HomeAssistant,
-    mock_smile_p1: MagicMock,
     snapshot: SnapshotAssertion,
     entity_registry: er.EntityRegistry,
     setup_platform: MockConfigEntry,
@@ -127,6 +127,7 @@ async def test_p1_dsmr_sensor_snapshot(
     await snapshot_platform(hass, entity_registry, snapshot, setup_platform.entry_id)
 
 
+@pytest.mark.usefixtures("mock_smile_p1")
 @pytest.mark.parametrize("chosen_env", ["p1v4_442_triple"], indirect=True)
 @pytest.mark.parametrize(
     "gateway_id", ["03e65b16e4b247a29ae0d75a78cb492e"], indirect=True
@@ -135,7 +136,6 @@ async def test_p1_dsmr_sensor_snapshot(
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_p1_3ph_dsmr_sensor_snapshot(
     hass: HomeAssistant,
-    mock_smile_p1: MagicMock,
     snapshot: SnapshotAssertion,
     entity_registry: er.EntityRegistry,
     setup_platform: MockConfigEntry,
@@ -144,6 +144,7 @@ async def test_p1_3ph_dsmr_sensor_snapshot(
     await snapshot_platform(hass, entity_registry, snapshot, setup_platform.entry_id)
 
 
+@pytest.mark.usefixtures("mock_smile_p1")
 @pytest.mark.parametrize("chosen_env", ["p1v4_442_triple"], indirect=True)
 @pytest.mark.parametrize(
     "gateway_id", ["03e65b16e4b247a29ae0d75a78cb492e"], indirect=True
@@ -151,7 +152,6 @@ async def test_p1_3ph_dsmr_sensor_snapshot(
 async def test_p1_3ph_dsmr_sensor_disabled_entities(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
-    mock_smile_p1: MagicMock,
     init_integration: MockConfigEntry,
 ) -> None:
     """Test disabled power related sensor entities intent."""
@@ -170,11 +170,11 @@ async def test_p1_3ph_dsmr_sensor_disabled_entities(
     assert float(state.state) == 233.2
 
 
+@pytest.mark.usefixtures("mock_stretch")
 @pytest.mark.parametrize("platforms", [(SENSOR_DOMAIN,)])
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_stretch_sensor_snapshot(
     hass: HomeAssistant,
-    mock_stretch: MagicMock,
     snapshot: SnapshotAssertion,
     entity_registry: er.EntityRegistry,
     setup_platform: MockConfigEntry,

--- a/tests/components/plugwise/test_switch.py
+++ b/tests/components/plugwise/test_switch.py
@@ -23,11 +23,11 @@ from syrupy.assertion import SnapshotAssertion
 from tests.common import MockConfigEntry, snapshot_platform
 
 
+@pytest.mark.usefixtures("mock_smile_adam")
 @pytest.mark.parametrize("platforms", [(SWITCH_DOMAIN,)])
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_adam_switch_snapshot(
     hass: HomeAssistant,
-    mock_smile_adam: MagicMock,
     snapshot: SnapshotAssertion,
     entity_registry: er.EntityRegistry,
     setup_platform: MockConfigEntry,
@@ -110,11 +110,11 @@ async def test_adam_climate_switch_negative_testing(
     )
 
 
+@pytest.mark.usefixtures("mock_stretch")
 @pytest.mark.parametrize("platforms", [(SWITCH_DOMAIN,)])
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_stretch_switch_snapshot(
     hass: HomeAssistant,
-    mock_stretch: MagicMock,
     snapshot: SnapshotAssertion,
     entity_registry: er.EntityRegistry,
     setup_platform: MockConfigEntry,
@@ -161,10 +161,10 @@ async def test_stretch_switch_changes(
     )
 
 
+@pytest.mark.usefixtures("mock_smile_adam")
 async def test_unique_id_migration_plug_relay(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
-    mock_smile_adam: MagicMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test unique ID migration of -plugs to -relay."""

--- a/tests/components/plugwise/test_water_heater.py
+++ b/tests/components/plugwise/test_water_heater.py
@@ -22,11 +22,11 @@ HA_PLUGWISE_SMILE_ASYNC_UPDATE = (
 )
 
 
+@pytest.mark.usefixtures("mock_smile_adam_jip")
 @pytest.mark.parametrize("platforms", [(WATER_HEATER_DOMAIN,)])
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_adam_water_heater_snapshot(
     hass: HomeAssistant,
-    mock_smile_adam_jip: MagicMock,
     snapshot: SnapshotAssertion,
     entity_registry: er.EntityRegistry,
     setup_platform: MockConfigEntry,
@@ -61,14 +61,13 @@ async def test_adam_water_heater_setpoint_change(
         "dhw_mode", "e4684553153b44afbef2200885f379dc", 2, "off"
     )
 
-
+@pytest.mark.usefixtures("mock_smile_anna")
 @pytest.mark.parametrize("chosen_env", ["anna_v4_dhw"], indirect=True)
 @pytest.mark.parametrize("cooling_present", [False], indirect=True)
 @pytest.mark.parametrize("platforms", [(WATER_HEATER_DOMAIN,)])
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_anna_water_heater_snapshot(
     hass: HomeAssistant,
-    mock_smile_anna: MagicMock,
     snapshot: SnapshotAssertion,
     entity_registry: er.EntityRegistry,
     setup_platform: MockConfigEntry,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated Plugwise integration tests to apply mock fixtures automatically using pytest fixture markers.
  * Simplified test signatures while preserving existing assertions, snapshots, and test behavior.

* **Documentation**
  * Added a changelog entry documenting the adoption of `usefixtures` for test setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->